### PR TITLE
feature: pass ModRevision field from kv.KeyValue structure to integrity.ValidatedResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- integrity.Validator: Ability to get ModRevision from a validated result (#23).
+
 ### Changed
 
 ### Fixed

--- a/integrity/generator.go
+++ b/integrity/generator.go
@@ -92,7 +92,7 @@ func (g Generator[T]) Generate(name string, value T) ([]kv.KeyValue, error) {
 		results = append(results, kv.KeyValue{
 			Key:         []byte(key.Build()),
 			Value:       valueData,
-			ModRevision: 0,
+			ModRevision: ModRevisionEmpty,
 		})
 	}
 

--- a/integrity/result.go
+++ b/integrity/result.go
@@ -6,7 +6,8 @@ import (
 
 // ValidatedResult represents a validated named value.
 type ValidatedResult[T any] struct {
-	Name  string
-	Value option.Generic[T]
-	Error error
+	Name        string
+	Value       option.Generic[T]
+	ModRevision int64
+	Error       error
 }

--- a/integrity/validator.go
+++ b/integrity/validator.go
@@ -12,6 +12,9 @@ import (
 	"github.com/tarantool/go-storage/namer"
 )
 
+// ModRevisionEmpty is used to initialize the ModRevision field by default.
+const ModRevisionEmpty = 0
+
 // Validator verifies integrity-protected key-value pairs.
 type Validator[T any] struct {
 	namer      namer.Namer
@@ -97,9 +100,10 @@ func (v Validator[T]) validateSingle(name string, kvs []extendedKV) ValidatedRes
 	aggregatedError := &FailedToValidateAggregatedError{parent: nil}
 
 	output := ValidatedResult[T]{
-		Name:  name,
-		Value: option.None[T](),
-		Error: nil,
+		Name:        name,
+		Value:       option.None[T](),
+		ModRevision: ModRevisionEmpty,
+		Error:       nil,
 	}
 
 	var (
@@ -119,6 +123,7 @@ func (v Validator[T]) validateSingle(name string, kvs []extendedKV) ValidatedRes
 		}
 
 		output.Value = option.Some(val)
+		output.ModRevision = kvi.keyValue.ModRevision
 		body = kvi.keyValue.Value
 	}
 

--- a/integrity/validator_test.go
+++ b/integrity/validator_test.go
@@ -54,13 +54,15 @@ func TestValidatorValidate_Success(t *testing.T) {
 		verifiers,
 	)
 
+	var expectedModRevision int64 = 0x123
+
 	// Create plain []KeyValue without generator.
 	value := SimpleStruct{Name: "test", Value: 42}
 	kvs := []kv.KeyValue{
 		{
 			Key:         []byte("/test/my-object"),
 			Value:       []byte("name: test\nvalue: 42\n"),
-			ModRevision: 0,
+			ModRevision: expectedModRevision,
 		},
 		{
 			Key: []byte("/test/hash/sha256/my-object"),
@@ -68,12 +70,12 @@ func TestValidatorValidate_Success(t *testing.T) {
 				0x86, 0x1c, 0xdf, 0xcd, 0x76, 0x2f, 0x0a, 0x8c, 0xc0, 0xc7, 0xfc, 0x44, 0xcb, 0xfa, 0x5d, 0x29, 0xde,
 				0xed, 0x36, 0xa2, 0x5c, 0x73, 0xf7, 0xa4, 0xc6, 0x7a, 0xd6, 0x37, 0xf7, 0x1b, 0xab, 0x39,
 			},
-			ModRevision: 0,
+			ModRevision: expectedModRevision,
 		},
 		{
 			Key:         []byte("/test/sig/rsa/my-object"),
 			Value:       []byte("mock-signature-rsa"),
-			ModRevision: 0,
+			ModRevision: expectedModRevision,
 		},
 	}
 
@@ -85,6 +87,7 @@ func TestValidatorValidate_Success(t *testing.T) {
 	result := validatedResults[0]
 	assert.Equal(t, "my-object", result.Name)
 	assert.True(t, result.Value.IsSome())
+	assert.Equal(t, expectedModRevision, result.ModRevision)
 
 	val, ok := result.Value.Get()
 	require.True(t, ok)


### PR DESCRIPTION
feature: pass ModRevision field from kv.KeyValue structure to integrity.ValidatedResult

Added ModRevision field to integrity.ValidatedResult. Tests have been supplemented with ModRevision checks.

Closes #23 