### PR TITLE
ci: bump golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -7,7 +7,7 @@ on:
 env:
   GO_VERSION: 1.24
   CODESPELL_VERSION: v2.4.1
-  GOLANGCI_LINT_VERSION: v2.10.1
+  GOLANGCI_LINT_VERSION: v2.11.4
 
 jobs:
   golangci-lint:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ coveralls-deps:
 .PHONY: lint-deps
 lint-deps:
 	@echo "Installing lint deps"
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.10.1
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 
 .PHONY: generate
 generate:


### PR DESCRIPTION
Update golangci-lint version from v2.10.1 to v2.11.4.
- Bump GOLANGCI_LINT_VERSION in .github/workflows/check.yaml.
- Bump install target in Makefile.