### PR TITLE
storage: add Prefixed wrapper for namespace scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- storage.Prefixed: New wrapper that scopes every operation, predicate,
+  Range, and Watch call under a given namespace prefix. Nested Prefixed
+  wrappers are flattened at construction.
+
 ### Changed
 
 ### Fixed

--- a/integrity/typed_test.go
+++ b/integrity/typed_test.go
@@ -1820,7 +1820,8 @@ func TestTypedWatch(t *testing.T) {
 	t.Run("basic event filtering", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := t.Context()
+
 		driverMock := mocks.NewDriverMock(t)
 		st := storage.NewStorage(driverMock)
 
@@ -1911,7 +1912,8 @@ func TestTypedWatch(t *testing.T) {
 	t.Run("ParseKey error skips event", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := t.Context()
+
 		driverMock := mocks.NewDriverMock(t)
 		st := storage.NewStorage(driverMock)
 

--- a/prefix.go
+++ b/prefix.go
@@ -1,0 +1,239 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/tarantool/go-storage/kv"
+	"github.com/tarantool/go-storage/operation"
+	"github.com/tarantool/go-storage/predicate"
+	txPkg "github.com/tarantool/go-storage/tx"
+	"github.com/tarantool/go-storage/watch"
+)
+
+// Prefixed returns a Storage that scopes every operation, predicate, range,
+// and watch under prefix. Keys returned to the caller (RequestResponse.Values,
+// kv.KeyValue, watch.Event.Prefix) have prefix stripped — callers never see
+// absolute keys.
+//
+// Composition: Prefixed("/a", Prefixed("/b", base)) ≡ Prefixed("/a/b", base).
+// Nested wrappers are flattened at construction so the outer prefix is the
+// leftmost segment.
+//
+// An empty prefix yields a transparent wrapper.
+func Prefixed(prefix string, inner Storage) Storage {
+	if existing, ok := inner.(*prefixed); ok {
+		merged := make([]byte, 0, len(prefix)+len(existing.prefix))
+
+		merged = append(merged, prefix...)
+		merged = append(merged, existing.prefix...)
+
+		return &prefixed{
+			prefix: merged,
+			inner:  existing.inner,
+		}
+	}
+
+	return &prefixed{
+		prefix: []byte(prefix),
+		inner:  inner,
+	}
+}
+
+type prefixed struct {
+	prefix []byte
+	inner  Storage
+}
+
+func (p *prefixed) Watch(ctx context.Context, key []byte, opts ...watch.Option) <-chan watch.Event {
+	absKey := concatKey(p.prefix, key)
+	innerCh := p.inner.Watch(ctx, absKey, opts...)
+
+	out := make(chan watch.Event, cap(innerCh))
+
+	go func() {
+		defer close(out)
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event, ok := <-innerCh:
+				if !ok {
+					return
+				}
+
+				event.Prefix = stripPrefix(p.prefix, event.Prefix)
+
+				select {
+				case <-ctx.Done():
+					return
+				case out <- event:
+				}
+			}
+		}
+	}()
+
+	return out
+}
+
+func (p *prefixed) Tx(ctx context.Context) txPkg.Tx {
+	return &prefixedTx{
+		inner:  p.inner.Tx(ctx),
+		prefix: p.prefix,
+	}
+}
+
+func (p *prefixed) Range(ctx context.Context, opts ...RangeOption) ([]kv.KeyValue, error) {
+	rangeOpts := &rangeOptions{Prefix: "", Limit: 0}
+	for _, opt := range opts {
+		opt(rangeOpts)
+	}
+
+	var newOpts []RangeOption
+
+	if rangeOpts.Prefix != "" {
+		newOpts = append(newOpts, WithPrefix(string(p.prefix)+rangeOpts.Prefix))
+	}
+
+	if rangeOpts.Limit != 0 {
+		newOpts = append(newOpts, WithLimit(rangeOpts.Limit))
+	}
+
+	kvs, err := p.inner.Range(ctx, newOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("range: %w", err)
+	}
+
+	for i := range kvs {
+		kvs[i].Key = stripPrefix(p.prefix, kvs[i].Key)
+	}
+
+	return kvs, nil
+}
+
+type prefixedTx struct {
+	inner  txPkg.Tx
+	prefix []byte
+}
+
+func (t *prefixedTx) If(predicates ...predicate.Predicate) txPkg.Tx {
+	rewritten := make([]predicate.Predicate, len(predicates))
+	for i, pred := range predicates {
+		rewritten[i] = rewritePredicate(t.prefix, pred)
+	}
+
+	t.inner.If(rewritten...)
+
+	return t
+}
+
+func (t *prefixedTx) Then(operations ...operation.Operation) txPkg.Tx {
+	rewritten := make([]operation.Operation, len(operations))
+	for i, op := range operations {
+		rewritten[i] = rewriteOperation(t.prefix, op)
+	}
+
+	t.inner.Then(rewritten...)
+
+	return t
+}
+
+func (t *prefixedTx) Else(operations ...operation.Operation) txPkg.Tx {
+	rewritten := make([]operation.Operation, len(operations))
+	for i, op := range operations {
+		rewritten[i] = rewriteOperation(t.prefix, op)
+	}
+
+	t.inner.Else(rewritten...)
+
+	return t
+}
+
+func (t *prefixedTx) Commit() (txPkg.Response, error) {
+	resp, err := t.inner.Commit()
+	if err != nil {
+		return resp, fmt.Errorf("tx commit: %w", err)
+	}
+
+	for i := range resp.Results {
+		for j := range resp.Results[i].Values {
+			resp.Results[i].Values[j].Key = stripPrefix(t.prefix, resp.Results[i].Values[j].Key)
+		}
+	}
+
+	return resp, nil
+}
+
+func rewriteOperation(prefix []byte, oper operation.Operation) operation.Operation {
+	newKey := concatKey(prefix, oper.Key())
+
+	switch oper.Type() {
+	case operation.TypeGet:
+		return operation.Get(newKey, oper.Options()...)
+	case operation.TypePut:
+		return operation.Put(newKey, oper.Value(), oper.Options()...)
+	case operation.TypeDelete:
+		return operation.Delete(newKey, oper.Options()...)
+	}
+
+	panic(fmt.Sprintf("storage.Prefixed: unknown operation type %s", oper.Type()))
+}
+
+func rewritePredicate(prefix []byte, pred predicate.Predicate) predicate.Predicate {
+	newKey := concatKey(prefix, pred.Key())
+	predOp := pred.Operation()
+	target := pred.Target()
+	val := pred.Value()
+
+	switch target {
+	case predicate.TargetValue:
+		switch predOp {
+		case predicate.OpEqual:
+			return predicate.ValueEqual(newKey, val)
+		case predicate.OpNotEqual:
+			return predicate.ValueNotEqual(newKey, val)
+		case predicate.OpGreater, predicate.OpLess:
+			// Greater/Less comparisons are not supported for value targets.
+		}
+	case predicate.TargetVersion:
+		version, ok := val.(int64)
+		if !ok {
+			panic(fmt.Sprintf("storage.Prefixed: predicate value for version target must be int64, got %T", val))
+		}
+
+		switch predOp {
+		case predicate.OpEqual:
+			return predicate.VersionEqual(newKey, version)
+		case predicate.OpNotEqual:
+			return predicate.VersionNotEqual(newKey, version)
+		case predicate.OpGreater:
+			return predicate.VersionGreater(newKey, version)
+		case predicate.OpLess:
+			return predicate.VersionLess(newKey, version)
+		}
+	}
+
+	panic(fmt.Sprintf("storage.Prefixed: unsupported predicate target=%s op=%s", target, predOp))
+}
+
+func concatKey(prefix, key []byte) []byte {
+	if len(prefix) == 0 {
+		return key
+	}
+
+	out := make([]byte, len(prefix)+len(key))
+	copy(out, prefix)
+	copy(out[len(prefix):], key)
+
+	return out
+}
+
+func stripPrefix(prefix, key []byte) []byte {
+	if bytes.HasPrefix(key, prefix) {
+		return key[len(prefix):]
+	}
+
+	return key
+}

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -1,0 +1,695 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/internal/mocks"
+	"github.com/tarantool/go-storage/kv"
+	"github.com/tarantool/go-storage/operation"
+	"github.com/tarantool/go-storage/predicate"
+	txPkg "github.com/tarantool/go-storage/tx"
+	"github.com/tarantool/go-storage/watch"
+)
+
+type recordedTxCall struct {
+	predicates []predicate.Predicate
+	thenOps    []operation.Operation
+	elseOps    []operation.Operation
+}
+
+type recordingStorage struct {
+	lastTx recordedTxCall
+	txResp txPkg.Response
+	txErr  error
+
+	lastWatchKey []byte
+	watchEvents  []watch.Event
+
+	// Range is exercised through DriverMock (see TestPrefixed_Range), so this
+	// stub does not implement it.
+}
+
+func (s *recordingStorage) Tx(_ context.Context) txPkg.Tx {
+	return &recordingTx{rec: s, call: recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil}}
+}
+
+func (s *recordingStorage) Range(_ context.Context, _ ...storage.RangeOption) ([]kv.KeyValue, error) {
+	panic("recordingStorage.Range: use DriverMock-based tests for Range")
+}
+
+func (s *recordingStorage) Watch(_ context.Context, key []byte, _ ...watch.Option) <-chan watch.Event {
+	s.lastWatchKey = key
+
+	watchCh := make(chan watch.Event, len(s.watchEvents)+1)
+	for _, e := range s.watchEvents {
+		watchCh <- e
+	}
+
+	// Closed so the Prefixed forwarder goroutine exits after draining events.
+	close(watchCh)
+
+	return watchCh
+}
+
+type recordingTx struct {
+	rec  *recordingStorage
+	call recordedTxCall
+}
+
+func (t *recordingTx) If(preds ...predicate.Predicate) txPkg.Tx {
+	t.call.predicates = append(t.call.predicates, preds...)
+	return t
+}
+
+func (t *recordingTx) Then(ops ...operation.Operation) txPkg.Tx {
+	t.call.thenOps = append(t.call.thenOps, ops...)
+	return t
+}
+
+func (t *recordingTx) Else(ops ...operation.Operation) txPkg.Tx {
+	t.call.elseOps = append(t.call.elseOps, ops...)
+	return t
+}
+
+func (t *recordingTx) Commit() (txPkg.Response, error) {
+	t.rec.lastTx = t.call
+	return t.rec.txResp, t.rec.txErr
+}
+
+func TestPrefixed_OperationKeyPrefixing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const namespace = "/ns"
+
+	t.Run("Put in Then", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		_, err := prefixedStore.Tx(ctx).
+			Then(operation.Put([]byte("key"), []byte("val"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, inner.lastTx.thenOps, 1)
+
+		op := inner.lastTx.thenOps[0]
+		assert.Equal(t, operation.TypePut, op.Type())
+		assert.Equal(t, []byte(namespace+"key"), op.Key())
+		assert.Equal(t, []byte("val"), op.Value())
+	})
+
+	t.Run("Get in Then", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		_, err := prefixedStore.Tx(ctx).
+			Then(operation.Get([]byte("foo"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, inner.lastTx.thenOps, 1)
+
+		op := inner.lastTx.thenOps[0]
+		assert.Equal(t, operation.TypeGet, op.Type())
+		assert.Equal(t, []byte(namespace+"foo"), op.Key())
+	})
+
+	t.Run("Delete in Else", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		_, err := prefixedStore.Tx(ctx).
+			Else(operation.Delete([]byte("bar"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, inner.lastTx.elseOps, 1)
+
+		op := inner.lastTx.elseOps[0]
+		assert.Equal(t, operation.TypeDelete, op.Type())
+		assert.Equal(t, []byte(namespace+"bar"), op.Key())
+	})
+
+	t.Run("empty prefix is transparent", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed("", inner)
+
+		_, err := prefixedStore.Tx(ctx).
+			Then(operation.Put([]byte("key"), []byte("val"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, inner.lastTx.thenOps, 1)
+		assert.Equal(t, []byte("key"), inner.lastTx.thenOps[0].Key())
+	})
+
+	t.Run("multiple ops in Then and Else", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		_, err := prefixedStore.Tx(ctx).
+			Then(
+				operation.Put([]byte("a"), []byte("1")),
+				operation.Get([]byte("b")),
+			).
+			Else(
+				operation.Delete([]byte("c")),
+			).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, inner.lastTx.thenOps, 2)
+		assert.Equal(t, []byte(namespace+"a"), inner.lastTx.thenOps[0].Key())
+		assert.Equal(t, []byte(namespace+"b"), inner.lastTx.thenOps[1].Key())
+
+		require.Len(t, inner.lastTx.elseOps, 1)
+		assert.Equal(t, []byte(namespace+"c"), inner.lastTx.elseOps[0].Key())
+	})
+}
+
+func TestPrefixed_PredicateKeyPrefixing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const namespace = "/pfx"
+
+	tests := []struct {
+		name   string
+		build  func(key []byte) predicate.Predicate
+		op     predicate.Op
+		target predicate.Target
+		val    any
+	}{
+		{
+			name:   "ValueEqual",
+			build:  func(k []byte) predicate.Predicate { return predicate.ValueEqual(k, []byte("v")) },
+			op:     predicate.OpEqual,
+			target: predicate.TargetValue,
+			val:    []byte("v"),
+		},
+		{
+			name:   "ValueNotEqual",
+			build:  func(k []byte) predicate.Predicate { return predicate.ValueNotEqual(k, []byte("v")) },
+			op:     predicate.OpNotEqual,
+			target: predicate.TargetValue,
+			val:    []byte("v"),
+		},
+		{
+			name:   "VersionEqual",
+			build:  func(k []byte) predicate.Predicate { return predicate.VersionEqual(k, int64(42)) },
+			op:     predicate.OpEqual,
+			target: predicate.TargetVersion,
+			val:    int64(42),
+		},
+		{
+			name:   "VersionNotEqual",
+			build:  func(k []byte) predicate.Predicate { return predicate.VersionNotEqual(k, int64(7)) },
+			op:     predicate.OpNotEqual,
+			target: predicate.TargetVersion,
+			val:    int64(7),
+		},
+		{
+			name:   "VersionGreater",
+			build:  func(k []byte) predicate.Predicate { return predicate.VersionGreater(k, int64(10)) },
+			op:     predicate.OpGreater,
+			target: predicate.TargetVersion,
+			val:    int64(10),
+		},
+		{
+			name:   "VersionLess",
+			build:  func(k []byte) predicate.Predicate { return predicate.VersionLess(k, int64(5)) },
+			op:     predicate.OpLess,
+			target: predicate.TargetVersion,
+			val:    int64(5),
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			inner := &recordingStorage{
+				lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+				txResp:       txPkg.Response{Succeeded: true, Results: nil},
+				txErr:        nil,
+				lastWatchKey: nil,
+				watchEvents:  nil,
+			}
+			prefixedStore := storage.Prefixed(namespace, inner)
+
+			callerKey := []byte("mykey")
+			pred := testCase.build(callerKey)
+
+			_, err := prefixedStore.Tx(ctx).
+				If(pred).
+				Then(operation.Put(callerKey, []byte("val"))).
+				Commit()
+			require.NoError(t, err)
+
+			require.Len(t, inner.lastTx.predicates, 1)
+
+			got := inner.lastTx.predicates[0]
+
+			assert.Equal(t, []byte(namespace+"mykey"), got.Key(),
+				"predicate key must have namespace prefix prepended")
+			assert.Equal(t, testCase.op, got.Operation(), "Op must be preserved")
+			assert.Equal(t, testCase.target, got.Target(), "Target must be preserved")
+			assert.Equal(t, testCase.val, got.Value(), "Value must be preserved")
+		})
+	}
+}
+
+func TestPrefixed_Range(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Range uses DriverMock because storage.go translates WithPrefix(p) into
+	// operation.Get([]byte(p+"/")), and we want to assert the combined key the
+	// driver actually sees.
+
+	t.Run("WithPrefix concatenates namespace prefix", func(t *testing.T) {
+		t.Parallel()
+
+		mockDriver := mocks.NewDriverMock(t)
+		inner := storage.NewStorage(mockDriver)
+		prefixedStore := storage.Prefixed("/test", inner)
+
+		// "/test" + "/foo" + trailing "/" added by storage.go.
+		combinedKey := []byte("/test/foo/")
+		absKVs := []kv.KeyValue{
+			{Key: []byte("/test/foo/a"), Value: []byte("1"), ModRevision: 0},
+			{Key: []byte("/test/foo/b"), Value: []byte("2"), ModRevision: 0},
+		}
+
+		mockDriver.ExecuteMock.
+			Expect(ctx, nil, []operation.Operation{operation.Get(combinedKey)}, nil).
+			Return(txPkg.Response{
+				Succeeded: true,
+				Results:   []txPkg.RequestResponse{{Values: absKVs}},
+			}, nil)
+
+		kvs, err := prefixedStore.Range(ctx, storage.WithPrefix("/foo"))
+		require.NoError(t, err)
+
+		require.Len(t, kvs, 2)
+		assert.Equal(t, []byte("/foo/a"), kvs[0].Key)
+		assert.Equal(t, []byte("/foo/b"), kvs[1].Key)
+
+		mockDriver.MinimockFinish()
+	})
+
+	t.Run("no WithPrefix passes nothing to inner", func(t *testing.T) {
+		t.Parallel()
+
+		// Without WithPrefix the wrapper has nothing to rewrite, so it must
+		// not invoke the driver at all — hence no ExecuteMock expectation.
+		mockDriver := mocks.NewDriverMock(t)
+		inner := storage.NewStorage(mockDriver)
+		prefixedStore := storage.Prefixed("/test", inner)
+
+		kvs, err := prefixedStore.Range(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, kvs)
+
+		mockDriver.MinimockFinish()
+	})
+
+	t.Run("result keys have namespace prefix stripped", func(t *testing.T) {
+		t.Parallel()
+
+		mockDriver := mocks.NewDriverMock(t)
+		inner := storage.NewStorage(mockDriver)
+		prefixedStore := storage.Prefixed("/ns", inner)
+
+		absKVs := []kv.KeyValue{
+			{Key: []byte("/ns/obj/x"), Value: []byte("val-x"), ModRevision: 1},
+		}
+
+		mockDriver.ExecuteMock.
+			Expect(ctx, nil, []operation.Operation{operation.Get([]byte("/ns/obj/"))}, nil).
+			Return(txPkg.Response{
+				Succeeded: true,
+				Results:   []txPkg.RequestResponse{{Values: absKVs}},
+			}, nil)
+
+		kvs, err := prefixedStore.Range(ctx, storage.WithPrefix("/obj"))
+		require.NoError(t, err)
+		require.Len(t, kvs, 1)
+		assert.Equal(t, []byte("/obj/x"), kvs[0].Key)
+		assert.Equal(t, []byte("val-x"), kvs[0].Value)
+		assert.Equal(t, int64(1), kvs[0].ModRevision)
+
+		mockDriver.MinimockFinish()
+	})
+}
+
+func TestPrefixed_Watch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const namespace = "/test"
+
+	t.Run("Watch key is prefixed and event Prefix is stripped", func(t *testing.T) {
+		t.Parallel()
+
+		// concatKey concatenates raw bytes with no separator: "/test"+"foo"
+		// = "/testfoo". The inner emits an event keyed at the absolute path,
+		// which the wrapper strips back down to "foo" for the caller.
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: false, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents: []watch.Event{
+				{Prefix: []byte("/testfoo")},
+			},
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		watchCh := prefixedStore.Watch(ctx, []byte("foo"))
+
+		assert.Equal(t, []byte("/testfoo"), inner.lastWatchKey)
+
+		select {
+		case event, ok := <-watchCh:
+			require.True(t, ok)
+			assert.Equal(t, []byte("foo"), event.Prefix,
+				"event Prefix must have namespace prefix stripped")
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("expected event from Watch channel")
+		}
+	})
+
+	t.Run("Watch channel closes when inner channel closes", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: false, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		watchCh := prefixedStore.Watch(ctx, []byte("k"))
+
+		// The recording stub buffers an empty event slice and immediately
+		// closes the inner channel; the wrapper goroutine should propagate
+		// the close to the caller-facing channel.
+		select {
+		case _, ok := <-watchCh:
+			assert.False(t, ok, "channel should be closed when inner closes")
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("expected channel to close")
+		}
+	})
+
+	t.Run("Watch channel closes on context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		// blockCh stays open until the deferred close below, so the wrapper
+		// goroutine has nothing to drain and can only exit via ctx.Done().
+		blockCh := make(chan watch.Event)
+		blockInner := &blockingWatchStorage{ch: blockCh}
+		prefixedStore := storage.Prefixed(namespace, blockInner)
+
+		ctx2, cancel := context.WithCancel(ctx)
+
+		watchCh := prefixedStore.Watch(ctx2, []byte("k"))
+
+		// Yield so the wrapper goroutine reaches its select before cancel.
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+
+		select {
+		case _, ok := <-watchCh:
+			assert.False(t, ok, "channel should be closed on context cancellation")
+		case <-time.After(500 * time.Millisecond):
+			t.Fatal("expected channel to close after context cancellation")
+		}
+
+		close(blockCh)
+	})
+}
+
+type blockingWatchStorage struct {
+	ch <-chan watch.Event
+}
+
+func (b *blockingWatchStorage) Tx(_ context.Context) txPkg.Tx {
+	return &recordingTx{
+		rec: &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: false, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		},
+		call: recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+	}
+}
+
+func (b *blockingWatchStorage) Range(_ context.Context, _ ...storage.RangeOption) ([]kv.KeyValue, error) {
+	return nil, nil
+}
+
+func (b *blockingWatchStorage) Watch(_ context.Context, _ []byte, _ ...watch.Option) <-chan watch.Event {
+	return b.ch
+}
+
+func TestPrefixed_Composition(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("flattened at construction: Put lands at combined prefix", func(t *testing.T) {
+		t.Parallel()
+
+		base := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		composed := storage.Prefixed("/a", storage.Prefixed("/b", base))
+
+		_, err := composed.Tx(ctx).
+			Then(operation.Put([]byte("k"), []byte("v"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, base.lastTx.thenOps, 1)
+		assert.Equal(t, []byte("/a/bk"), base.lastTx.thenOps[0].Key(),
+			"composed Put key must equal /a/b concatenated with the caller key")
+	})
+
+	t.Run("equivalent to single Prefixed with concatenated prefix", func(t *testing.T) {
+		t.Parallel()
+
+		base1 := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		base2 := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+
+		composed := storage.Prefixed("/a", storage.Prefixed("/b", base1))
+		flat := storage.Prefixed("/a/b", base2)
+
+		callerKey := []byte("/obj/name")
+		callerVal := []byte("data")
+
+		_, err1 := composed.Tx(ctx).Then(operation.Put(callerKey, callerVal)).Commit()
+		_, err2 := flat.Tx(ctx).Then(operation.Put(callerKey, callerVal)).Commit()
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+
+		require.Len(t, base1.lastTx.thenOps, 1)
+		require.Len(t, base2.lastTx.thenOps, 1)
+
+		assert.Equal(t, base1.lastTx.thenOps[0].Key(), base2.lastTx.thenOps[0].Key(),
+			"composed and flat prefixes must produce identical inner keys")
+	})
+
+	t.Run("three levels", func(t *testing.T) {
+		t.Parallel()
+
+		base := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		composed := storage.Prefixed("/a", storage.Prefixed("/b", storage.Prefixed("/c", base)))
+
+		_, err := composed.Tx(ctx).
+			Then(operation.Put([]byte("x"), []byte("v"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, base.lastTx.thenOps, 1)
+		assert.Equal(t, []byte("/a/b/cx"), base.lastTx.thenOps[0].Key())
+	})
+}
+
+func TestPrefixed_ResultKeyStripping(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const namespace = "/ns"
+
+	t.Run("Tx.Commit Values keys are stripped", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx: recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp: txPkg.Response{
+				Succeeded: true,
+				Results: []txPkg.RequestResponse{
+					{Values: []kv.KeyValue{
+						{Key: []byte("/ns/a"), Value: []byte("1"), ModRevision: 10},
+						{Key: []byte("/ns/b"), Value: []byte("2"), ModRevision: 20},
+					}},
+					{Values: []kv.KeyValue{
+						{Key: []byte("/ns/c"), Value: []byte("3"), ModRevision: 30},
+					}},
+				},
+			},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		resp, err := prefixedStore.Tx(ctx).
+			Then(operation.Get([]byte("a")), operation.Get([]byte("c"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, resp.Results, 2)
+		require.Len(t, resp.Results[0].Values, 2)
+		assert.Equal(t, []byte("/a"), resp.Results[0].Values[0].Key)
+		assert.Equal(t, []byte("/b"), resp.Results[0].Values[1].Key)
+
+		require.Len(t, resp.Results[1].Values, 1)
+		assert.Equal(t, []byte("/c"), resp.Results[1].Values[0].Key)
+	})
+
+	t.Run("non-prefixed keys in results are returned unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		// If the inner storage returns a key that does not carry the expected
+		// prefix (e.g. a driver bug), the wrapper must not corrupt it.
+		inner := &recordingStorage{
+			lastTx: recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp: txPkg.Response{
+				Succeeded: true,
+				Results: []txPkg.RequestResponse{
+					{Values: []kv.KeyValue{
+						{Key: []byte("/other/x"), Value: []byte("v"), ModRevision: 0},
+					}},
+				},
+			},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := storage.Prefixed(namespace, inner)
+
+		resp, err := prefixedStore.Tx(ctx).Then(operation.Get([]byte("x"))).Commit()
+		require.NoError(t, err)
+
+		require.Len(t, resp.Results[0].Values, 1)
+		assert.Equal(t, []byte("/other/x"), resp.Results[0].Values[0].Key)
+	})
+
+	t.Run("Range result keys are stripped (via DriverMock)", func(t *testing.T) {
+		t.Parallel()
+
+		mockDriver := mocks.NewDriverMock(t)
+		inner := storage.NewStorage(mockDriver)
+		prefixedStore := storage.Prefixed("/ns", inner)
+
+		absKVs := []kv.KeyValue{
+			{Key: []byte("/ns/objects/myname"), Value: []byte("data"), ModRevision: 1},
+		}
+
+		mockDriver.ExecuteMock.
+			Expect(ctx, nil, []operation.Operation{operation.Get([]byte("/ns/objects/"))}, nil).
+			Return(txPkg.Response{
+				Succeeded: true,
+				Results:   []txPkg.RequestResponse{{Values: absKVs}},
+			}, nil)
+
+		kvs, err := prefixedStore.Range(ctx, storage.WithPrefix("/objects"))
+		require.NoError(t, err)
+		require.Len(t, kvs, 1)
+		assert.Equal(t, []byte("/objects/myname"), kvs[0].Key)
+
+		mockDriver.MinimockFinish()
+	})
+}


### PR DESCRIPTION
Add `storage.Prefixed` Storage that scopes every operation, predicate, `Range`, and `Watch` call under the given namespace prefix. Nested `Prefixed` wrappers are flattened at construction.
