### PR TITLE
namer: add LayeredNamer for per-category key layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - storage.Prefixed: New wrapper that scopes every operation, predicate,
   Range, and Watch call under a given namespace prefix. Nested Prefixed
   wrappers are flattened at construction.
+- namer.LayeredNamer: namespace-agnostic namer that places each key
+  category under its own top-level location segment
+  (`/<objectLocation>/<name>`, `/<hashLocation>/<name>`,
+  `/<sigLocation>/<name>`). The constructor validates segments
+  (non-empty, slash-free, unique across categories) and `ParseKey`
+  parses keys back to `(name, KeyType, property)` unambiguously.
 
 ### Changed
 

--- a/namer/layered.go
+++ b/namer/layered.go
@@ -1,0 +1,477 @@
+package namer
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Fixed marker segments distinguishing key categories. Hash and signature keys
+// always live under these literals; the per-hasher / per-signer location
+// segment sits between the marker and the objectLocation. Mirrors the
+// hashName / signatureName constants used by DefaultNamer.
+const (
+	layeredHashMarker = "hash"
+	layeredSigMarker  = "sig"
+)
+
+// Sentinel errors for NewLayeredNamer validation.
+var (
+	// ErrEmptyHasherName is returned when a hash entry has an empty HasherName.
+	ErrEmptyHasherName = errors.New("namer: hash entry has empty HasherName")
+	// ErrEmptySignerName is returned when a sig entry has an empty SignerName.
+	ErrEmptySignerName = errors.New("namer: sig entry has empty SignerName")
+	// ErrDuplicateLocation is returned when a location segment is used more than once within a category.
+	ErrDuplicateLocation = errors.New("namer: duplicate location segment")
+	// ErrSegmentEmpty is returned when a location segment is empty.
+	ErrSegmentEmpty = errors.New("namer: segment must not be empty")
+	// ErrSegmentLeadingSlash is returned when a segment starts with '/'.
+	ErrSegmentLeadingSlash = errors.New("namer: segment must not start with '/'")
+	// ErrSegmentTrailingSlash is returned when a segment ends with '/'.
+	ErrSegmentTrailingSlash = errors.New("namer: segment must not end with '/'")
+	// ErrSegmentInnerSlash is returned when a segment contains '/'.
+	ErrSegmentInnerSlash = errors.New("namer: segment must not contain '/'")
+	// ErrObjectLocationReserved is returned when objectLocation equals one of the
+	// reserved category markers ("hash" or "sig"), which would collide with
+	// hash/sig key paths.
+	ErrObjectLocationReserved = errors.New("namer: objectLocation must not equal reserved marker \"hash\" or \"sig\"")
+	// ErrCompactSingleHashCardinality is returned when CompactSingleHash is set
+	// but the configured hash list does not have exactly one entry.
+	ErrCompactSingleHashCardinality = errors.New("namer: CompactSingleHash requires exactly one hash entry")
+	// ErrCompactSingleSigCardinality is returned when CompactSingleSig is set
+	// but the configured sig list does not have exactly one entry.
+	ErrCompactSingleSigCardinality = errors.New("namer: CompactSingleSig requires exactly one sig entry")
+)
+
+// LayeredHashLocation associates a hasher name with its key location segment.
+type LayeredHashLocation struct {
+	HasherName string // matches hasher.Hasher.Name().
+	Location   string // the location segment (e.g. "sha256").
+}
+
+// LayeredSigLocation associates a signer name with its key location segment.
+type LayeredSigLocation struct {
+	SignerName string // matches crypto.Signer.Name() / Verifier.Name().
+	Location   string // the location segment (e.g. "ed25519").
+}
+
+// LayeredOption configures NewLayeredNamer.
+type LayeredOption func(*layeredOpts)
+
+type layeredOpts struct {
+	compactHash bool
+	compactSig  bool
+}
+
+// CompactSingleHash drops the per-hasher location segment in generated and
+// parsed hash keys. Layout becomes /hash/<objectLocation>/<name>.
+// NewLayeredNamer returns ErrCompactSingleHashCardinality if the hash list
+// does not have exactly one entry.
+func CompactSingleHash() LayeredOption {
+	return func(o *layeredOpts) { o.compactHash = true }
+}
+
+// CompactSingleSig drops the per-signer location segment in generated and
+// parsed sig keys. Layout becomes /sig/<objectLocation>/<name>.
+// NewLayeredNamer returns ErrCompactSingleSigCardinality if the sig list
+// does not have exactly one entry.
+func CompactSingleSig() LayeredOption {
+	return func(o *layeredOpts) { o.compactSig = true }
+}
+
+type layeredNamer struct {
+	objectLocation string
+	hashLocations  []LayeredHashLocation
+	sigLocations   []LayeredSigLocation
+	compactHash    bool
+	compactSig     bool
+	// Reverse maps populated once at construction so ParseKey is O(1)
+	// regardless of hash/sig list size.
+	hashIndex map[string]string // hashLocation -> hasherName.
+	sigIndex  map[string]string // sigLocation  -> signerName.
+}
+
+// NewLayeredNamer constructs a Namer that emits keys with per-category
+// location segments. All segment strings are validated at construction time.
+//
+// Layout (default):
+//
+//	/<objectLocation>/<name>                          (value)
+//	/hash/<hashLocation>/<objectLocation>/<name>      (hash, one per hasher)
+//	/sig/<sigLocation>/<objectLocation>/<name>        (sig, one per signer)
+//
+// With CompactSingleHash, the <hashLocation> segment is omitted; with
+// CompactSingleSig, the <sigLocation> segment is omitted.
+//
+// Validation rules:
+//   - Each segment must be non-empty, contain no '/', and not equal "hash" or "sig" for objectLocation.
+//   - hashLocations must be unique within hashes; sigLocations must be unique within sigs.
+//   - Compact flags require exactly one entry in their respective category.
+func NewLayeredNamer(
+	objectLocation string,
+	hashLocations []LayeredHashLocation,
+	sigLocations []LayeredSigLocation,
+	opts ...LayeredOption,
+) (Namer, error) {
+	var resolved layeredOpts
+
+	for _, opt := range opts {
+		opt(&resolved)
+	}
+
+	err := validateSegment("objectLocation", objectLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	if objectLocation == layeredHashMarker || objectLocation == layeredSigMarker {
+		return nil, fmt.Errorf("%w: got %q", ErrObjectLocationReserved, objectLocation)
+	}
+
+	if resolved.compactHash && len(hashLocations) != 1 {
+		return nil, fmt.Errorf("%w: got %d", ErrCompactSingleHashCardinality, len(hashLocations))
+	}
+
+	if resolved.compactSig && len(sigLocations) != 1 {
+		return nil, fmt.Errorf("%w: got %d", ErrCompactSingleSigCardinality, len(sigLocations))
+	}
+
+	hashIndex := make(map[string]string, len(hashLocations))
+
+	for _, hashLoc := range hashLocations {
+		if hashLoc.HasherName == "" {
+			return nil, ErrEmptyHasherName
+		}
+
+		err = validateSegment("hash Location", hashLoc.Location)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := hashIndex[hashLoc.Location]; exists {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateLocation, hashLoc.Location)
+		}
+
+		hashIndex[hashLoc.Location] = hashLoc.HasherName
+	}
+
+	sigIndex := make(map[string]string, len(sigLocations))
+
+	for _, sigLoc := range sigLocations {
+		if sigLoc.SignerName == "" {
+			return nil, ErrEmptySignerName
+		}
+
+		err = validateSegment("sig Location", sigLoc.Location)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := sigIndex[sigLoc.Location]; exists {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateLocation, sigLoc.Location)
+		}
+
+		sigIndex[sigLoc.Location] = sigLoc.SignerName
+	}
+
+	return &layeredNamer{
+		objectLocation: objectLocation,
+		hashLocations:  hashLocations,
+		sigLocations:   sigLocations,
+		compactHash:    resolved.compactHash,
+		compactSig:     resolved.compactSig,
+		hashIndex:      hashIndex,
+		sigIndex:       sigIndex,
+	}, nil
+}
+
+func validateSegment(field, seg string) error {
+	if seg == "" {
+		return fmt.Errorf("%w: %s", ErrSegmentEmpty, field)
+	}
+
+	if strings.HasPrefix(seg, "/") {
+		return fmt.Errorf("%w: %s %q", ErrSegmentLeadingSlash, field, seg)
+	}
+
+	if strings.HasSuffix(seg, "/") {
+		return fmt.Errorf("%w: %s %q", ErrSegmentTrailingSlash, field, seg)
+	}
+
+	if strings.Contains(seg, "/") {
+		return fmt.Errorf("%w: %s %q", ErrSegmentInnerSlash, field, seg)
+	}
+
+	return nil
+}
+
+// GenerateNames returns one key per category for the given object name.
+// name must be non-empty; a leading "/" is stripped.
+func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
+	if name == "" {
+		return nil, errInvalidName(name, "should not be empty")
+	}
+
+	name = strings.TrimPrefix(name, "/")
+
+	out := make([]Key, 0, 1+len(n.hashLocations)+len(n.sigLocations))
+
+	out = append(out, NewDefaultKey(
+		name,
+		KeyTypeValue,
+		"",
+		"/"+n.objectLocation+"/"+name,
+	))
+
+	for _, hl := range n.hashLocations {
+		out = append(out, NewDefaultKey(
+			name,
+			KeyTypeHash,
+			hl.HasherName,
+			n.buildHashKey(hl.Location, name),
+		))
+	}
+
+	for _, sl := range n.sigLocations {
+		out = append(out, NewDefaultKey(
+			name,
+			KeyTypeSignature,
+			sl.SignerName,
+			n.buildSigKey(sl.Location, name),
+		))
+	}
+
+	return out, nil
+}
+
+// ParseKey parses a raw key path back to a DefaultKey.
+//
+// Recognized shapes (must match the namer's configured layout):
+//
+//	/<objectLocation>/<name>                          → KeyTypeValue
+//	/hash/<hashLocation>/<objectLocation>/<name>      → KeyTypeHash
+//	/sig/<sigLocation>/<objectLocation>/<name>        → KeyTypeSignature
+//
+// With CompactSingleHash / CompactSingleSig the corresponding location
+// segment is absent.
+func (n *layeredNamer) ParseKey(raw string) (DefaultKey, error) {
+	stripped := strings.TrimPrefix(raw, "/")
+
+	first, rest, found := strings.Cut(stripped, "/")
+	if !found || first == "" {
+		return DefaultKey{}, errInvalidKey(raw, "key must have at least two path segments")
+	}
+
+	switch first {
+	case layeredHashMarker:
+		return n.parseHashKey(raw, rest)
+	case layeredSigMarker:
+		return n.parseSigKey(raw, rest)
+	default:
+		return n.parseValueKey(raw, first, rest)
+	}
+}
+
+// ParseKeys groups raw key paths by object name. It mirrors DefaultNamer.ParseKeys.
+func (n *layeredNamer) ParseKeys(names []string, ignoreError bool) (Results, error) {
+	out := map[string][]Key{}
+
+	for _, name := range names {
+		key, err := n.ParseKey(name)
+		switch {
+		case err != nil && ignoreError:
+			continue
+		case err != nil:
+			return Results{}, err
+		}
+
+		out[key.name] = append(out[key.name], key)
+	}
+
+	return NewResults(out), nil
+}
+
+// Prefix returns the prefix string for value-layer range walks.
+// It always covers only the objectLocation sub-tree (hashes/sigs are separate).
+//
+// Examples (objectLocation="objects"):
+//
+//	Prefix("", false)       → "/objects/"
+//	Prefix("alice", false)  → "/objects/alice"
+//	Prefix("users", true)   → "/objects/users/"
+//	Prefix("/alice/", false) → "/objects/alice"
+func (n *layeredNamer) Prefix(val string, isPrefix bool) string {
+	suffix := strings.Trim(val, "/")
+
+	var builder strings.Builder
+
+	builder.WriteByte('/')
+	builder.WriteString(n.objectLocation)
+	builder.WriteByte('/')
+
+	if suffix != "" {
+		builder.WriteString(suffix)
+
+		if isPrefix {
+			builder.WriteByte('/')
+		}
+	}
+
+	return builder.String()
+}
+
+func (n *layeredNamer) buildHashKey(hashLocation, name string) string {
+	if n.compactHash {
+		return "/" + layeredHashMarker + "/" + n.objectLocation + "/" + name
+	}
+
+	return "/" + layeredHashMarker + "/" + hashLocation + "/" + n.objectLocation + "/" + name
+}
+
+func (n *layeredNamer) buildSigKey(sigLocation, name string) string {
+	if n.compactSig {
+		return "/" + layeredSigMarker + "/" + n.objectLocation + "/" + name
+	}
+
+	return "/" + layeredSigMarker + "/" + sigLocation + "/" + n.objectLocation + "/" + name
+}
+
+func (n *layeredNamer) parseValueKey(raw, first, rest string) (DefaultKey, error) {
+	if first != n.objectLocation {
+		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown location segment %q", first))
+	}
+
+	if rest == "" {
+		return DefaultKey{}, errInvalidKey(raw, "name part must not be empty")
+	}
+
+	if strings.HasSuffix(rest, "/") {
+		return DefaultKey{}, errInvalidKey(raw, "key name should not be prefix")
+	}
+
+	return NewDefaultKey(rest, KeyTypeValue, "", raw), nil
+}
+
+func (n *layeredNamer) parseHashKey(raw, rest string) (DefaultKey, error) {
+	if n.compactHash {
+		return n.parseCompactHashKey(raw, rest)
+	}
+
+	return n.parseFullHashKey(raw, rest)
+}
+
+func (n *layeredNamer) parseCompactHashKey(raw, rest string) (DefaultKey, error) {
+	objLoc, after, found := strings.Cut(rest, "/")
+	if !found || objLoc == "" {
+		return DefaultKey{}, errInvalidKey(raw, "hash key missing objectLocation")
+	}
+
+	if objLoc != n.objectLocation {
+		return DefaultKey{}, errInvalidKey(raw,
+			fmt.Sprintf("hash key objectLocation %q does not match %q", objLoc, n.objectLocation))
+	}
+
+	err := validateNamePart(raw, after, "hash")
+	if err != nil {
+		return DefaultKey{}, err
+	}
+
+	return NewDefaultKey(after, KeyTypeHash, n.hashLocations[0].HasherName, raw), nil
+}
+
+func (n *layeredNamer) parseFullHashKey(raw, rest string) (DefaultKey, error) {
+	hashLoc, afterLoc, foundLoc := strings.Cut(rest, "/")
+	if !foundLoc || hashLoc == "" {
+		return DefaultKey{}, errInvalidKey(raw, "hash key missing hashLocation segment")
+	}
+
+	hasherName, ok := n.hashIndex[hashLoc]
+	if !ok {
+		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown hash location %q", hashLoc))
+	}
+
+	objLoc, after, found := strings.Cut(afterLoc, "/")
+	if !found || objLoc == "" {
+		return DefaultKey{}, errInvalidKey(raw, "hash key missing objectLocation")
+	}
+
+	if objLoc != n.objectLocation {
+		return DefaultKey{}, errInvalidKey(raw,
+			fmt.Sprintf("hash key objectLocation %q does not match %q", objLoc, n.objectLocation))
+	}
+
+	err := validateNamePart(raw, after, "hash")
+	if err != nil {
+		return DefaultKey{}, err
+	}
+
+	return NewDefaultKey(after, KeyTypeHash, hasherName, raw), nil
+}
+
+func (n *layeredNamer) parseSigKey(raw, rest string) (DefaultKey, error) {
+	if n.compactSig {
+		return n.parseCompactSigKey(raw, rest)
+	}
+
+	return n.parseFullSigKey(raw, rest)
+}
+
+func (n *layeredNamer) parseCompactSigKey(raw, rest string) (DefaultKey, error) {
+	objLoc, after, found := strings.Cut(rest, "/")
+	if !found || objLoc == "" {
+		return DefaultKey{}, errInvalidKey(raw, "sig key missing objectLocation")
+	}
+
+	if objLoc != n.objectLocation {
+		return DefaultKey{}, errInvalidKey(raw,
+			fmt.Sprintf("sig key objectLocation %q does not match %q", objLoc, n.objectLocation))
+	}
+
+	err := validateNamePart(raw, after, "sig")
+	if err != nil {
+		return DefaultKey{}, err
+	}
+
+	return NewDefaultKey(after, KeyTypeSignature, n.sigLocations[0].SignerName, raw), nil
+}
+
+func (n *layeredNamer) parseFullSigKey(raw, rest string) (DefaultKey, error) {
+	sigLoc, afterLoc, foundLoc := strings.Cut(rest, "/")
+	if !foundLoc || sigLoc == "" {
+		return DefaultKey{}, errInvalidKey(raw, "sig key missing sigLocation segment")
+	}
+
+	signerName, ok := n.sigIndex[sigLoc]
+	if !ok {
+		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown sig location %q", sigLoc))
+	}
+
+	objLoc, after, found := strings.Cut(afterLoc, "/")
+	if !found || objLoc == "" {
+		return DefaultKey{}, errInvalidKey(raw, "sig key missing objectLocation")
+	}
+
+	if objLoc != n.objectLocation {
+		return DefaultKey{}, errInvalidKey(raw,
+			fmt.Sprintf("sig key objectLocation %q does not match %q", objLoc, n.objectLocation))
+	}
+
+	err := validateNamePart(raw, after, "sig")
+	if err != nil {
+		return DefaultKey{}, err
+	}
+
+	return NewDefaultKey(after, KeyTypeSignature, signerName, raw), nil
+}
+
+func validateNamePart(raw, name, kind string) error {
+	if name == "" {
+		return errInvalidKey(raw, kind+" key missing name")
+	}
+
+	if strings.HasSuffix(name, "/") {
+		return errInvalidKey(raw, kind+" key name should not be prefix")
+	}
+
+	return nil
+}

--- a/namer/layered_test.go
+++ b/namer/layered_test.go
@@ -1,0 +1,730 @@
+package namer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/namer"
+)
+
+// Compile-time check that NewLayeredNamer returns a Namer; the concrete type
+// is unexported, so the assertion has to go through the constructor.
+var _ namer.Namer = func() namer.Namer {
+	layeredN, err := namer.NewLayeredNamer("objects", nil, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	return layeredN
+}()
+
+func TestLayeredNamer_Constructor_Validation(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		objectLocation string
+		hashLocations  []namer.LayeredHashLocation
+		sigLocations   []namer.LayeredSigLocation
+		opts           []namer.LayeredOption
+	}
+
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name:    "empty objectLocation",
+			args:    args{objectLocation: "", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name:    "objectLocation with leading slash",
+			args:    args{objectLocation: "/objects", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name:    "objectLocation with trailing slash",
+			args:    args{objectLocation: "objects/", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name:    "objectLocation with inner slash",
+			args:    args{objectLocation: "obj/ects", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name:    "objectLocation reserved: hash",
+			args:    args{objectLocation: "hash", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name:    "objectLocation reserved: sig",
+			args:    args{objectLocation: "sig", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name: "hash Location with leading slash",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: "/hashes"}},
+				sigLocations:   nil,
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "hash Location with trailing slash",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: "hashes/"}},
+				sigLocations:   nil,
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "hash Location with inner slash",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: "hash/sha256"}},
+				sigLocations:   nil,
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "hash Location empty",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: ""}},
+				sigLocations:   nil,
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "hash HasherName empty",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "", Location: "sha256"}},
+				sigLocations:   nil,
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sig Location with leading slash",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "ed25519", Location: "/sigs"}},
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sig Location with trailing slash",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "ed25519", Location: "sigs/"}},
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sig Location with inner slash",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "ed25519", Location: "sig/ed25519"}},
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sig Location empty",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "ed25519", Location: ""}},
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sig SignerName empty",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "", Location: "ed25519"}},
+				opts:           nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate hash entries share location",
+			args: args{
+				objectLocation: "objects",
+				hashLocations: []namer.LayeredHashLocation{
+					{HasherName: "sha256", Location: "shared"},
+					{HasherName: "sha512", Location: "shared"},
+				},
+				sigLocations: nil,
+				opts:         nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate sig entries share location",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations: []namer.LayeredSigLocation{
+					{SignerName: "ed25519", Location: "shared"},
+					{SignerName: "rsa", Location: "shared"},
+				},
+				opts: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid: object and hash share location (different namespaces)",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: "objects"}},
+				sigLocations:   nil,
+				opts:           nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid: hash and sig share location (different markers)",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: "common"}},
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "ed25519", Location: "common"}},
+				opts:           nil,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "valid: no hash/sig",
+			args:    args{objectLocation: "objects", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: false,
+		},
+		{
+			name: "valid: with hash and sig",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+				opts:           nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "compact hash: zero entries fails",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   nil,
+				opts:           []namer.LayeredOption{namer.CompactSingleHash()},
+			},
+			wantErr: true,
+		},
+		{
+			name: "compact hash: two entries fails",
+			args: args{
+				objectLocation: "objects",
+				hashLocations: []namer.LayeredHashLocation{
+					{HasherName: "sha256", Location: "sha256"},
+					{HasherName: "sha512", Location: "sha512"},
+				},
+				sigLocations: nil,
+				opts:         []namer.LayeredOption{namer.CompactSingleHash()},
+			},
+			wantErr: true,
+		},
+		{
+			name: "compact hash: one entry succeeds",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  []namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+				sigLocations:   nil,
+				opts:           []namer.LayeredOption{namer.CompactSingleHash()},
+			},
+			wantErr: false,
+		},
+		{
+			name: "compact sig: zero entries fails",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   nil,
+				opts:           []namer.LayeredOption{namer.CompactSingleSig()},
+			},
+			wantErr: true,
+		},
+		{
+			name: "compact sig: two entries fails",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations: []namer.LayeredSigLocation{
+					{SignerName: "ed25519", Location: "ed25519"},
+					{SignerName: "rsa", Location: "rsa"},
+				},
+				opts: []namer.LayeredOption{namer.CompactSingleSig()},
+			},
+			wantErr: true,
+		},
+		{
+			name: "compact sig: one entry succeeds",
+			args: args{
+				objectLocation: "objects",
+				hashLocations:  nil,
+				sigLocations:   []namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+				opts:           []namer.LayeredOption{namer.CompactSingleSig()},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := namer.NewLayeredNamer(
+				tt.args.objectLocation,
+				tt.args.hashLocations,
+				tt.args.sigLocations,
+				tt.args.opts...,
+			)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLayeredNamer_Constructor_CompactErrors_Sentinels(t *testing.T) {
+	t.Parallel()
+
+	t.Run("compact hash cardinality error is sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := namer.NewLayeredNamer("objects", nil, nil, namer.CompactSingleHash())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, namer.ErrCompactSingleHashCardinality)
+	})
+
+	t.Run("compact sig cardinality error is sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := namer.NewLayeredNamer("objects", nil, nil, namer.CompactSingleSig())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, namer.ErrCompactSingleSigCardinality)
+	})
+
+	t.Run("reserved objectLocation error is sentinel", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := namer.NewLayeredNamer("hash", nil, nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, namer.ErrObjectLocationReserved)
+	})
+}
+
+func newTestLayeredNamer(t *testing.T) namer.Namer {
+	t.Helper()
+
+	layeredN, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+	require.NoError(t, err)
+
+	return layeredN
+}
+
+func TestLayeredNamer_GenerateNames_Success(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	expected := []struct {
+		build    string
+		keyType  namer.KeyType
+		property string
+		name     string
+	}{
+		{"/objects/alice", namer.KeyTypeValue, "", "alice"},
+		{"/hash/sha256/objects/alice", namer.KeyTypeHash, "sha256", "alice"},
+		{"/sig/ed25519/objects/alice", namer.KeyTypeSignature, "ed25519", "alice"},
+	}
+
+	for i, exp := range expected {
+		assert.Equal(t, exp.build, keys[i].Build(), "key[%d].Build()", i)
+		assert.Equal(t, exp.keyType, keys[i].Type(), "key[%d].Type()", i)
+		assert.Equal(t, exp.property, keys[i].Property(), "key[%d].Property()", i)
+		assert.Equal(t, exp.name, keys[i].Name(), "key[%d].Name()", i)
+	}
+}
+
+func TestLayeredNamer_GenerateNames_EmptyName(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	_, err := layeredN.GenerateNames("")
+	require.Error(t, err)
+
+	var nameErr namer.InvalidNameError
+	require.ErrorAs(t, err, &nameErr)
+}
+
+func TestLayeredNamer_GenerateNames_LeadingSlash(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	keys, err := layeredN.GenerateNames("/alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	assert.Equal(t, "/objects/alice", keys[0].Build())
+	assert.Equal(t, "alice", keys[0].Name())
+}
+
+func TestLayeredNamer_GenerateNames_Compact(t *testing.T) {
+	t.Parallel()
+
+	t.Run("compact hash drops hashLocation segment", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(
+			"objects",
+			[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+			nil,
+			namer.CompactSingleHash(),
+		)
+		require.NoError(t, err)
+
+		keys, err := layeredN.GenerateNames("alice")
+		require.NoError(t, err)
+		require.Len(t, keys, 2)
+
+		assert.Equal(t, "/objects/alice", keys[0].Build())
+		assert.Equal(t, "/hash/objects/alice", keys[1].Build())
+		assert.Equal(t, namer.KeyTypeHash, keys[1].Type())
+		assert.Equal(t, "sha256", keys[1].Property())
+	})
+
+	t.Run("compact sig drops sigLocation segment", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(
+			"objects",
+			nil,
+			[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+			namer.CompactSingleSig(),
+		)
+		require.NoError(t, err)
+
+		keys, err := layeredN.GenerateNames("alice")
+		require.NoError(t, err)
+		require.Len(t, keys, 2)
+
+		assert.Equal(t, "/objects/alice", keys[0].Build())
+		assert.Equal(t, "/sig/objects/alice", keys[1].Build())
+		assert.Equal(t, namer.KeyTypeSignature, keys[1].Type())
+		assert.Equal(t, "ed25519", keys[1].Property())
+	})
+
+	t.Run("both compact flags", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(
+			"objects",
+			[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+			[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+			namer.CompactSingleHash(),
+			namer.CompactSingleSig(),
+		)
+		require.NoError(t, err)
+
+		keys, err := layeredN.GenerateNames("alice")
+		require.NoError(t, err)
+		require.Len(t, keys, 3)
+
+		assert.Equal(t, "/objects/alice", keys[0].Build())
+		assert.Equal(t, "/hash/objects/alice", keys[1].Build())
+		assert.Equal(t, "/sig/objects/alice", keys[2].Build())
+	})
+}
+
+func TestLayeredNamer_ParseKey_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	for _, nkey := range keys {
+		t.Run(nkey.Build(), func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := layeredN.ParseKey(nkey.Build())
+			require.NoError(t, err)
+
+			assert.Equal(t, nkey.Name(), parsed.Name())
+			assert.Equal(t, nkey.Type(), parsed.Type())
+			assert.Equal(t, nkey.Property(), parsed.Property())
+			assert.Equal(t, nkey.Build(), parsed.Build())
+		})
+	}
+}
+
+func TestLayeredNamer_ParseKey_RoundTrip_Compact(t *testing.T) {
+	t.Parallel()
+
+	layeredN, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		namer.CompactSingleHash(),
+		namer.CompactSingleSig(),
+	)
+	require.NoError(t, err)
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	for _, nkey := range keys {
+		t.Run(nkey.Build(), func(t *testing.T) {
+			t.Parallel()
+
+			parsed, err := layeredN.ParseKey(nkey.Build())
+			require.NoError(t, err)
+
+			assert.Equal(t, nkey.Name(), parsed.Name())
+			assert.Equal(t, nkey.Type(), parsed.Type())
+			assert.Equal(t, nkey.Property(), parsed.Property())
+			assert.Equal(t, nkey.Build(), parsed.Build())
+		})
+	}
+}
+
+func TestLayeredNamer_ParseKey_Errors(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "unknown location segment",
+			raw:  "/unknown/alice",
+		},
+		{
+			name: "empty name part (trailing slash after location)",
+			raw:  "/objects/",
+		},
+		{
+			name: "name part has trailing slash",
+			raw:  "/objects/alice/",
+		},
+		{
+			name: "missing name segment (only location)",
+			raw:  "/objects",
+		},
+		{
+			name: "completely empty",
+			raw:  "",
+		},
+		{
+			name: "hash key with unknown hashLocation",
+			raw:  "/hash/unknown/objects/alice",
+		},
+		{
+			name: "hash key with mismatched objectLocation",
+			raw:  "/hash/sha256/wrong/alice",
+		},
+		{
+			name: "hash key missing objectLocation segment",
+			raw:  "/hash/sha256/alice",
+		},
+		{
+			name: "hash key missing name",
+			raw:  "/hash/sha256/objects",
+		},
+		{
+			name: "hash key missing hashLocation",
+			raw:  "/hash",
+		},
+		{
+			name: "sig key with unknown sigLocation",
+			raw:  "/sig/unknown/objects/alice",
+		},
+		{
+			name: "sig key with mismatched objectLocation",
+			raw:  "/sig/ed25519/wrong/alice",
+		},
+		{
+			name: "sig key missing name",
+			raw:  "/sig/ed25519/objects",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := layeredN.ParseKey(tt.raw)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestLayeredNamer_ParseKeys_Grouping(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	t.Run("multiple names grouped correctly", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{
+			"/objects/alice",
+			"/hash/sha256/objects/alice",
+			"/sig/ed25519/objects/alice",
+			"/objects/bob",
+			"/hash/sha256/objects/bob",
+			"/sig/ed25519/objects/bob",
+		}
+
+		results, err := layeredN.ParseKeys(input, false)
+		require.NoError(t, err)
+		assert.Equal(t, 2, results.Len())
+
+		aliceKeys, ok := results.Select("alice")
+		require.True(t, ok)
+		assert.Len(t, aliceKeys, 3)
+
+		bobKeys, ok := results.Select("bob")
+		require.True(t, ok)
+		assert.Len(t, bobKeys, 3)
+	})
+
+	t.Run("single name produces isSingle=true", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{
+			"/objects/alice",
+			"/hash/sha256/objects/alice",
+			"/sig/ed25519/objects/alice",
+		}
+
+		results, err := layeredN.ParseKeys(input, false)
+		require.NoError(t, err)
+
+		keys, ok := results.SelectSingle()
+		require.True(t, ok)
+		assert.Len(t, keys, 3)
+	})
+
+	t.Run("ignoreError=true skips invalid keys", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{
+			"/unknown/alice",
+			"/objects/alice",
+		}
+
+		results, err := layeredN.ParseKeys(input, true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, results.Len())
+
+		_, ok := results.Select("alice")
+		assert.True(t, ok)
+	})
+
+	t.Run("ignoreError=false returns first error", func(t *testing.T) {
+		t.Parallel()
+
+		input := []string{
+			"/unknown/alice",
+			"/objects/alice",
+		}
+
+		_, err := layeredN.ParseKeys(input, false)
+		require.Error(t, err)
+	})
+}
+
+func TestLayeredNamer_Prefix(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	tests := []struct {
+		name     string
+		val      string
+		isPrefix bool
+		expected string
+	}{
+		{
+			name:     "empty val, isPrefix=false",
+			val:      "",
+			isPrefix: false,
+			expected: "/objects/",
+		},
+		{
+			name:     "empty val, isPrefix=true",
+			val:      "",
+			isPrefix: true,
+			expected: "/objects/",
+		},
+		{
+			name:     "simple val, isPrefix=false",
+			val:      "alice",
+			isPrefix: false,
+			expected: "/objects/alice",
+		},
+		{
+			name:     "simple val, isPrefix=true",
+			val:      "users",
+			isPrefix: true,
+			expected: "/objects/users/",
+		},
+		{
+			name:     "val with leading and trailing slash trimmed",
+			val:      "/alice/",
+			isPrefix: false,
+			expected: "/objects/alice",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := layeredN.Prefix(tt.val, tt.isPrefix)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
Add `LayeredNamer`: a namespace-agnostic namer that places each key category under its own top-level location segment:

```
  /<objectLocation>/<name>                       (value)
  /hash/<hashLocation>/<objectLocation>/<name>   (hash, one per hasher)
  /sig/<sigLocation>/<objectLocation>/<name>     (signature, one per signer)
```

`CompactSingleHash` / `CompactSingleSig` drop the per-hasher / per-signer location segment when the configured list has exactly one entry; the constructor validates that the corresponding list has exactly one entry.

The constructor validates all segments (non-empty, no slashes, unique across categories) and returns an error on violation. `ParseKey` parses back to (name, KeyType, property) unambiguously.

Part of TNTP-7587