### PR TITLE
integrity: add Codec[T] and CodecBuilder[T]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `/<sigLocation>/<name>`). The constructor validates segments
   (non-empty, slash-free, unique across categories) and `ParseKey`
   parses keys back to `(name, KeyType, property)` unambiguously.
+- integrity.Codec: schema-only `Codec[T]` (no storage handle) and
+  `CodecBuilder[T]` with a fluent value-receiver API mirroring
+  `TypedBuilder[T]`. `Build()` returns `(*Codec[T], error)` and
+  validates location-override keys eagerly so typos like
+  `WithHashLocation("sah256", …)` are no longer silently ignored.
 
 ### Changed
 

--- a/integrity/codec.go
+++ b/integrity/codec.go
@@ -1,0 +1,420 @@
+package integrity
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/tarantool/go-storage/crypto"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/marshaller"
+	"github.com/tarantool/go-storage/namer"
+	"github.com/tarantool/go-storage/predicate"
+)
+
+// ErrUnknownHasherLocation is returned when a WithHashLocation key does not match any configured hasher.
+var ErrUnknownHasherLocation = errors.New("codec: WithHashLocation key does not match any configured hasher")
+
+// ErrUnknownSignerLocation is returned when a WithSignatureLocation key does not match
+// any configured signer or verifier.
+var ErrUnknownSignerLocation = errors.New(
+	"codec: WithSignatureLocation key does not match any configured signer or verifier")
+
+// ErrSingleHashCompactCardinality is returned when WithSingleHashCompact is set
+// but the codec is not configured with exactly one hasher.
+var ErrSingleHashCompactCardinality = errors.New(
+	"codec: WithSingleHashCompact requires exactly one hasher")
+
+// ErrSingleSigCompactCardinality is returned when WithSingleSigCompact is set
+// but the union of signers and verifiers (deduped by name) is not of size one.
+var ErrSingleSigCompactCardinality = errors.New(
+	"codec: WithSingleSigCompact requires exactly one unique signer/verifier")
+
+// CodecNamerConstructor builds a namer for a Codec given the resolved
+// object/hash/sig location bindings and any LayeredOptions threaded through
+// from the builder (e.g. compact-mode flags).
+type CodecNamerConstructor func(
+	objectLocation string,
+	hashLocations []namer.LayeredHashLocation,
+	sigLocations []namer.LayeredSigLocation,
+	opts ...namer.LayeredOption,
+) (namer.Namer, error)
+
+// Codec holds the integrity schema for type T: marshaller, hashers,
+// signers/verifiers, and three namer instances (generator, validator, and a
+// top-level union). It carries no storage handle and no namespace prefix —
+// namespace scoping is the storage layer's concern.
+type Codec[T any] struct {
+	gen        Generator[T]
+	val        Validator[T]
+	namer      namer.Namer
+	marshaller marshaller.TypedMarshaller[T]
+}
+
+// ValueEqual creates a predicate that checks if a key's value equals the specified value.
+func (c *Codec[T]) ValueEqual(value T) (Predicate, error) {
+	return c.valuePredicate(value, predicate.ValueEqual)
+}
+
+// ValueNotEqual creates a predicate that checks if a key's value is not equal to the specified value.
+func (c *Codec[T]) ValueNotEqual(value T) (Predicate, error) {
+	return c.valuePredicate(value, predicate.ValueNotEqual)
+}
+
+// VersionEqual creates a predicate that checks if a key's version equals the specified version.
+func (c *Codec[T]) VersionEqual(v int64) Predicate {
+	return c.versionPredicate(v, predicate.VersionEqual)
+}
+
+// VersionNotEqual creates a predicate that checks if a key's version is not equal to the specified version.
+func (c *Codec[T]) VersionNotEqual(v int64) Predicate {
+	return c.versionPredicate(v, predicate.VersionNotEqual)
+}
+
+// VersionGreater creates a predicate that checks if a key's version is greater than the specified version.
+func (c *Codec[T]) VersionGreater(v int64) Predicate {
+	return c.versionPredicate(v, predicate.VersionGreater)
+}
+
+// VersionLess creates a predicate that checks if a key's version is less than the specified version.
+func (c *Codec[T]) VersionLess(v int64) Predicate {
+	return c.versionPredicate(v, predicate.VersionLess)
+}
+
+func (c *Codec[T]) valuePredicate(value T,
+	predFunc func(key []byte, value any) predicate.Predicate) (Predicate, error) {
+	mValue, err := c.marshaller.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to marshal predicate value", err)
+	}
+
+	return func(key []byte) predicate.Predicate {
+		return predFunc(key, mValue)
+	}, nil
+}
+
+func (c *Codec[T]) versionPredicate(
+	v int64,
+	predFunc func(key []byte, value int64) predicate.Predicate) Predicate {
+	return func(key []byte) predicate.Predicate { return predFunc(key, v) }
+}
+
+// CodecBuilder[T] is a fluent, value-receiver builder for Codec[T].
+// Each setter returns a copy of the builder (copy-on-write), so the original
+// builder is not mutated.
+type CodecBuilder[T any] struct {
+	marshaller     marshaller.TypedMarshaller[T]
+	hashers        []hasher.Hasher
+	signers        []crypto.Signer
+	verifiers      []crypto.Verifier
+	objectLocation string
+	hashLocations  map[string]string // hasher.Name() → location override.
+	sigLocations   map[string]string // signer/verifier name → location override.
+	namerFunc      CodecNamerConstructor
+	compactHash    bool
+	compactSig     bool
+}
+
+// NewCodecBuilder returns a new CodecBuilder with sensible defaults.
+// Default marshaller: TypedYamlMarshaller[T].
+// Default objectLocation: "" (resolved to "objects" at Build time).
+// Default namerFunc: wraps namer.NewLayeredNamer.
+func NewCodecBuilder[T any]() CodecBuilder[T] {
+	return CodecBuilder[T]{
+		marshaller:     marshaller.NewTypedYamlMarshaller[T](),
+		hashers:        []hasher.Hasher{},
+		signers:        []crypto.Signer{},
+		verifiers:      []crypto.Verifier{},
+		objectLocation: "",
+		hashLocations:  map[string]string{},
+		sigLocations:   map[string]string{},
+		namerFunc:      nil,
+		compactHash:    false,
+		compactSig:     false,
+	}
+}
+
+func (b CodecBuilder[T]) copy() CodecBuilder[T] {
+	hashLocs := maps.Clone(b.hashLocations)
+	sigLocs := maps.Clone(b.sigLocations)
+
+	return CodecBuilder[T]{
+		marshaller:     b.marshaller,
+		hashers:        slices.Clone(b.hashers),
+		signers:        slices.Clone(b.signers),
+		verifiers:      slices.Clone(b.verifiers),
+		objectLocation: b.objectLocation,
+		hashLocations:  hashLocs,
+		sigLocations:   sigLocs,
+		namerFunc:      b.namerFunc,
+		compactHash:    b.compactHash,
+		compactSig:     b.compactSig,
+	}
+}
+
+// WithMarshaller sets a custom marshaller.
+func (b CodecBuilder[T]) WithMarshaller(m marshaller.TypedMarshaller[T]) CodecBuilder[T] {
+	out := b.copy()
+
+	out.marshaller = m
+
+	return out
+}
+
+// WithHasher adds a hasher to the codec.
+func (b CodecBuilder[T]) WithHasher(h hasher.Hasher) CodecBuilder[T] {
+	out := b.copy()
+
+	out.hashers = append(out.hashers, h)
+
+	return out
+}
+
+// WithSigner adds a signer to the codec.
+func (b CodecBuilder[T]) WithSigner(s crypto.Signer) CodecBuilder[T] {
+	out := b.copy()
+
+	out.signers = append(out.signers, s)
+
+	return out
+}
+
+// WithVerifier adds a verifier to the codec.
+func (b CodecBuilder[T]) WithVerifier(v crypto.Verifier) CodecBuilder[T] {
+	out := b.copy()
+
+	out.verifiers = append(out.verifiers, v)
+
+	return out
+}
+
+// WithSignerVerifier adds a combined signer/verifier to both the signer and verifier lists.
+func (b CodecBuilder[T]) WithSignerVerifier(sv crypto.SignerVerifier) CodecBuilder[T] {
+	out := b.copy()
+
+	out.signers = append(out.signers, sv)
+	out.verifiers = append(out.verifiers, sv)
+
+	return out
+}
+
+// WithObjectLocation sets the location segment for value keys.
+// If not called, defaults to "objects" at Build time.
+func (b CodecBuilder[T]) WithObjectLocation(loc string) CodecBuilder[T] {
+	out := b.copy()
+
+	out.objectLocation = loc
+
+	return out
+}
+
+// WithHashLocation overrides the location segment for the named hasher.
+// hasherName must match the hasher's Name() method. If not called, the
+// location defaults to the hasher's Name().
+func (b CodecBuilder[T]) WithHashLocation(hasherName, loc string) CodecBuilder[T] {
+	out := b.copy()
+
+	out.hashLocations[hasherName] = loc
+
+	return out
+}
+
+// WithSignatureLocation overrides the location segment for the named signer/verifier.
+// signerName must match the signer's or verifier's Name() method. If not called, the
+// location defaults to the signer's Name().
+func (b CodecBuilder[T]) WithSignatureLocation(signerName, loc string) CodecBuilder[T] {
+	out := b.copy()
+
+	out.sigLocations[signerName] = loc
+
+	return out
+}
+
+// WithNamer sets a custom CodecNamerConstructor.
+func (b CodecBuilder[T]) WithNamer(f CodecNamerConstructor) CodecBuilder[T] {
+	out := b.copy()
+
+	out.namerFunc = f
+
+	return out
+}
+
+// WithSingleHashCompact opts the codec into the compact hash key layout
+// (/hash/<objectLocation>/<name>, dropping the per-hasher segment). Build
+// returns ErrSingleHashCompactCardinality if exactly one hasher is not
+// configured.
+func (b CodecBuilder[T]) WithSingleHashCompact() CodecBuilder[T] {
+	out := b.copy()
+
+	out.compactHash = true
+
+	return out
+}
+
+// WithSingleSigCompact opts the codec into the compact sig key layout
+// (/sig/<objectLocation>/<name>, dropping the per-signer segment). Build
+// returns ErrSingleSigCompactCardinality if the union of signers and
+// verifiers (deduped by name) is not of size one.
+func (b CodecBuilder[T]) WithSingleSigCompact() CodecBuilder[T] {
+	out := b.copy()
+
+	out.compactSig = true
+
+	return out
+}
+
+// Build constructs a *Codec[T] from the current builder state.
+//
+// It returns an error if any location segment is invalid, if any pair of
+// segments collides, or if a WithHashLocation/WithSignatureLocation key does
+// not match a configured hasher/signer/verifier (catches typos that would
+// otherwise be silently ignored).
+func (b CodecBuilder[T]) Build() (*Codec[T], error) {
+	namerFn := b.namerFunc
+	if namerFn == nil {
+		namerFn = namer.NewLayeredNamer
+	}
+
+	objLoc := b.objectLocation
+	if objLoc == "" {
+		objLoc = "objects"
+	}
+
+	// hashLocations/sigLocations override key→loc; reject keys that have no
+	// matching hasher/signer/verifier so a typo doesn't silently no-op.
+	hasherNames := make(map[string]struct{}, len(b.hashers))
+	for _, h := range b.hashers {
+		hasherNames[h.Name()] = struct{}{}
+	}
+
+	sigNames := make(map[string]struct{}, len(b.signers)+len(b.verifiers))
+	for _, s := range b.signers {
+		sigNames[s.Name()] = struct{}{}
+	}
+
+	for _, v := range b.verifiers {
+		sigNames[v.Name()] = struct{}{}
+	}
+
+	for name := range b.hashLocations {
+		if _, ok := hasherNames[name]; !ok {
+			return nil, fmt.Errorf("%w: %q", ErrUnknownHasherLocation, name)
+		}
+	}
+
+	for name := range b.sigLocations {
+		if _, ok := sigNames[name]; !ok {
+			return nil, fmt.Errorf("%w: %q", ErrUnknownSignerLocation, name)
+		}
+	}
+
+	genHashLocs := make([]namer.LayeredHashLocation, 0, len(b.hashers))
+	for _, hasher := range b.hashers {
+		loc := hasher.Name()
+		if override, ok := b.hashLocations[hasher.Name()]; ok {
+			loc = override
+		}
+
+		genHashLocs = append(genHashLocs, namer.LayeredHashLocation{
+			HasherName: hasher.Name(),
+			Location:   loc,
+		})
+	}
+
+	// SignerName always carries the real signer/verifier name (not the
+	// location override) because downstream lookups index by Property().
+	genSigLocs := make([]namer.LayeredSigLocation, 0, len(b.signers))
+	for _, signer := range b.signers {
+		loc := signer.Name()
+		if override, ok := b.sigLocations[signer.Name()]; ok {
+			loc = override
+		}
+
+		genSigLocs = append(genSigLocs, namer.LayeredSigLocation{
+			SignerName: signer.Name(),
+			Location:   loc,
+		})
+	}
+
+	valSigLocs := make([]namer.LayeredSigLocation, 0, len(b.verifiers))
+	for _, verifier := range b.verifiers {
+		loc := verifier.Name()
+		if override, ok := b.sigLocations[verifier.Name()]; ok {
+			loc = override
+		}
+
+		valSigLocs = append(valSigLocs, namer.LayeredSigLocation{
+			SignerName: verifier.Name(),
+			Location:   loc,
+		})
+	}
+
+	// Top-level namer must accept keys produced by either side (signer or
+	// verifier), so its sig list is the union deduplicated by name.
+	seenSigNames := make(map[string]struct{})
+	topSigLocs := make([]namer.LayeredSigLocation, 0, len(b.signers)+len(b.verifiers))
+
+	for _, sl := range genSigLocs {
+		if _, ok := seenSigNames[sl.SignerName]; !ok {
+			seenSigNames[sl.SignerName] = struct{}{}
+			topSigLocs = append(topSigLocs, sl)
+		}
+	}
+
+	for _, sl := range valSigLocs {
+		if _, ok := seenSigNames[sl.SignerName]; !ok {
+			seenSigNames[sl.SignerName] = struct{}{}
+			topSigLocs = append(topSigLocs, sl)
+		}
+	}
+
+	// Compact flags must be uniform across gen/val/top — otherwise their
+	// emitted/parsed key shapes diverge and round-trips break. Check
+	// cardinality against every list that will become a namer's sig/hash list.
+	var opts []namer.LayeredOption
+
+	if b.compactHash {
+		if len(genHashLocs) != 1 {
+			return nil, fmt.Errorf("%w: got %d", ErrSingleHashCompactCardinality, len(genHashLocs))
+		}
+
+		opts = append(opts, namer.CompactSingleHash())
+	}
+
+	if b.compactSig {
+		if len(genSigLocs) != 1 || len(valSigLocs) != 1 || len(topSigLocs) != 1 {
+			return nil, fmt.Errorf("%w: signers=%d verifiers=%d union=%d",
+				ErrSingleSigCompactCardinality, len(genSigLocs), len(valSigLocs), len(topSigLocs))
+		}
+
+		opts = append(opts, namer.CompactSingleSig())
+	}
+
+	genNamer, err := namerFn(objLoc, genHashLocs, genSigLocs, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("codec: failed to build generator namer: %w", err)
+	}
+
+	valNamer, err := namerFn(objLoc, genHashLocs, valSigLocs, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("codec: failed to build validator namer: %w", err)
+	}
+
+	topNamer, err := namerFn(objLoc, genHashLocs, topSigLocs, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("codec: failed to build top-level namer: %w", err)
+	}
+
+	marsh := b.marshaller
+
+	gen := NewGenerator[T](genNamer, marsh, b.hashers, b.signers)
+	val := NewValidator[T](valNamer, marsh, b.hashers, b.verifiers)
+
+	return &Codec[T]{
+		gen:        gen,
+		val:        val,
+		namer:      topNamer,
+		marshaller: marsh,
+	}, nil
+}

--- a/integrity/codec_test.go
+++ b/integrity/codec_test.go
@@ -1,0 +1,488 @@
+package integrity_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/crypto"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+	"github.com/tarantool/go-storage/marshaller"
+	"github.com/tarantool/go-storage/namer"
+)
+
+type codecTestStruct struct {
+	Name  string `yaml:"name"`
+	Value int    `yaml:"value"`
+}
+
+func newTestRSAPSS(t *testing.T) crypto.SignerVerifier {
+	t.Helper()
+
+	pk, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	return crypto.NewRSAPSSSignerVerifier(*pk)
+}
+
+func TestCodecBuilder_Defaults(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+}
+
+// The codec keeps its namer private, so the default-object-location guarantee
+// is verified by constructing an equivalent LayeredNamer and asserting its
+// output matches the documented "/objects/<name>" shape.
+func TestCodecBuilder_DefaultObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	defaultNamer, err := namer.NewLayeredNamer("objects", nil, nil)
+	require.NoError(t, err)
+
+	keys, err := defaultNamer.GenerateNames("foo")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "/objects/foo", keys[0].Build())
+}
+
+func TestCodecBuilder_WithObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("myobjects").
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+}
+
+func TestCodecBuilder_WithHasher(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+
+	n, err := namer.NewLayeredNamer("objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil)
+	require.NoError(t, err)
+
+	keys, err := n.GenerateNames("foo")
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	var foundHash bool
+
+	for _, k := range keys {
+		if k.Build() == "/hash/sha256/objects/foo" {
+			foundHash = true
+		}
+	}
+
+	assert.True(t, foundHash, "expected hash key at /hash/sha256/objects/foo")
+}
+
+func TestCodecBuilder_WithHashLocation(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithHashLocation("sha256", "checksums").
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+
+	n, err := namer.NewLayeredNamer("objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "checksums"}},
+		nil)
+	require.NoError(t, err)
+
+	keys, err := n.GenerateNames("foo")
+	require.NoError(t, err)
+
+	var foundCustom bool
+
+	for _, k := range keys {
+		if k.Build() == "/hash/checksums/objects/foo" {
+			foundCustom = true
+		}
+	}
+
+	assert.True(t, foundCustom, "expected hash key at /hash/checksums/objects/foo")
+}
+
+func TestCodecBuilder_WithSigner(t *testing.T) {
+	t.Parallel()
+
+	sv := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithSigner(sv).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+}
+
+func TestCodecBuilder_WithVerifier(t *testing.T) {
+	t.Parallel()
+
+	sv := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithVerifier(sv).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+}
+
+func TestCodecBuilder_WithSignerVerifier(t *testing.T) {
+	t.Parallel()
+
+	sv := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithSignerVerifier(sv).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+}
+
+func TestCodecBuilder_WithSignatureLocation(t *testing.T) {
+	t.Parallel()
+
+	signerVerifier := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithSignerVerifier(signerVerifier).
+		WithSignatureLocation(signerVerifier.Name(), "sigs").
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+
+	n, err := namer.NewLayeredNamer("objects", nil,
+		[]namer.LayeredSigLocation{{SignerName: signerVerifier.Name(), Location: "sigs"}})
+	require.NoError(t, err)
+
+	keys, err := n.GenerateNames("bar")
+	require.NoError(t, err)
+
+	var foundSig bool
+
+	for _, key := range keys {
+		if key.Build() == "/sig/sigs/objects/bar" {
+			foundSig = true
+		}
+	}
+
+	assert.True(t, foundSig, "expected sig key at /sig/sigs/objects/bar")
+}
+
+func TestCodecBuilder_StaleHashLocationKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithHashLocation("sah256", "custom"). // typo — no matching hasher.
+		Build()
+	require.Error(t, err, "Build should fail when WithHashLocation key has no matching hasher")
+	assert.Contains(t, err.Error(), "sah256")
+}
+
+func TestCodecBuilder_StaleSigLocationKey(t *testing.T) {
+	t.Parallel()
+
+	sv := newTestRSAPSS(t)
+
+	_, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithSignerVerifier(sv).
+		WithSignatureLocation("nonexistent-signer", "sigs").
+		Build()
+	require.Error(t, err, "Build should fail when WithSignatureLocation key has no matching signer/verifier")
+	assert.Contains(t, err.Error(), "nonexistent-signer")
+}
+
+func TestCodecBuilder_ReservedObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	for _, reserved := range []string{"hash", "sig"} {
+		t.Run(reserved, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := integrity.NewCodecBuilder[codecTestStruct]().
+				WithObjectLocation(reserved).
+				Build()
+			require.Error(t, err, "Build should fail when objectLocation equals reserved marker %q", reserved)
+		})
+	}
+}
+
+func TestCodecBuilder_InvalidObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	_, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("/foo"). // leading slash — invalid.
+		Build()
+	require.Error(t, err, "Build should fail for location starting with '/'")
+}
+
+func TestCodecBuilder_EmptyObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	// "" is a valid input (it falls back to "objects" inside Build), so the
+	// invalid-segment check has to be exercised with a non-empty bad value.
+	_, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("a/b").
+		Build()
+	require.Error(t, err)
+}
+
+type sentinelMarshaller struct {
+	marshalCalled bool
+}
+
+func (s *sentinelMarshaller) Marshal(_ codecTestStruct) ([]byte, error) {
+	s.marshalCalled = true
+
+	return []byte(`name: "x"\nvalue: 1\n`), nil
+}
+
+func (s *sentinelMarshaller) Unmarshal(_ []byte) (codecTestStruct, error) {
+	return codecTestStruct{Name: "x", Value: 1}, nil
+}
+
+func TestCodecBuilder_WithMarshaller(t *testing.T) {
+	t.Parallel()
+
+	sentMarsh := &sentinelMarshaller{marshalCalled: false}
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithMarshaller(sentMarsh).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+
+	// ValueEqual is the smallest public surface that calls Marshal, so it
+	// makes a good probe for "did the custom marshaller actually take effect?".
+	_, err = codec.ValueEqual(codecTestStruct{Name: "x", Value: 1})
+	require.NoError(t, err)
+	assert.True(t, sentMarsh.marshalCalled, "custom marshaller should have been called")
+}
+
+type sentinelNamer struct {
+	called bool
+}
+
+func (n *sentinelNamer) GenerateNames(name string) ([]namer.Key, error) {
+	return []namer.Key{
+		namer.NewDefaultKey(name, namer.KeyTypeValue, "", "/sentinel/"+name),
+	}, nil
+}
+
+func (n *sentinelNamer) ParseKey(raw string) (namer.DefaultKey, error) {
+	name := strings.TrimPrefix(raw, "/sentinel/")
+
+	return namer.NewDefaultKey(name, namer.KeyTypeValue, "", raw), nil
+}
+
+func (n *sentinelNamer) ParseKeys(names []string, ignoreError bool) (namer.Results, error) {
+	out := map[string][]namer.Key{}
+
+	for _, raw := range names {
+		key, err := n.ParseKey(raw)
+		if err != nil {
+			if ignoreError {
+				continue
+			}
+
+			return namer.Results{}, err
+		}
+
+		out[key.Name()] = append(out[key.Name()], key)
+	}
+
+	return namer.NewResults(out), nil
+}
+
+func (n *sentinelNamer) Prefix(val string, _ bool) string {
+	return "/sentinel/" + strings.Trim(val, "/")
+}
+
+func TestCodecBuilder_WithNamer(t *testing.T) {
+	t.Parallel()
+
+	var constructorCalled bool
+
+	customConstructor := integrity.CodecNamerConstructor(func(
+		_ string,
+		_ []namer.LayeredHashLocation,
+		_ []namer.LayeredSigLocation,
+		_ ...namer.LayeredOption,
+	) (namer.Namer, error) {
+		constructorCalled = true
+
+		return &sentinelNamer{called: false}, nil
+	})
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithNamer(customConstructor).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+
+	// Build creates three namers (gen/val/top), so seeing the constructor
+	// fire at least once is enough to prove the override took effect.
+	assert.True(t, constructorCalled, "custom CodecNamerConstructor should have been called during Build")
+}
+
+func TestCodec_ValueEqual(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+
+	val := codecTestStruct{Name: "hello", Value: 42}
+	pred, err := codec.ValueEqual(val)
+	require.NoError(t, err)
+	require.NotNil(t, pred)
+
+	key := []byte("/objects/foo")
+	concretePred := pred(key)
+	require.NotNil(t, concretePred)
+	assert.Equal(t, key, concretePred.Key())
+
+	marsh := marshaller.NewTypedYamlMarshaller[codecTestStruct]()
+	expected, err := marsh.Marshal(val)
+	require.NoError(t, err)
+	assert.Equal(t, expected, concretePred.Value())
+}
+
+func TestCodec_ValueNotEqual(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+
+	val := codecTestStruct{Name: "hello", Value: 42}
+	pred, err := codec.ValueNotEqual(val)
+	require.NoError(t, err)
+	require.NotNil(t, pred)
+
+	key := []byte("/objects/foo")
+	p := pred(key)
+	require.NotNil(t, p)
+	assert.Equal(t, key, p.Key())
+}
+
+func TestCodec_VersionEqual(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+
+	pred := codec.VersionEqual(int64(42))
+	require.NotNil(t, pred)
+
+	key := []byte("/objects/foo")
+	p := pred(key)
+	require.NotNil(t, p)
+	assert.Equal(t, key, p.Key())
+	assert.Equal(t, int64(42), p.Value())
+}
+
+func TestCodec_VersionNotEqual(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+
+	pred := codec.VersionNotEqual(int64(7))
+	key := []byte("/objects/bar")
+	p := pred(key)
+	assert.Equal(t, int64(7), p.Value())
+	assert.Equal(t, key, p.Key())
+}
+
+func TestCodec_VersionGreater(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+
+	pred := codec.VersionGreater(int64(100))
+	key := []byte("/objects/baz")
+	p := pred(key)
+	assert.Equal(t, int64(100), p.Value())
+}
+
+func TestCodec_VersionLess(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+
+	pred := codec.VersionLess(int64(5))
+	key := []byte("/objects/qux")
+	p := pred(key)
+	assert.Equal(t, int64(5), p.Value())
+}
+
+func TestCodecBuilder_Immutability(t *testing.T) {
+	t.Parallel()
+
+	base := integrity.NewCodecBuilder[codecTestStruct]()
+
+	marsh1 := marshaller.NewTypedYamlMarshaller[codecTestStruct]()
+	marsh2 := marshaller.NewTypedYamlMarshaller[codecTestStruct]()
+
+	builder1 := base.WithMarshaller(marsh1)
+	builder2 := builder1.WithMarshaller(marsh2)
+
+	codec1, err := builder1.Build()
+	require.NoError(t, err)
+
+	codec2, err := builder2.Build()
+	require.NoError(t, err)
+
+	assert.NotSame(t, codec1, codec2)
+}
+
+func TestCodecBuilder_ImmutabilityHashers(t *testing.T) {
+	t.Parallel()
+
+	base := integrity.NewCodecBuilder[codecTestStruct]()
+	withSHA256 := base.WithHasher(hasher.NewSHA256Hasher())
+	withSHA256SHA1 := withSHA256.WithHasher(hasher.NewSHA1Hasher())
+
+	_, err := base.Build()
+	require.NoError(t, err)
+
+	_, err = withSHA256.Build()
+	require.NoError(t, err)
+
+	_, err = withSHA256SHA1.Build()
+	require.NoError(t, err)
+}
+
+func TestCodecBuilder_MultipleBuildCalls(t *testing.T) {
+	t.Parallel()
+
+	builder := integrity.NewCodecBuilder[codecTestStruct]()
+
+	codec1, err := builder.Build()
+	require.NoError(t, err)
+
+	codec2, err := builder.Build()
+	require.NoError(t, err)
+
+	assert.NotSame(t, codec1, codec2, "each Build call should return a distinct *Codec[T]")
+}


### PR DESCRIPTION
Introduce `Codec[T]` (schema-only, no storage handle) and `CodecBuilder[T]` with a value-receiver API mirroring `TypedBuilder[T]`.

Part of TNTP-7587