### PR TITLE
tests: add example and integration tests for new APIs

### DIFF
--- a/integrity/codec_example_test.go
+++ b/integrity/codec_example_test.go
@@ -1,0 +1,171 @@
+package integrity_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"log"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/crypto"
+	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+)
+
+type codecExampleConfig struct {
+	Name string `yaml:"name"`
+	N    int    `yaml:"n"`
+}
+
+// ExampleNewCodecBuilder builds a Codec[T] using the fluent builder.
+// Each WithX call returns a copy, so the original builder is never mutated.
+func ExampleNewCodecBuilder() {
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	if err != nil {
+		log.Fatalf("build codec: %v", err)
+	}
+
+	store := codec.Bind(storage.NewStorage(dummy.New()))
+
+	ctx := context.Background()
+
+	err = store.Put(ctx, "alice", codecExampleConfig{Name: "alice", N: 42})
+	if err != nil {
+		log.Fatalf("put: %v", err)
+	}
+
+	res, err := store.Get(ctx, "alice")
+	if err != nil {
+		log.Fatalf("get: %v", err)
+	}
+
+	got := res.Value.Unwrap()
+	fmt.Printf("Name=%s N=%d\n", got.Name, got.N)
+
+	// Output:
+	// Name=alice N=42
+}
+
+// ExampleCodecBuilder_WithObjectLocation shows overriding the value-layer
+// location segment. The default is "objects".
+func ExampleCodecBuilder_WithObjectLocation() {
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().
+		WithObjectLocation("users").
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	if err != nil {
+		log.Fatalf("build codec: %v", err)
+	}
+
+	store := codec.Bind(storage.NewStorage(dummy.New()))
+
+	ctx := context.Background()
+
+	err = store.Put(ctx, "alice", codecExampleConfig{Name: "alice", N: 1})
+	if err != nil {
+		log.Fatalf("put: %v", err)
+	}
+
+	// The value lands under /users/alice instead of /objects/alice.
+	res, err := store.Get(ctx, "alice")
+	if err != nil {
+		log.Fatalf("get: %v", err)
+	}
+
+	fmt.Println("name:", res.Value.Unwrap().Name)
+
+	// Output:
+	// name: alice
+}
+
+// ExampleNewCodecBuilder_immutability demonstrates copy-on-write: the
+// original builder is unchanged after a setter call, so two divergent codecs
+// can be built from the same base.
+func ExampleNewCodecBuilder_immutability() {
+	base := integrity.NewCodecBuilder[codecExampleConfig]()
+
+	withHasher := base.WithHasher(hasher.NewSHA256Hasher())
+	withoutHasher := base // unchanged.
+
+	codecHashed, err := withHasher.Build()
+	if err != nil {
+		log.Fatalf("codecHashed: %v", err)
+	}
+
+	codecPlain, err := withoutHasher.Build()
+	if err != nil {
+		log.Fatalf("codecPlain: %v", err)
+	}
+
+	fmt.Println("two distinct codecs:", codecHashed != codecPlain)
+
+	// Output:
+	// two distinct codecs: true
+}
+
+// ExampleCodecBuilder_WithSignerVerifier configures a codec with both a
+// hasher and an RSA-PSS signer/verifier. Put writes value, hash, and
+// signature keys; Get verifies all of them on read.
+func ExampleCodecBuilder_WithSignerVerifier() {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		log.Fatalf("genkey: %v", err)
+	}
+
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithSignerVerifier(crypto.NewRSAPSSSignerVerifier(*priv)).
+		Build()
+	if err != nil {
+		log.Fatalf("build codec: %v", err)
+	}
+
+	store := codec.Bind(storage.NewStorage(dummy.New()))
+
+	ctx := context.Background()
+
+	err = store.Put(ctx, "alice", codecExampleConfig{Name: "alice", N: 7})
+	if err != nil {
+		log.Fatalf("put: %v", err)
+	}
+
+	res, err := store.Get(ctx, "alice")
+	if err != nil {
+		log.Fatalf("get: %v", err)
+	}
+
+	fmt.Printf("verified Name=%s N=%d\n", res.Value.Unwrap().Name, res.Value.Unwrap().N)
+
+	// Output:
+	// verified Name=alice N=7
+}
+
+// ExampleCodec_ValueEqual produces a Codec-bound predicate that can be passed
+// to Tx.If via Codec.BindPredicate, or used through Store helpers like
+// WithPutPredicates.
+func ExampleCodec_ValueEqual() {
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().Build()
+	if err != nil {
+		log.Fatalf("build: %v", err)
+	}
+
+	pred, err := codec.ValueEqual(codecExampleConfig{Name: "alice", N: 1})
+	if err != nil {
+		log.Fatalf("predicate: %v", err)
+	}
+
+	bound, err := codec.BindPredicate("alice", pred)
+	if err != nil {
+		log.Fatalf("bind: %v", err)
+	}
+
+	// The bound predicate targets the value-layer key for "alice".
+	fmt.Printf("predicate key: %s\n", bound.Key())
+
+	// Output:
+	// predicate key: /objects/alice
+}

--- a/integrity/integration_codec_tx_test.go
+++ b/integrity/integration_codec_tx_test.go
@@ -1,0 +1,492 @@
+//nolint:paralleltest
+package integrity_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/go-option"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/crypto"
+	"github.com/tarantool/go-storage/driver"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+)
+
+// integrationPrefix returns a per-test storage namespace so concurrent driver
+// subtests (and reused TCS instances) do not collide.
+func integrationPrefix(t *testing.T) string {
+	t.Helper()
+
+	return "/test/" + strings.ReplaceAll(t.Name(), "/", "-")
+}
+
+// scopedStorage wraps the driver in a per-test Prefixed namespace.
+func scopedStorage(t *testing.T, driverInstance driver.Driver) storage.Storage {
+	t.Helper()
+
+	return storage.Prefixed(integrationPrefix(t), storage.NewStorage(driverInstance))
+}
+
+// newIntegrationCodecStore builds a Codec[IntegrationStruct] and binds it to
+// a per-test storage namespace. Both are returned because some tests need the
+// codec directly (predicates, raw Tx) while others only need the store.
+func newIntegrationCodecStore(
+	t *testing.T,
+	driverInstance driver.Driver,
+	configure func(integrity.CodecBuilder[IntegrationStruct]) integrity.CodecBuilder[IntegrationStruct],
+) (*integrity.Codec[IntegrationStruct], *integrity.Store[IntegrationStruct]) {
+	t.Helper()
+
+	builder := integrity.NewCodecBuilder[IntegrationStruct]()
+	if configure != nil {
+		builder = configure(builder)
+	}
+
+	codec, err := builder.Build()
+	require.NoError(t, err)
+
+	base := scopedStorage(t, driverInstance)
+
+	return codec, codec.Bind(base)
+}
+
+func cleanupStore[T any](t *testing.T, store *integrity.Store[T], names ...string) {
+	t.Helper()
+
+	ctx := t.Context()
+
+	for _, name := range names {
+		_ = store.Delete(ctx, name)
+	}
+}
+
+// TestStoreIntegration_GetPut is the round-trip smoke test for Store[T] across
+// every registered backend.
+func TestStoreIntegration_GetPut(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		_, store := newIntegrationCodecStore(t, driverInstance, nil)
+
+		value := IntegrationStruct{Name: "test", Value: 42}
+		require.NoError(t, store.Put(ctx, "my-object", value))
+
+		got, err := store.Get(ctx, "my-object")
+		require.NoError(t, err)
+		assert.Equal(t, "my-object", got.Name)
+		require.True(t, got.Value.IsSome())
+
+		val, _ := got.Value.Get()
+		assert.Equal(t, value, val)
+
+		cleanupStore(t, store, "my-object")
+	})
+}
+
+// TestStoreIntegration_Put_WithPredicates exercises both the
+// "predicate matches → write" and "predicate fails → ErrPredicateFailed" paths.
+func TestStoreIntegration_Put_WithPredicates(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		codec, store := newIntegrationCodecStore(t, driverInstance, nil)
+
+		initial := IntegrationStruct{Name: "init", Value: 1}
+		updated := IntegrationStruct{Name: "updated", Value: 2}
+
+		// Allow case: ValueEqual matches the seeded record, write proceeds.
+		require.NoError(t, store.Put(ctx, "allow", initial))
+
+		pAllow, err := codec.ValueEqual(initial)
+		require.NoError(t, err)
+
+		err = store.Put(ctx, "allow", updated, integrity.WithPutPredicates(pAllow))
+		require.NoError(t, err)
+
+		got, err := store.Get(ctx, "allow")
+		require.NoError(t, err)
+
+		gotVal, _ := got.Value.Get()
+		assert.Equal(t, updated, gotVal)
+
+		// Deny case: ValueEqual on the post-update value is still bound to
+		// `initial`, so the next write must report ErrPredicateFailed.
+		err = store.Put(ctx, "allow", IntegrationStruct{Name: "third", Value: 3},
+			integrity.WithPutPredicates(pAllow))
+		require.ErrorIs(t, err, integrity.ErrPredicateFailed)
+
+		// Verify the update did not land.
+		got, err = store.Get(ctx, "allow")
+		require.NoError(t, err)
+
+		gotVal, _ = got.Value.Get()
+		assert.Equal(t, updated, gotVal)
+
+		cleanupStore(t, store, "allow")
+	})
+}
+
+// TestStoreIntegration_Delete deletes a freshly written value.
+func TestStoreIntegration_Delete(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		_, store := newIntegrationCodecStore(t, driverInstance, nil)
+
+		require.NoError(t, store.Put(ctx, "victim", IntegrationStruct{Name: "x", Value: 1}))
+		require.NoError(t, store.Delete(ctx, "victim"))
+
+		_, err := store.Get(ctx, "victim")
+		require.ErrorIs(t, err, integrity.ErrNotFound)
+	})
+}
+
+// TestStoreIntegration_Delete_Prefix removes every value under the given name
+// prefix in a single round-trip.
+func TestStoreIntegration_Delete_Prefix(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		_, store := newIntegrationCodecStore(t, driverInstance, nil)
+
+		for i, name := range []string{"tmp/a", "tmp/b", "keep/me"} {
+			err := store.Put(ctx, name, IntegrationStruct{Name: name, Value: i})
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, store.Delete(ctx, "tmp/", integrity.WithPrefix()))
+
+		_, err := store.Get(ctx, "tmp/a")
+		require.ErrorIs(t, err, integrity.ErrNotFound)
+
+		_, err = store.Get(ctx, "tmp/b")
+		require.ErrorIs(t, err, integrity.ErrNotFound)
+
+		got, err := store.Get(ctx, "keep/me")
+		require.NoError(t, err)
+		require.True(t, got.Value.IsSome())
+
+		cleanupStore(t, store, "keep/me")
+	})
+}
+
+// TestStoreIntegration_Range ensures Range returns every codec-owned value
+// under the supplied prefix and decodes them correctly.
+func TestStoreIntegration_Range(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		_, store := newIntegrationCodecStore(t, driverInstance, nil)
+
+		seed := map[string]IntegrationStruct{
+			"records/1": {Name: "obj1", Value: 100},
+			"records/2": {Name: "obj2", Value: 200},
+		}
+		for name, value := range seed {
+			require.NoError(t, store.Put(ctx, name, value))
+		}
+
+		results, err := store.Range(ctx, "records/")
+		require.NoError(t, err)
+		require.Len(t, results, len(seed))
+
+		// ModRevision differs between drivers; normalize before comparing.
+		for i := range results {
+			results[i].ModRevision = 0
+		}
+
+		expected := []integrity.ValidatedResult[IntegrationStruct]{
+			{
+				Name:        "records/1",
+				Value:       option.Some(seed["records/1"]),
+				ModRevision: 0,
+				Error:       nil,
+			},
+			{
+				Name:        "records/2",
+				Value:       option.Some(seed["records/2"]),
+				ModRevision: 0,
+				Error:       nil,
+			},
+		}
+		require.ElementsMatch(t, expected, results)
+
+		cleanupStore(t, store, "records/1", "records/2")
+	})
+}
+
+// TestStoreIntegration_WithSignerVerifier round-trips a value through a codec
+// with both a hasher and an RSA-PSS signer/verifier; Get must verify cleanly.
+func TestStoreIntegration_WithSignerVerifier(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		shaHash := hasher.NewSHA256Hasher()
+		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+
+		_, store := newIntegrationCodecStore(t, driverInstance,
+			func(b integrity.CodecBuilder[IntegrationStruct]) integrity.CodecBuilder[IntegrationStruct] {
+				return b.WithHasher(shaHash).WithSignerVerifier(rsaSV)
+			})
+
+		value := IntegrationStruct{Name: "secured", Value: 7}
+		require.NoError(t, store.Put(ctx, "alice", value))
+
+		got, err := store.Get(ctx, "alice")
+		require.NoError(t, err)
+
+		gotVal, _ := got.Value.Get()
+		assert.Equal(t, value, gotVal)
+
+		cleanupStore(t, store, "alice")
+	})
+}
+
+// TestStoreIntegration_Watch verifies Watch sees an event for a delete after
+// the channel is established.
+func TestStoreIntegration_Watch(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		_, store := newIntegrationCodecStore(t, driverInstance, nil)
+
+		require.NoError(t, store.Put(ctx, "object1", IntegrationStruct{Name: "obj1", Value: 100}))
+
+		eventCh, err := store.Watch(ctx, "object1")
+		require.NoError(t, err)
+
+		require.NoError(t, store.Delete(ctx, "object1"))
+
+		select {
+		case ev := <-eventCh:
+			require.Equal(t, []byte("/objects/object1"), ev.Prefix)
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for watch event")
+		}
+	})
+}
+
+// TestTxIntegration_MultiOpAtomic enqueues multiple TxPut calls onto a single
+// Tx and verifies they all land in one commit.
+func TestTxIntegration_MultiOpAtomic(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		require.NoError(t, err)
+
+		txn := integrity.NewTx(base)
+		require.NoError(t, codec.TxPut(txn, "alice", IntegrationStruct{Name: "alice", Value: 1}))
+		require.NoError(t, codec.TxPut(txn, "bob", IntegrationStruct{Name: "bob", Value: 2}))
+
+		resp, err := txn.Commit(ctx)
+		require.NoError(t, err)
+		require.True(t, resp.Succeeded)
+
+		store := codec.Bind(base)
+		defer cleanupStore(t, store, "alice", "bob")
+
+		gotA, err := store.Get(ctx, "alice")
+		require.NoError(t, err)
+
+		valA, _ := gotA.Value.Get()
+		assert.Equal(t, IntegrationStruct{Name: "alice", Value: 1}, valA)
+
+		gotB, err := store.Get(ctx, "bob")
+		require.NoError(t, err)
+
+		valB, _ := gotB.Value.Get()
+		assert.Equal(t, IntegrationStruct{Name: "bob", Value: 2}, valB)
+	})
+}
+
+// TestTxIntegration_ThenElse_ThenFires checks that with a satisfied predicate
+// the Then branch executes and the Else-branch future returns ErrBranchNotFired.
+func TestTxIntegration_ThenElse_ThenFires(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		require.NoError(t, err)
+
+		store := codec.Bind(base)
+		require.NoError(t, store.Put(ctx, "anchor", IntegrationStruct{Name: "anchor", Value: 1}))
+
+		defer cleanupStore(t, store, "anchor")
+
+		// VersionGreater(0) is always true once the value exists.
+		bound, err := codec.BindPredicate("anchor", codec.VersionGreater(0))
+		require.NoError(t, err)
+
+		txn := integrity.NewTx(base).If(bound)
+
+		thenFut := codec.TxGet(txn.Then(), "anchor")
+		elseFut := codec.TxGet(txn.Else(), "anchor")
+
+		resp, err := txn.Commit(ctx)
+		require.NoError(t, err)
+		require.True(t, resp.Succeeded)
+
+		thenRes, err := thenFut.Result()
+		require.NoError(t, err)
+
+		thenVal, _ := thenRes.Value.Get()
+		assert.Equal(t, "anchor", thenVal.Name)
+
+		_, elseErr := elseFut.Result()
+		require.ErrorIs(t, elseErr, integrity.ErrBranchNotFired)
+	})
+}
+
+// TestTxIntegration_ThenElse_ElseFires inverts the previous test: the
+// predicate fails, Else fires, Then-branch futures return ErrBranchNotFired.
+func TestTxIntegration_ThenElse_ElseFires(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		require.NoError(t, err)
+
+		store := codec.Bind(base)
+		require.NoError(t, store.Put(ctx, "fallback", IntegrationStruct{Name: "fallback", Value: 1}))
+
+		defer cleanupStore(t, store, "fallback")
+
+		// Predicate that cannot hold: ValueEqual against a value the seeded
+		// record cannot match.
+		mismatch, err := codec.ValueEqual(IntegrationStruct{Name: "nope", Value: 99})
+		require.NoError(t, err)
+
+		bound, err := codec.BindPredicate("fallback", mismatch)
+		require.NoError(t, err)
+
+		txn := integrity.NewTx(base).If(bound)
+
+		thenFut := codec.TxGet(txn.Then(), "fallback")
+		elseFut := codec.TxGet(txn.Else(), "fallback")
+
+		resp, err := txn.Commit(ctx)
+		require.NoError(t, err)
+		require.False(t, resp.Succeeded)
+
+		_, thenErr := thenFut.Result()
+		require.ErrorIs(t, thenErr, integrity.ErrBranchNotFired)
+
+		elseRes, err := elseFut.Result()
+		require.NoError(t, err)
+
+		elseVal, _ := elseRes.Value.Get()
+		assert.Equal(t, "fallback", elseVal.Name)
+	})
+}
+
+// TestTxIntegration_TxRange exercises TxRange against every backend.
+func TestTxIntegration_TxRange(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		require.NoError(t, err)
+
+		store := codec.Bind(base)
+		for i, name := range []string{"records/1", "records/2"} {
+			require.NoError(t, store.Put(ctx, name,
+				IntegrationStruct{Name: name, Value: 100 + i}))
+		}
+
+		defer cleanupStore(t, store, "records/1", "records/2")
+
+		readTx := integrity.NewTx(base)
+		fut := codec.TxRange(readTx, "records/")
+
+		_, err = readTx.Commit(ctx)
+		require.NoError(t, err)
+
+		results, err := fut.Result()
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		gotNames := []string{results[0].Name, results[1].Name}
+		assert.ElementsMatch(t, []string{"records/1", "records/2"}, gotNames)
+	})
+}
+
+// TestTxIntegration_TxDelete checks that TxDelete enqueued onto a Tx removes
+// every key that backs the named value.
+func TestTxIntegration_TxDelete(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().
+			WithHasher(hasher.NewSHA256Hasher()).
+			Build()
+		require.NoError(t, err)
+
+		store := codec.Bind(base)
+		require.NoError(t, store.Put(ctx, "victim", IntegrationStruct{Name: "victim", Value: 1}))
+
+		txn := integrity.NewTx(base)
+		require.NoError(t, codec.TxDelete(txn, "victim"))
+
+		resp, err := txn.Commit(ctx)
+		require.NoError(t, err)
+		require.True(t, resp.Succeeded)
+
+		_, err = store.Get(ctx, "victim")
+		require.ErrorIs(t, err, integrity.ErrNotFound)
+	})
+}
+
+// TestTxIntegration_AlreadyCommitted ensures a second Commit call returns
+// ErrTxAlreadyCommitted without re-issuing storage work.
+func TestTxIntegration_AlreadyCommitted(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		require.NoError(t, err)
+
+		txn := integrity.NewTx(base)
+		require.NoError(t, codec.TxPut(txn, "once", IntegrationStruct{Name: "once", Value: 1}))
+
+		resp, err := txn.Commit(ctx)
+		require.NoError(t, err)
+		require.True(t, resp.Succeeded)
+
+		_, err = txn.Commit(ctx)
+		require.ErrorIs(t, err, integrity.ErrTxAlreadyCommitted)
+
+		store := codec.Bind(base)
+		defer cleanupStore(t, store, "once")
+	})
+}

--- a/integrity/store_example_test.go
+++ b/integrity/store_example_test.go
@@ -1,0 +1,189 @@
+package integrity_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+)
+
+type storeExampleValue struct {
+	Field string `yaml:"field"`
+}
+
+func newExampleCodec() *integrity.Codec[storeExampleValue] {
+	codec, err := integrity.NewCodecBuilder[storeExampleValue]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	if err != nil {
+		log.Fatalf("build codec: %v", err)
+	}
+
+	return codec
+}
+
+func newExampleStore() *integrity.Store[storeExampleValue] {
+	return newExampleCodec().Bind(storage.NewStorage(dummy.New()))
+}
+
+// ExampleStore demonstrates a Put/Get round-trip via Store[T]. Each method
+// is a thin single-op wrapper around a Tx — observably indistinguishable
+// from a single-op Tx.Commit.
+func ExampleStore() {
+	ctx := context.Background()
+	store := newExampleStore()
+
+	err := store.Put(ctx, "alice", storeExampleValue{Field: "hello"})
+	if err != nil {
+		log.Fatalf("put: %v", err)
+	}
+
+	res, err := store.Get(ctx, "alice")
+	if err != nil {
+		log.Fatalf("get: %v", err)
+	}
+
+	fmt.Println("name:", res.Name)
+	fmt.Println("field:", res.Value.Unwrap().Field)
+
+	// Output:
+	// name: alice
+	// field: hello
+}
+
+// ExampleStore_Put_predicate uses WithPutPredicates to make the write
+// conditional. ErrPredicateFailed is returned when the predicate does not hold.
+func ExampleStore_Put_predicate() {
+	ctx := context.Background()
+	codec := newExampleCodec()
+	store := codec.Bind(storage.NewStorage(dummy.New()))
+
+	err := store.Put(ctx, "k", storeExampleValue{Field: "v1"})
+	if err != nil {
+		log.Fatalf("seed: %v", err)
+	}
+
+	pred, err := codec.ValueEqual(storeExampleValue{Field: "v1"})
+	if err != nil {
+		log.Fatalf("predicate: %v", err)
+	}
+
+	// Predicate matches: this update succeeds.
+	err = store.Put(ctx, "k", storeExampleValue{Field: "v2"},
+		integrity.WithPutPredicates(pred))
+	fmt.Println("first update err:", err)
+
+	// Predicate no longer matches (current value is "v2"): ErrPredicateFailed.
+	err = store.Put(ctx, "k", storeExampleValue{Field: "v3"},
+		integrity.WithPutPredicates(pred))
+	fmt.Println("second update is ErrPredicateFailed:", errors.Is(err, integrity.ErrPredicateFailed))
+
+	// Output:
+	// first update err: <nil>
+	// second update is ErrPredicateFailed: true
+}
+
+// ExampleStore_Range fetches and validates every value under a name prefix.
+// Pass "" to fetch everything under the codec's object location.
+func ExampleStore_Range() {
+	ctx := context.Background()
+	store := newExampleStore()
+
+	for _, name := range []string{"users/alice", "users/bob", "groups/admins"} {
+		err := store.Put(ctx, name, storeExampleValue{Field: name})
+		if err != nil {
+			log.Fatalf("put %s: %v", name, err)
+		}
+	}
+
+	results, err := store.Range(ctx, "users/")
+	if err != nil {
+		log.Fatalf("range: %v", err)
+	}
+
+	names := make([]string, 0, len(results))
+	for _, r := range results {
+		names = append(names, r.Name)
+	}
+
+	sort.Strings(names)
+
+	for _, n := range names {
+		fmt.Println(n)
+	}
+
+	// Output:
+	// users/alice
+	// users/bob
+}
+
+// ExampleStore_Watch streams events for changes to a specific name. The
+// emitted event Prefix is the codec-internal absolute key; Watch filters out
+// events whose key does not belong to this codec's namespace.
+func ExampleStore_Watch() {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store := newExampleStore()
+
+	events, err := store.Watch(ctx, "alice")
+	if err != nil {
+		cancel()
+		log.Fatalf("watch: %v", err)
+	}
+
+	go func() {
+		_ = store.Put(ctx, "alice", storeExampleValue{Field: "v"})
+	}()
+
+	ev := <-events
+
+	cancel()
+
+	fmt.Println("event:", string(ev.Prefix))
+
+	// Output:
+	// event: /objects/alice
+}
+
+// ExampleStore_Delete_withPrefix removes every value (and its hashes) whose
+// name starts with the given prefix. The prefix must end with '/'.
+func ExampleStore_Delete_withPrefix() {
+	ctx := context.Background()
+	store := newExampleStore()
+
+	for _, name := range []string{"tmp/a", "tmp/b"} {
+		err := store.Put(ctx, name, storeExampleValue{Field: name})
+		if err != nil {
+			log.Fatalf("put %s: %v", name, err)
+		}
+	}
+
+	before, err := store.Range(ctx, "tmp/")
+	if err != nil {
+		log.Fatalf("range before: %v", err)
+	}
+
+	fmt.Println("before:", len(before))
+
+	err = store.Delete(ctx, "tmp/", integrity.WithPrefix())
+	if err != nil {
+		log.Fatalf("delete: %v", err)
+	}
+
+	after, err := store.Range(ctx, "tmp/")
+	if err != nil {
+		log.Fatalf("range after: %v", err)
+	}
+
+	fmt.Println("after:", len(after))
+
+	// Output:
+	// before: 2
+	// after: 0
+}

--- a/integrity/tx_example_test.go
+++ b/integrity/tx_example_test.go
@@ -1,0 +1,257 @@
+package integrity_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sort"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+)
+
+type txExampleValue struct {
+	Field string `yaml:"field"`
+}
+
+func newTxExampleCodec() *integrity.Codec[txExampleValue] {
+	codec, err := integrity.NewCodecBuilder[txExampleValue]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	if err != nil {
+		log.Fatalf("build codec: %v", err)
+	}
+
+	return codec
+}
+
+// ExampleNewTx demonstrates a multi-codec, multi-op transaction. Two TxPut
+// calls are accumulated, then committed atomically with a single storage call.
+func ExampleNewTx() {
+	ctx := context.Background()
+	store := storage.NewStorage(dummy.New())
+	codec := newTxExampleCodec()
+
+	txn := integrity.NewTx(store)
+
+	err := codec.TxPut(txn, "alice", txExampleValue{Field: "a"})
+	if err != nil {
+		log.Fatalf("put alice: %v", err)
+	}
+
+	err = codec.TxPut(txn, "bob", txExampleValue{Field: "b"})
+	if err != nil {
+		log.Fatalf("put bob: %v", err)
+	}
+
+	resp, err := txn.Commit(ctx)
+	if err != nil {
+		log.Fatalf("commit: %v", err)
+	}
+
+	fmt.Println("succeeded:", resp.Succeeded)
+
+	// Output:
+	// succeeded: true
+}
+
+// ExampleGetFuture shows how TxGet hands back a *GetFuture[T] whose
+// Result() is populated only after Commit.
+func ExampleGetFuture() {
+	ctx := context.Background()
+	store := storage.NewStorage(dummy.New())
+	codec := newTxExampleCodec()
+
+	seedTx := integrity.NewTx(store)
+
+	err := codec.TxPut(seedTx, "alice", txExampleValue{Field: "hello"})
+	if err != nil {
+		log.Fatalf("seed: %v", err)
+	}
+
+	_, err = seedTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("seed commit: %v", err)
+	}
+
+	readTx := integrity.NewTx(store)
+	fut := codec.TxGet(readTx, "alice")
+
+	// Calling Result() before Commit returns ErrTxNotCommitted.
+	_, err = fut.Result()
+	fmt.Println("before commit:", errors.Is(err, integrity.ErrTxNotCommitted))
+
+	_, err = readTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("read commit: %v", err)
+	}
+
+	res, err := fut.Result()
+	if err != nil {
+		log.Fatalf("result: %v", err)
+	}
+
+	fmt.Println("field:", res.Value.Unwrap().Field)
+
+	// Output:
+	// before commit: true
+	// field: hello
+}
+
+// ExampleRangeFuture shows TxRange returning every value under a name
+// prefix in a single transaction. Use "" to fetch every value the codec
+// owns; pass a non-empty prefix (must end with "/") to scope.
+func ExampleRangeFuture() {
+	ctx := context.Background()
+	store := storage.NewStorage(dummy.New())
+	codec := newTxExampleCodec()
+
+	seedTx := integrity.NewTx(store)
+	for _, name := range []string{"users/alice", "users/bob"} {
+		err := codec.TxPut(seedTx, name, txExampleValue{Field: name})
+		if err != nil {
+			log.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	_, err := seedTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("seed commit: %v", err)
+	}
+
+	readTx := integrity.NewTx(store)
+	fut := codec.TxRange(readTx, "users/")
+
+	_, err = readTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("read commit: %v", err)
+	}
+
+	results, err := fut.Result()
+	if err != nil {
+		log.Fatalf("result: %v", err)
+	}
+
+	names := make([]string, 0, len(results))
+	for _, r := range results {
+		names = append(names, r.Name)
+	}
+
+	sort.Strings(names)
+
+	for _, n := range names {
+		fmt.Println(n)
+	}
+
+	// Output:
+	// users/alice
+	// users/bob
+}
+
+// ExampleCodec_TxDelete enqueues a Delete onto the Then branch and removes
+// every key that belongs to the named value (value plus all hash/sig keys).
+func ExampleCodec_TxDelete() {
+	ctx := context.Background()
+	store := storage.NewStorage(dummy.New())
+	codec := newTxExampleCodec()
+
+	seedTx := integrity.NewTx(store)
+
+	err := codec.TxPut(seedTx, "victim", txExampleValue{Field: "x"})
+	if err != nil {
+		log.Fatalf("seed: %v", err)
+	}
+
+	_, err = seedTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("seed commit: %v", err)
+	}
+
+	delTx := integrity.NewTx(store)
+
+	err = codec.TxDelete(delTx, "victim")
+	if err != nil {
+		log.Fatalf("delete: %v", err)
+	}
+
+	_, err = delTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("delete commit: %v", err)
+	}
+
+	getTx := integrity.NewTx(store)
+	fut := codec.TxGet(getTx, "victim")
+
+	_, err = getTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("get commit: %v", err)
+	}
+
+	_, err = fut.Result()
+	fmt.Println("not found:", errors.Is(err, integrity.ErrNotFound))
+
+	// Output:
+	// not found: true
+}
+
+// ExampleTx_thenElse routes operations to the Then or Else branch, depending
+// on which side fires after If predicates are evaluated. Futures attached to
+// a branch that did not fire return ErrBranchNotFired.
+func ExampleTx_thenElse() {
+	ctx := context.Background()
+	store := storage.NewStorage(dummy.New())
+	codec := newTxExampleCodec()
+
+	// Seed a value the Else branch will read.
+	seedTx := integrity.NewTx(store)
+
+	err := codec.TxPut(seedTx, "fallback", txExampleValue{Field: "fallback-value"})
+	if err != nil {
+		log.Fatalf("seed: %v", err)
+	}
+
+	_, err = seedTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("seed commit: %v", err)
+	}
+
+	// Build a tx whose If can never hold.
+	mainTx := integrity.NewTx(store)
+
+	pred, err := codec.BindPredicate("missing", codec.VersionGreater(999))
+	if err != nil {
+		log.Fatalf("bind: %v", err)
+	}
+
+	mainTx.If(pred)
+
+	thenFut := codec.TxGet(mainTx.Then(), "missing")
+	elseFut := codec.TxGet(mainTx.Else(), "fallback")
+
+	resp, err := mainTx.Commit(ctx)
+	if err != nil {
+		log.Fatalf("commit: %v", err)
+	}
+
+	fmt.Println("succeeded:", resp.Succeeded)
+
+	_, thenErr := thenFut.Result()
+	if errors.Is(thenErr, integrity.ErrBranchNotFired) {
+		fmt.Println("then branch did not fire")
+	}
+
+	res, err := elseFut.Result()
+	if err != nil {
+		log.Fatalf("else result: %v", err)
+	}
+
+	fmt.Println("else field:", res.Value.Unwrap().Field)
+
+	// Output:
+	// succeeded: false
+	// then branch did not fire
+	// else field: fallback-value
+}

--- a/namer/layered_example_test.go
+++ b/namer/layered_example_test.go
@@ -1,0 +1,139 @@
+package namer_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/tarantool/go-storage/namer"
+)
+
+// ExampleNewLayeredNamer demonstrates the default layered key layout:
+//
+//	/<obj>/<name>                       (value)
+//	/hash/<hashLoc>/<obj>/<name>        (one per hasher)
+//	/sig/<sigLoc>/<obj>/<name>          (one per signer)
+func ExampleNewLayeredNamer() {
+	layered, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "rsa", Location: "rsa"}},
+	)
+	if err != nil {
+		log.Fatalf("new namer: %v", err)
+	}
+
+	keys, err := layered.GenerateNames("alice")
+	if err != nil {
+		log.Fatalf("generate: %v", err)
+	}
+
+	for _, k := range keys {
+		fmt.Printf("%s -> %s\n", k.Type(), k.Build())
+	}
+
+	// Output:
+	// KeyTypeValue -> /objects/alice
+	// KeyTypeHash -> /hash/sha256/objects/alice
+	// KeyTypeSignature -> /sig/rsa/objects/alice
+}
+
+// ExampleCompactSingleHash shows the compact hash layout, which drops the
+// per-hasher segment when exactly one hasher is configured.
+func ExampleCompactSingleHash() {
+	layered, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+		namer.CompactSingleHash(),
+	)
+	if err != nil {
+		log.Fatalf("new namer: %v", err)
+	}
+
+	keys, err := layered.GenerateNames("alice")
+	if err != nil {
+		log.Fatalf("generate: %v", err)
+	}
+
+	for _, k := range keys {
+		fmt.Printf("%s -> %s\n", k.Type(), k.Build())
+	}
+
+	// Output:
+	// KeyTypeValue -> /objects/alice
+	// KeyTypeHash -> /hash/objects/alice
+}
+
+// ExampleCompactSingleSig shows the compact sig layout, which drops the
+// per-signer segment when exactly one signer is configured.
+func ExampleCompactSingleSig() {
+	layered, err := namer.NewLayeredNamer(
+		"objects",
+		nil,
+		[]namer.LayeredSigLocation{{SignerName: "rsapss", Location: "rsapss"}},
+		namer.CompactSingleSig(),
+	)
+	if err != nil {
+		log.Fatalf("new namer: %v", err)
+	}
+
+	keys, err := layered.GenerateNames("alice")
+	if err != nil {
+		log.Fatalf("generate: %v", err)
+	}
+
+	for _, k := range keys {
+		fmt.Printf("%s -> %s\n", k.Type(), k.Build())
+	}
+
+	// Output:
+	// KeyTypeValue -> /objects/alice
+	// KeyTypeSignature -> /sig/objects/alice
+}
+
+// ExampleNewLayeredNamer_parse shows how ParseKey resolves a raw key path
+// back into its category and object name.
+func ExampleNewLayeredNamer_parse() {
+	layered, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+	)
+	if err != nil {
+		log.Fatalf("new namer: %v", err)
+	}
+
+	for _, raw := range []string{
+		"/objects/alice",
+		"/hash/sha256/objects/alice",
+	} {
+		k, err := layered.ParseKey(raw)
+		if err != nil {
+			log.Fatalf("parse %q: %v", raw, err)
+		}
+
+		fmt.Printf("%s name=%s property=%q\n", k.Type(), k.Name(), k.Property())
+	}
+
+	// Output:
+	// KeyTypeValue name=alice property=""
+	// KeyTypeHash name=alice property="sha256"
+}
+
+// ExampleNewLayeredNamer_prefix shows the prefix used to walk all values
+// under the value layer (hashes/sigs are separate sub-trees).
+func ExampleNewLayeredNamer_prefix() {
+	layered, err := namer.NewLayeredNamer("objects", nil, nil)
+	if err != nil {
+		log.Fatalf("new namer: %v", err)
+	}
+
+	fmt.Println(layered.Prefix("", false))
+	fmt.Println(layered.Prefix("alice", false))
+	fmt.Println(layered.Prefix("users", true))
+
+	// Output:
+	// /objects/
+	// /objects/alice
+	// /objects/users/
+}

--- a/prefix_example_test.go
+++ b/prefix_example_test.go
@@ -1,0 +1,101 @@
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/operation"
+	"github.com/tarantool/go-storage/predicate"
+)
+
+// ExamplePrefixed shows how Prefixed scopes every Tx operation under a
+// namespace. Callers work with logical keys ("/cfg/version"); the underlying
+// driver sees absolute keys ("/ns/cfg/version"), and the namespace is stripped
+// from any keys returned to the caller.
+func ExamplePrefixed() {
+	ctx := context.Background()
+	base := storage.NewStorage(dummy.New())
+	scoped := storage.Prefixed("/ns", base)
+
+	_, err := scoped.Tx(ctx).Then(
+		operation.Put([]byte("/cfg/version"), []byte("1.0.0")),
+	).Commit()
+	if err != nil {
+		log.Fatalf("put: %v", err)
+	}
+
+	resp, err := scoped.Tx(ctx).Then(
+		operation.Get([]byte("/cfg/version")),
+	).Commit()
+	if err != nil {
+		log.Fatalf("get: %v", err)
+	}
+
+	got := resp.Results[0].Values[0]
+	fmt.Printf("logical key: %s, value: %s\n", got.Key, got.Value)
+
+	// Output:
+	// logical key: /cfg/version, value: 1.0.0
+}
+
+// ExamplePrefixed_nested shows that nested wrappers are flattened at
+// construction time: Prefixed("/a", Prefixed("/b", base)) is equivalent to
+// Prefixed("/a/b", base). This is observable by reading the same key through
+// the un-wrapped base storage.
+func ExamplePrefixed_nested() {
+	ctx := context.Background()
+	base := storage.NewStorage(dummy.New())
+	outer := storage.Prefixed("/a", storage.Prefixed("/b", base))
+
+	_, err := outer.Tx(ctx).Then(
+		operation.Put([]byte("/k"), []byte("v")),
+	).Commit()
+	if err != nil {
+		log.Fatalf("put: %v", err)
+	}
+
+	// Read directly from base to see the absolute key the driver actually stored.
+	resp, err := base.Tx(ctx).Then(
+		operation.Get([]byte("/a/b/k")),
+	).Commit()
+	if err != nil {
+		log.Fatalf("get: %v", err)
+	}
+
+	got := resp.Results[0].Values[0]
+	fmt.Printf("absolute: %s = %s\n", got.Key, got.Value)
+
+	// Output:
+	// absolute: /a/b/k = v
+}
+
+// ExamplePrefixed_predicates shows that predicates are also rewritten under
+// the configured prefix, so conditional transactions stay scoped.
+func ExamplePrefixed_predicates() {
+	ctx := context.Background()
+	scoped := storage.Prefixed("/ns", storage.NewStorage(dummy.New()))
+
+	_, err := scoped.Tx(ctx).Then(
+		operation.Put([]byte("/feature"), []byte("on")),
+	).Commit()
+	if err != nil {
+		log.Fatalf("seed: %v", err)
+	}
+
+	resp, err := scoped.Tx(ctx).
+		If(predicate.ValueEqual([]byte("/feature"), "on")).
+		Then(operation.Put([]byte("/feature"), []byte("off"))).
+		Else(operation.Put([]byte("/feature"), []byte("unchanged"))).
+		Commit()
+	if err != nil {
+		log.Fatalf("commit: %v", err)
+	}
+
+	fmt.Println("succeeded:", resp.Succeeded)
+
+	// Output:
+	// succeeded: true
+}


### PR DESCRIPTION
Examples for `storage.Prefixed`, `namer.LayeredNamer`, `integrity.Codec/CodecBuilder`, `integrity.Store`, and `integrity.Tx` covering typical usage paths and the interesting edge cases (predicates, copy-on-write builder, then/else branches, futures).

Integration tests in `integrity/integration_codec_tx_test.go` run the `Codec`/`Store`/`Tx` surface against tcs, etcd, and dummy drivers to confirm cross-backend parity.

Closes TNTP-7587