### PR TITLE
marshaller: add JSON and bytes passthrough marshallers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Get`/`Put`/`Delete`/`Range`/`Watch` implemented as thin `Tx`
   wrappers, and `Codec[T].Bind` for cheap binding. Multi-codec
   transactions lower to a single storage call.
+- marshaller: `TypedJSONMarshaller[T]` for `encoding/json`-based
+  marshalling and `TypedBytesMarshaller` passthrough
+  `TypedMarshaller[[]byte]` for values that are already serialized or
+  stored as opaque blobs.
 
 ### Changed
 

--- a/marshaller/typed.go
+++ b/marshaller/typed.go
@@ -1,6 +1,8 @@
 package marshaller
 
 import (
+	"encoding/json"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -32,4 +34,54 @@ func (m TypedYamlMarshaller[T]) Unmarshal(data []byte) (T, error) {
 	}
 
 	return out, nil
+}
+
+// TypedJSONMarshaller is a generic JSON marshaller for typed objects.
+type TypedJSONMarshaller[T any] struct{}
+
+// NewTypedJSONMarshaller creates a new TypedJSONMarshaller for the specified type.
+func NewTypedJSONMarshaller[T any]() TypedJSONMarshaller[T] {
+	return TypedJSONMarshaller[T]{}
+}
+
+// Marshal serializes the typed data to JSON format.
+func (m TypedJSONMarshaller[T]) Marshal(data T) ([]byte, error) {
+	marshalled, err := json.Marshal(data)
+	if err != nil {
+		return []byte{}, errMarshal(err)
+	}
+
+	return marshalled, nil
+}
+
+// Unmarshal deserializes JSON data into a typed object.
+func (m TypedJSONMarshaller[T]) Unmarshal(data []byte) (T, error) {
+	var out T
+
+	err := json.Unmarshal(data, &out)
+	if err != nil {
+		return zero[T](), errUnmarshal(err)
+	}
+
+	return out, nil
+}
+
+// TypedBytesMarshaller is a passthrough marshaller for raw []byte payloads.
+// It implements TypedMarshaller[[]byte] without performing any encoding,
+// useful when values are already serialized or stored as opaque blobs.
+type TypedBytesMarshaller struct{}
+
+// NewTypedBytesMarshaller creates a new TypedBytesMarshaller.
+func NewTypedBytesMarshaller() TypedBytesMarshaller {
+	return TypedBytesMarshaller{}
+}
+
+// Marshal returns the input bytes unchanged.
+func (m TypedBytesMarshaller) Marshal(data []byte) ([]byte, error) {
+	return data, nil
+}
+
+// Unmarshal returns the input bytes unchanged.
+func (m TypedBytesMarshaller) Unmarshal(data []byte) ([]byte, error) {
+	return data, nil
 }

--- a/marshaller/typed_test.go
+++ b/marshaller/typed_test.go
@@ -9,15 +9,15 @@ import (
 )
 
 type TestStruct struct {
-	Name  string   `yaml:"name"`
-	Value int      `yaml:"value"`
-	Tags  []string `yaml:"tags,omitempty"`
+	Name  string   `json:"name"           yaml:"name"`
+	Value int      `json:"value"          yaml:"value"`
+	Tags  []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 }
 
 type NestedStruct struct {
-	ID     int        `yaml:"id"`
-	Data   TestStruct `yaml:"data"`
-	Active bool       `yaml:"active"`
+	ID     int        `json:"id"     yaml:"id"`
+	Data   TestStruct `json:"data"   yaml:"data"`
+	Active bool       `json:"active" yaml:"active"`
 }
 
 func TestTypedYamlMarshaller_New(t *testing.T) {
@@ -240,4 +240,93 @@ func TestTypedYamlMarshaller_WithSliceType(t *testing.T) {
 	unmarshaled, err := marsh.Unmarshal(marshaled)
 	require.NoError(t, err)
 	require.Equal(t, original, unmarshaled)
+}
+
+func TestTypedJSONMarshaller_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	marsh := marshaller.NewTypedJSONMarshaller[TestStruct]()
+
+	original := TestStruct{
+		Name:  "roundtrip",
+		Value: 99,
+		Tags:  []string{"a", "b", "c"},
+	}
+
+	marshaled, err := marsh.Marshal(original)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"name":"roundtrip","value":99,"tags":["a","b","c"]}`, string(marshaled))
+
+	unmarshaled, err := marsh.Unmarshal(marshaled)
+	require.NoError(t, err)
+	require.Equal(t, original, unmarshaled)
+}
+
+func TestTypedJSONMarshaller_NestedStruct(t *testing.T) {
+	t.Parallel()
+
+	marsh := marshaller.NewTypedJSONMarshaller[NestedStruct]()
+
+	original := NestedStruct{
+		ID: 1,
+		Data: TestStruct{
+			Name:  "nested",
+			Value: 100,
+			Tags:  nil,
+		},
+		Active: true,
+	}
+
+	marshaled, err := marsh.Marshal(original)
+	require.NoError(t, err)
+
+	unmarshaled, err := marsh.Unmarshal(marshaled)
+	require.NoError(t, err)
+	require.Equal(t, original, unmarshaled)
+}
+
+func TestTypedJSONMarshaller_Unmarshal_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	marsh := marshaller.NewTypedJSONMarshaller[TestStruct]()
+
+	_, err := marsh.Unmarshal([]byte(`{not json}`))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Failed to unmarshal")
+}
+
+func TestTypedBytesMarshaller_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	marsh := marshaller.NewTypedBytesMarshaller()
+
+	original := []byte{0x00, 0x01, 0x02, 0xff}
+
+	marshaled, err := marsh.Marshal(original)
+	require.NoError(t, err)
+	require.Equal(t, original, marshaled)
+
+	unmarshaled, err := marsh.Unmarshal(marshaled)
+	require.NoError(t, err)
+	require.Equal(t, original, unmarshaled)
+}
+
+func TestTypedBytesMarshaller_Nil(t *testing.T) {
+	t.Parallel()
+
+	marsh := marshaller.NewTypedBytesMarshaller()
+
+	marshaled, err := marsh.Marshal(nil)
+	require.NoError(t, err)
+	require.Nil(t, marshaled)
+
+	unmarshaled, err := marsh.Unmarshal(nil)
+	require.NoError(t, err)
+	require.Nil(t, unmarshaled)
+}
+
+func TestTypedBytesMarshaller_ImplementsTypedMarshaller(t *testing.T) {
+	t.Parallel()
+
+	var _ marshaller.TypedMarshaller[[]byte] = marshaller.NewTypedBytesMarshaller()
 }


### PR DESCRIPTION
Add two additional typed marshaller implementations alongside the existing YAML one.
- Add TypedJSONMarshaller[T] for default encoding/json marshalling.
- Add TypedBytesMarshaller as a passthrough TypedMarshaller[[]byte] for values that are already serialized or stored as opaque blobs.