### PR TITLE
ci: inline govulncheck and bump Go to 1.26

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -12,7 +12,10 @@ on:
         default: false
 
 env:
-  GO_VERSION: 1.24
+  GO_VERSION: "1.26"
+  # Track latest; pre-v1.3.0 panics in the SSA builder on generic
+  # signatures used by github.com/go-json-experiment/json.
+  GOVULNCHECK_VERSION: latest
 
 jobs:
   govulncheck:
@@ -30,12 +33,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@${{ env.GOVULNCHECK_VERSION }}
+
       - name: Run govulncheck
         id: govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-version-input: ${{ env.GO_VERSION }}
-          cache: false
+        run: govulncheck ./...
 
       - name: Send notification on scheduled run failure
         if: |


### PR DESCRIPTION
The vulncheck workflow was broken: `golang/govulncheck-action@v1` bundles `actions/checkout@v4.1.1`, which collides with the outer `actions/checkout@v6` — both inject an `Authorization` extraheader, so module fetches fail with `remote: Duplicate header: "Authorization"` (HTTP 400).

Replace the action with a direct `go install golang.org/x/vuln/cmd/govulncheck@latest` followed by `govulncheck ./...`. Two lines, no third-party dependency, no auth collision.

Bump `GO_VERSION` to 1.26 because v1.3.0 govulncheck requires Go 1.26+.