### PR TITLE
watch: unify drivers on signal-only Event.Prefix contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- watch: unified all drivers (etcd, dummy, tcs) on a signal-only
+  `Event.Prefix` contract. Every driver now emits the watched key with
+  any trailing `/` stripped — a signal that something at or under the
+  watched key changed, not the per-event changed key. Consumers that
+  need the changed key must follow up with `Range`. tcs's per-watcher
+  buffer is bumped to 16 with a blocking, ctx-aware send so server
+  bursts no longer drop on a full channel.
+
 ### Fixed
+
+- watch: prefix-shaped Watch calls (e.g. `Watch(ctx, "acl/")`) used to
+  silently drop every event because drivers emitted the watched key
+  with the trailing `/` intact and the integrity layer's `ParseKey`
+  rejected it. Drivers now strip the trailing `/`; the integrity store
+  filter strips it from the user-supplied name as well so the
+  neighbour-codec filter matches both single-key and prefix watches.
 
 ## [v1.3.0] - 2026-05-05
 

--- a/driver/dummy/dummy.go
+++ b/driver/dummy/dummy.go
@@ -307,15 +307,17 @@ func (d *Driver) addWatcher(ctx context.Context, key string) (chan watch.Event, 
 	return wch, func() { isStoppedOnce.Do(func() { close(isStopped) }) }
 }
 
-// notifyWatchers sends a watch event to all watchers
-// whose prefix matches the given key.
+// notifyWatchers sends a signal event (the watched key with any trailing "/"
+// stripped) to every watcher whose prefix matches the given key.
 func (d *Driver) notifyWatchers(key string) {
 	for prefix, watchers := range d.data.watchChanStorage {
 		if strings.HasPrefix(key, prefix) && isPrefix(prefix) || key == prefix {
+			emitted := strings.TrimSuffix(prefix, "/")
+
 			for _, ch := range watchers.chans {
 				select {
 				case ch <- watch.Event{
-					Prefix: []byte(prefix),
+					Prefix: []byte(emitted),
 				}:
 				default:
 				}

--- a/driver/dummy/dummy_test.go
+++ b/driver/dummy/dummy_test.go
@@ -1,6 +1,7 @@
 package dummy_test
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -842,7 +843,8 @@ func TestDummyDriver_Watch_Recursive(t *testing.T) {
 
 	select {
 	case event := <-eventCh:
-		assert.Equal(t, prefix, event.Prefix)
+		assert.Equal(t, bytes.TrimSuffix(prefix, []byte("/")), event.Prefix,
+			"event.Prefix is the watched prefix with trailing slash stripped")
 	case <-watchCtx.Done():
 		t.Fatal("Timeout waiting for recursive watch event")
 	}

--- a/driver/dummy/examples_test.go
+++ b/driver/dummy/examples_test.go
@@ -310,7 +310,7 @@ func ExampleDriver_Watch() {
 	// Watching for changes on: /config/app/status
 	// Received watch event for key: /config/app/status
 	// Watching for changes on prefix: /config/database/
-	// Received watch event for prefix: /config/database/
+	// Received watch event for prefix: /config/database
 	// Started watch with manual control
 	// Stopping watch gracefully...
 }

--- a/driver/etcd/etcd.go
+++ b/driver/etcd/etcd.go
@@ -99,7 +99,7 @@ const (
 )
 
 // Watch monitors changes to a specific key and returns a stream of events.
-// It supports optional watch configuration through the opts parameter.
+// event.Prefix is the watched key with any trailing "/" stripped.
 func (d Driver) Watch(ctx context.Context, key []byte, _ ...watch.Option) (<-chan watch.Event, func(), error) {
 	eventCh := make(chan watch.Event, eventChannelSize)
 
@@ -109,6 +109,8 @@ func (d Driver) Watch(ctx context.Context, key []byte, _ ...watch.Option) (<-cha
 	if bytes.HasSuffix(key, []byte("/")) {
 		opts = append(opts, etcd.WithPrefix())
 	}
+
+	emitted := bytes.TrimSuffix(key, []byte("/"))
 
 	watchChan := d.client.Watch(ctx, string(key), opts...)
 
@@ -131,7 +133,7 @@ func (d Driver) Watch(ctx context.Context, key []byte, _ ...watch.Option) (<-cha
 				for range watchResp.Events {
 					select {
 					case eventCh <- watch.Event{
-						Prefix: key,
+						Prefix: emitted,
 					}:
 					case <-ctx.Done():
 						return

--- a/driver/etcd/examples_test.go
+++ b/driver/etcd/examples_test.go
@@ -437,9 +437,9 @@ func ExampleDriver_Watch_multipleOperations() {
 
 	// Output:
 	// Watching for changes on prefix: /config/database/
-	// Event 1: change detected on /config/database/
-	// Event 2: change detected on /config/database/
-	// Event 3: change detected on /config/database/
+	// Event 1: change detected on /config/database
+	// Event 2: change detected on /config/database
+	// Event 3: change detected on /config/database
 }
 
 // ExampleDriver_Watch_gracefulTermination demonstrates graceful watch termination with manual control.

--- a/driver/etcd/integration_test.go
+++ b/driver/etcd/integration_test.go
@@ -8,6 +8,7 @@
 package etcd_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -371,16 +372,16 @@ func TestEtcdDriver_Watch_Prefix(t *testing.T) {
 	putValue(ctx, t, driver, key1, value1)
 	putValue(ctx, t, driver, key2, value2)
 
-	// Wait for watch events for both puts.
-	eventCount := 0
-	for eventCount < 2 {
+	expected := bytes.TrimSuffix(prefix, []byte("/"))
+
+	// Wait for watch events for both puts. Each event carries the watched
+	// prefix (trailing slash stripped) as a signal, not the changed key.
+	for i := range 2 {
 		select {
 		case event := <-eventCh:
-			assert.Equal(t, prefix, event.Prefix, "Event should contain the watched prefix")
-
-			eventCount++
+			assert.Equal(t, expected, event.Prefix, "Event should signal the watched prefix")
 		case <-time.After(defaultWaitTimeout):
-			t.Fatalf("Expected %d watch events but only received %d", 2, eventCount)
+			t.Fatalf("Expected 2 watch events but only received %d", i)
 		}
 	}
 
@@ -389,7 +390,7 @@ func TestEtcdDriver_Watch_Prefix(t *testing.T) {
 	// Wait for the delete event.
 	select {
 	case event := <-eventCh:
-		assert.Equal(t, prefix, event.Prefix, "Event should contain the watched prefix")
+		assert.Equal(t, expected, event.Prefix, "Event should signal the watched prefix")
 	case <-time.After(defaultWaitTimeout):
 		assert.Fail(t, "Expected watch event for delete but timed out")
 	}

--- a/driver/etcd/watch_test.go
+++ b/driver/etcd/watch_test.go
@@ -114,9 +114,8 @@ func TestDriver_Watch_EventsForwarded(t *testing.T) {
 	})
 
 	driver := New(client)
-	key := []byte("test-key")
 
-	eventCh, cancelWatch, err := driver.Watch(context.Background(), key)
+	eventCh, cancelWatch, err := driver.Watch(context.Background(), []byte("test-prefix/"))
 	require.NoError(t, err)
 
 	defer cancelWatch()
@@ -129,7 +128,8 @@ func TestDriver_Watch_EventsForwarded(t *testing.T) {
 
 	select {
 	case event := <-eventCh:
-		assert.Equal(t, key, event.Prefix)
+		assert.Equal(t, []byte("test-prefix"), event.Prefix,
+			"event.Prefix is the watched key with trailing slash stripped")
 	case <-time.After(time.Second):
 		t.Fatal("expected event to be forwarded")
 	}

--- a/driver/tcs/examples_test.go
+++ b/driver/tcs/examples_test.go
@@ -436,9 +436,9 @@ func ExampleDriver_Watch() {
 	// Watching for changes on: /config/app/status
 	// Received watch event for key: /config/app/status
 	// Watching for changes on prefix: /config/database/
-	// Event 1: change detected on /config/database/
-	// Event 2: change detected on /config/database/
-	// Event 3: change detected on /config/database/
+	// Event 1: change detected on /config/database
+	// Event 2: change detected on /config/database
+	// Event 3: change detected on /config/database
 	// Started watch with manual control
 	// Stopping watch gracefully...
 }

--- a/driver/tcs/tcs.go
+++ b/driver/tcs/tcs.go
@@ -3,6 +3,7 @@
 package tcs
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -16,6 +17,8 @@ import (
 	"github.com/tarantool/go-storage/tx"
 	"github.com/tarantool/go-storage/watch"
 )
+
+const watchEventChannelSize = 16
 
 // DoerWatcher is an interface that combines tarantool.Doer and NewWatcher method.
 // tarantool.Connection and pool.ConnectionAdapter implement this interface.
@@ -69,15 +72,16 @@ func (d Driver) Execute(
 }
 
 // Watch monitors changes to a specific key and returns a stream of events.
-// It supports optional watch configuration through the opts parameter.
-// To watch for config storage key "config.storage:" prefix should be used.
+// event.Prefix is the watched key with any trailing "/" stripped.
 func (d Driver) Watch(ctx context.Context, key []byte, _ ...watch.Option) (<-chan watch.Event, func(), error) {
-	rvChan := make(chan watch.Event, 1)
+	rvChan := make(chan watch.Event, watchEventChannelSize)
+
+	emitted := bytes.TrimSuffix(key, []byte("/"))
 
 	watcher, err := d.conn.NewWatcher("config.storage:"+string(key), func(_ tarantool.WatchEvent) {
 		select {
-		case rvChan <- watch.Event{Prefix: key}:
-		default:
+		case rvChan <- watch.Event{Prefix: emitted}:
+		case <-ctx.Done():
 		}
 	})
 	if err != nil {

--- a/driver/tcs/tcs_test.go
+++ b/driver/tcs/tcs_test.go
@@ -246,19 +246,61 @@ func TestDriver_Watch_CallbackTwiceCalled(t *testing.T) {
 	assert.NotNil(t, events)
 	assert.NotNil(t, cleanup)
 
-	select {
-	case val, ok := <-events:
-		require.True(t, ok)
-		assert.Equal(t, []byte("test-key"), val.Prefix)
-	case <-time.After(defaultWaitTimeout):
-		assert.Fail(t, "timeout")
+	for attempt := range 2 {
+		select {
+		case val, ok := <-events:
+			require.True(t, ok)
+			assert.Equal(t, []byte("test-key"), val.Prefix)
+		case <-time.After(defaultWaitTimeout):
+			assert.Fail(t, "timeout waiting for event", ": #%d", attempt+1)
+		}
 	}
 
 	select {
 	case val, ok := <-events:
-		require.True(t, ok)
-		assert.Fail(t, "must be empty", ": %v, %v", val, ok)
+		assert.Fail(t, "channel must be drained after both events", ": %v, %v", val, ok)
 	default:
+	}
+
+	cleanup()
+	mc.Wait(defaultUnregisterTimeout)
+}
+
+func TestDriver_Watch_PrefixKeyStripsTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	mc := minimock.NewController(t)
+
+	mockDoer := mocks.NewDoerWatcherMock(mc)
+	watcher := mocks.NewWatcherMock(mc).UnregisterMock.Expect().Times(1).Return()
+
+	mockDoer.NewWatcherMock.Set(func(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error) {
+		assert.Equal(t, "config.storage:/acl/", key, "subscribed topic keeps the trailing slash")
+		assert.NotNil(t, callback)
+
+		callback(tarantool.WatchEvent{
+			Conn:  nil,
+			Key:   "config.storage:/acl/",
+			Value: int8(1),
+		})
+
+		return watcher, nil
+	})
+
+	driver := tcs.New(mockDoer)
+
+	ctx := context.Background()
+	events, cleanup, err := driver.Watch(ctx, []byte("/acl/"))
+
+	require.NoError(t, err)
+
+	select {
+	case val, ok := <-events:
+		require.True(t, ok)
+		assert.Equal(t, []byte("/acl"), val.Prefix,
+			"emitted event drops the trailing slash so consumers can ParseKey it")
+	case <-time.After(defaultWaitTimeout):
+		assert.Fail(t, "timeout")
 	}
 
 	cleanup()

--- a/integrity/integration_test.go
+++ b/integrity/integration_test.go
@@ -901,6 +901,36 @@ func TestTypedIntegration_NonEmptyRangeWithDiffHashIgnore(t *testing.T) {
 	})
 }
 
+// Regression: Watch over a prefix-shaped name used to silently drop every
+// event because drivers emitted the watched key with a trailing "/" that
+// the integrity layer's ParseKey rejected.
+func TestTypedIntegration_Watch_Prefix(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		typed := integrity.NewTypedBuilder[IntegrationStruct](storage.NewStorage(driverInstance)).
+			WithPrefix("/test").
+			Build()
+
+		eventCh, err := typed.Watch(ctx, "obj/")
+		require.NoError(t, err)
+
+		time.Sleep(200 * time.Millisecond)
+
+		require.NoError(t, typed.Put(ctx, "obj/1", IntegrationStruct{Name: "1", Value: 1}))
+
+		select {
+		case event := <-eventCh:
+			assert.Equal(t, []byte("/test/obj"), event.Prefix)
+		case <-time.After(defaultWaitTimeout):
+			t.Fatal("regression: prefix Watch delivered no events")
+		}
+
+		require.NoError(t, typed.Delete(ctx, "obj/1"))
+	})
+}
+
 func TestTypedIntegration_Watch(t *testing.T) {
 	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
 		t.Helper()

--- a/integrity/store.go
+++ b/integrity/store.go
@@ -151,6 +151,9 @@ func (s *Store[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, 
 	rawCh := s.storage.Watch(ctx, []byte(key))
 	filteredCh := make(chan watch.Event)
 
+	// Drivers strip the trailing "/" from event.Prefix; mirror that here.
+	filterName := strings.TrimSuffix(name, "/")
+
 	go func() {
 		defer close(filteredCh)
 
@@ -170,7 +173,7 @@ func (s *Store[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, 
 					continue
 				}
 
-				if !strings.HasPrefix(parsedKey.Name(), name) {
+				if !strings.HasPrefix(parsedKey.Name(), filterName) {
 					continue
 				}
 

--- a/integrity/typed.go
+++ b/integrity/typed.go
@@ -446,6 +446,9 @@ func (t *Typed[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, 
 	rawCh := t.base.Watch(ctx, []byte(key))
 	filteredCh := make(chan watch.Event)
 
+	// Drivers strip the trailing "/" from event.Prefix; mirror that here.
+	filterName := strings.TrimSuffix(name, "/")
+
 	go func() {
 		defer close(filteredCh)
 
@@ -466,7 +469,7 @@ func (t *Typed[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, 
 				}
 
 				// Filter by name prefix.
-				if !strings.HasPrefix(key.Name(), name) {
+				if !strings.HasPrefix(key.Name(), filterName) {
 					continue
 				}
 


### PR DESCRIPTION
Until now each driver had a different idea of what `Event.Prefix` carries. etcd and dummy emitted the per-event changed key, sometimes with a trailing `/`; tcs emitted the watched prefix because its server-side watch is broadcast-shaped and carries no per-event key. Consumers had to special-case each driver, and the integrity layer's `ParseKey` filter rejected anything ending in `/`, which silently dropped events for prefix-shaped watches like `Watch(ctx, "acl/")`.

All three drivers now emit the watched key with any trailing `/` stripped — a signal that something at or under the watched key changed, not the changed key itself. Consumers that need the changed key follow up with `Range`. The integrity store filter strips the same suffix from the user-supplied name so single-key and prefix watches both match the neighbour-codec filter.

tcs's per-watcher buffer is bumped to 16 with a blocking, ctx-aware send so server bursts no longer drop on a full channel.

`TestTypedIntegration_Watch_Prefix` is added as a regression across etcd, dummy, and tcs.

Closes TNTP-7708