### PR TITLE
namer: allow multi-segment objectLocation in LayeredNamer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- namer.LayeredNamer: `objectLocation` may now be a multi-segment path
+  (e.g. `"settings/ldap"`). Previously the segment validator rejected any
+  inner `/`. The reserved-marker check still applies to the first segment,
+  so `objectLocation` values like `"hash/foo"` or `"sig/foo"` remain
+  rejected because they would collide with the hash/sig key dispatch.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -445,6 +445,13 @@ category under its own top-level location segment:
 /sig/<sigLocation>/<objectLocation>/<name>     (one per signer)
 ```
 
+`objectLocation` may itself be a multi-segment path (e.g. `"settings/ldap"`)
+— useful when the on-disk hierarchy of a feature is fixed at codec build
+time rather than per item. `hashLocation` and `sigLocation` are still
+single tokens because they index per-hasher / per-signer maps. The first
+segment of `objectLocation` must not equal the reserved markers `hash` or
+`sig` (they would collide with the parser's category dispatch).
+
 `namer.CompactSingleHash()` and `namer.CompactSingleSig()` drop the
 per-hasher / per-signer segment when exactly one is configured. `ParseKey`
 parses a raw key back to `(name, KeyType, property)` unambiguously.

--- a/integrity/codec_test.go
+++ b/integrity/codec_test.go
@@ -235,13 +235,30 @@ func TestCodecBuilder_InvalidObjectLocation(t *testing.T) {
 	require.Error(t, err, "Build should fail for location starting with '/'")
 }
 
-func TestCodecBuilder_EmptyObjectLocation(t *testing.T) {
+func TestCodecBuilder_MultiSegmentObjectLocation(t *testing.T) {
 	t.Parallel()
 
-	// "" is a valid input (it falls back to "objects" inside Build), so the
-	// invalid-segment check has to be exercised with a non-empty bad value.
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("settings/ldap").
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
+
+	n, err := namer.NewLayeredNamer("settings/ldap", nil, nil)
+	require.NoError(t, err)
+
+	keys, err := n.GenerateNames("entry-1")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	assert.Equal(t, "/settings/ldap/entry-1", keys[0].Build())
+}
+
+func TestCodecBuilder_EmptyInnerSegmentObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	// Multi-segment paths are allowed, but empty inner segments ("//") are not.
 	_, err := integrity.NewCodecBuilder[codecTestStruct]().
-		WithObjectLocation("a/b").
+		WithObjectLocation("a//b").
 		Build()
 	require.Error(t, err)
 }

--- a/namer/layered.go
+++ b/namer/layered.go
@@ -31,10 +31,11 @@ var (
 	ErrSegmentTrailingSlash = errors.New("namer: segment must not end with '/'")
 	// ErrSegmentInnerSlash is returned when a segment contains '/'.
 	ErrSegmentInnerSlash = errors.New("namer: segment must not contain '/'")
-	// ErrObjectLocationReserved is returned when objectLocation equals one of the
-	// reserved category markers ("hash" or "sig"), which would collide with
-	// hash/sig key paths.
-	ErrObjectLocationReserved = errors.New("namer: objectLocation must not equal reserved marker \"hash\" or \"sig\"")
+	// ErrObjectLocationReserved is returned when objectLocation's first segment
+	// is one of the reserved category markers ("hash" or "sig"), which would
+	// collide with hash/sig key paths during parsing.
+	ErrObjectLocationReserved = errors.New(
+		"namer: objectLocation must not start with reserved segment \"hash\" or \"sig\"")
 	// ErrCompactSingleHashCardinality is returned when CompactSingleHash is set
 	// but the configured hash list does not have exactly one entry.
 	ErrCompactSingleHashCardinality = errors.New("namer: CompactSingleHash requires exactly one hash entry")
@@ -100,11 +101,18 @@ type layeredNamer struct {
 //	/hash/<hashLocation>/<objectLocation>/<name>      (hash, one per hasher)
 //	/sig/<sigLocation>/<objectLocation>/<name>        (sig, one per signer)
 //
+// objectLocation may itself be a multi-segment path (e.g. "settings/ldap").
+// hashLocation and sigLocation are still single tokens since they index
+// per-hasher / per-signer maps.
+//
 // With CompactSingleHash, the <hashLocation> segment is omitted; with
 // CompactSingleSig, the <sigLocation> segment is omitted.
 //
 // Validation rules:
-//   - Each segment must be non-empty, contain no '/', and not equal "hash" or "sig" for objectLocation.
+//   - hashLocation / sigLocation must be a single non-empty segment with no '/'.
+//   - objectLocation must be non-empty, must not start or end with '/', and
+//     must not contain empty inner segments ("//"). Its first segment must
+//     not be "hash" or "sig".
 //   - hashLocations must be unique within hashes; sigLocations must be unique within sigs.
 //   - Compact flags require exactly one entry in their respective category.
 func NewLayeredNamer(
@@ -119,12 +127,13 @@ func NewLayeredNamer(
 		opt(&resolved)
 	}
 
-	err := validateSegment("objectLocation", objectLocation)
+	err := validateObjectLocation(objectLocation)
 	if err != nil {
 		return nil, err
 	}
 
-	if objectLocation == layeredHashMarker || objectLocation == layeredSigMarker {
+	firstSeg, _, _ := strings.Cut(objectLocation, "/")
+	if firstSeg == layeredHashMarker || firstSeg == layeredSigMarker {
 		return nil, fmt.Errorf("%w: got %q", ErrObjectLocationReserved, objectLocation)
 	}
 
@@ -205,6 +214,29 @@ func validateSegment(field, seg string) error {
 	return nil
 }
 
+// validateObjectLocation accepts multi-segment paths (e.g. "settings/ldap")
+// while still rejecting empty input, leading or trailing '/', and empty
+// inner segments ("//"). Reserved-marker checks are done by the caller.
+func validateObjectLocation(seg string) error {
+	if seg == "" {
+		return fmt.Errorf("%w: objectLocation", ErrSegmentEmpty)
+	}
+
+	if strings.HasPrefix(seg, "/") {
+		return fmt.Errorf("%w: objectLocation %q", ErrSegmentLeadingSlash, seg)
+	}
+
+	if strings.HasSuffix(seg, "/") {
+		return fmt.Errorf("%w: objectLocation %q", ErrSegmentTrailingSlash, seg)
+	}
+
+	if strings.Contains(seg, "//") {
+		return fmt.Errorf("%w: objectLocation %q has empty inner segment", ErrSegmentEmpty, seg)
+	}
+
+	return nil
+}
+
 // GenerateNames returns one key per category for the given object name.
 // name must be non-empty; a leading "/" is stripped.
 func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
@@ -268,7 +300,7 @@ func (n *layeredNamer) ParseKey(raw string) (DefaultKey, error) {
 	case layeredSigMarker:
 		return n.parseSigKey(raw, rest)
 	default:
-		return n.parseValueKey(raw, first, rest)
+		return n.parseValueKey(raw, stripped)
 	}
 }
 
@@ -336,20 +368,23 @@ func (n *layeredNamer) buildSigKey(sigLocation, name string) string {
 	return "/" + layeredSigMarker + "/" + sigLocation + "/" + n.objectLocation + "/" + name
 }
 
-func (n *layeredNamer) parseValueKey(raw, first, rest string) (DefaultKey, error) {
-	if first != n.objectLocation {
+func (n *layeredNamer) parseValueKey(raw, stripped string) (DefaultKey, error) {
+	name, ok := strings.CutPrefix(stripped, n.objectLocation+"/")
+	if !ok {
+		first, _, _ := strings.Cut(stripped, "/")
+
 		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown location segment %q", first))
 	}
 
-	if rest == "" {
+	if name == "" {
 		return DefaultKey{}, errInvalidKey(raw, "name part must not be empty")
 	}
 
-	if strings.HasSuffix(rest, "/") {
+	if strings.HasSuffix(name, "/") {
 		return DefaultKey{}, errInvalidKey(raw, "key name should not be prefix")
 	}
 
-	return NewDefaultKey(rest, KeyTypeValue, "", raw), nil
+	return NewDefaultKey(name, KeyTypeValue, "", raw), nil
 }
 
 func (n *layeredNamer) parseHashKey(raw, rest string) (DefaultKey, error) {
@@ -361,14 +396,10 @@ func (n *layeredNamer) parseHashKey(raw, rest string) (DefaultKey, error) {
 }
 
 func (n *layeredNamer) parseCompactHashKey(raw, rest string) (DefaultKey, error) {
-	objLoc, after, found := strings.Cut(rest, "/")
-	if !found || objLoc == "" {
-		return DefaultKey{}, errInvalidKey(raw, "hash key missing objectLocation")
-	}
-
-	if objLoc != n.objectLocation {
+	after, ok := strings.CutPrefix(rest, n.objectLocation+"/")
+	if !ok {
 		return DefaultKey{}, errInvalidKey(raw,
-			fmt.Sprintf("hash key objectLocation %q does not match %q", objLoc, n.objectLocation))
+			fmt.Sprintf("hash key objectLocation does not match %q", n.objectLocation))
 	}
 
 	err := validateNamePart(raw, after, "hash")
@@ -390,14 +421,10 @@ func (n *layeredNamer) parseFullHashKey(raw, rest string) (DefaultKey, error) {
 		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown hash location %q", hashLoc))
 	}
 
-	objLoc, after, found := strings.Cut(afterLoc, "/")
-	if !found || objLoc == "" {
-		return DefaultKey{}, errInvalidKey(raw, "hash key missing objectLocation")
-	}
-
-	if objLoc != n.objectLocation {
+	after, ok := strings.CutPrefix(afterLoc, n.objectLocation+"/")
+	if !ok {
 		return DefaultKey{}, errInvalidKey(raw,
-			fmt.Sprintf("hash key objectLocation %q does not match %q", objLoc, n.objectLocation))
+			fmt.Sprintf("hash key objectLocation does not match %q", n.objectLocation))
 	}
 
 	err := validateNamePart(raw, after, "hash")
@@ -417,14 +444,10 @@ func (n *layeredNamer) parseSigKey(raw, rest string) (DefaultKey, error) {
 }
 
 func (n *layeredNamer) parseCompactSigKey(raw, rest string) (DefaultKey, error) {
-	objLoc, after, found := strings.Cut(rest, "/")
-	if !found || objLoc == "" {
-		return DefaultKey{}, errInvalidKey(raw, "sig key missing objectLocation")
-	}
-
-	if objLoc != n.objectLocation {
+	after, ok := strings.CutPrefix(rest, n.objectLocation+"/")
+	if !ok {
 		return DefaultKey{}, errInvalidKey(raw,
-			fmt.Sprintf("sig key objectLocation %q does not match %q", objLoc, n.objectLocation))
+			fmt.Sprintf("sig key objectLocation does not match %q", n.objectLocation))
 	}
 
 	err := validateNamePart(raw, after, "sig")
@@ -446,14 +469,10 @@ func (n *layeredNamer) parseFullSigKey(raw, rest string) (DefaultKey, error) {
 		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown sig location %q", sigLoc))
 	}
 
-	objLoc, after, found := strings.Cut(afterLoc, "/")
-	if !found || objLoc == "" {
-		return DefaultKey{}, errInvalidKey(raw, "sig key missing objectLocation")
-	}
-
-	if objLoc != n.objectLocation {
+	after, ok := strings.CutPrefix(afterLoc, n.objectLocation+"/")
+	if !ok {
 		return DefaultKey{}, errInvalidKey(raw,
-			fmt.Sprintf("sig key objectLocation %q does not match %q", objLoc, n.objectLocation))
+			fmt.Sprintf("sig key objectLocation does not match %q", n.objectLocation))
 	}
 
 	err := validateNamePart(raw, after, "sig")

--- a/namer/layered_test.go
+++ b/namer/layered_test.go
@@ -51,8 +51,13 @@ func TestLayeredNamer_Constructor_Validation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "objectLocation with inner slash",
+			name:    "objectLocation with inner slash is valid (multi-segment)",
 			args:    args{objectLocation: "obj/ects", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: false,
+		},
+		{
+			name:    "objectLocation with empty inner segment",
+			args:    args{objectLocation: "a//b", hashLocations: nil, sigLocations: nil, opts: nil},
 			wantErr: true,
 		},
 		{
@@ -64,6 +69,21 @@ func TestLayeredNamer_Constructor_Validation(t *testing.T) {
 			name:    "objectLocation reserved: sig",
 			args:    args{objectLocation: "sig", hashLocations: nil, sigLocations: nil, opts: nil},
 			wantErr: true,
+		},
+		{
+			name:    "objectLocation with reserved first segment: hash/foo",
+			args:    args{objectLocation: "hash/foo", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name:    "objectLocation with reserved first segment: sig/foo",
+			args:    args{objectLocation: "sig/foo", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: true,
+		},
+		{
+			name:    "objectLocation with non-reserved segments and inner /",
+			args:    args{objectLocation: "settings/ldap", hashLocations: nil, sigLocations: nil, opts: nil},
+			wantErr: false,
 		},
 		{
 			name: "hash Location with leading slash",
@@ -727,4 +747,111 @@ func TestLayeredNamer_Prefix(t *testing.T) {
 			assert.Equal(t, tt.expected, got)
 		})
 	}
+}
+
+// TestLayeredNamer_MultiSegmentObjectLocation covers the round-trip of value,
+// hash, and sig keys when objectLocation is itself a multi-segment path
+// (e.g. "settings/ldap"). The full and compact layouts are both exercised.
+func TestLayeredNamer_MultiSegmentObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	const objLoc = "settings/ldap"
+
+	t.Run("value key generate and parse", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(objLoc, nil, nil)
+		require.NoError(t, err)
+
+		keys, err := layeredN.GenerateNames("entry-1")
+		require.NoError(t, err)
+		require.Len(t, keys, 1)
+		assert.Equal(t, "/settings/ldap/entry-1", keys[0].Build())
+
+		parsed, err := layeredN.ParseKey("/settings/ldap/entry-1")
+		require.NoError(t, err)
+		assert.Equal(t, namer.KeyTypeValue, parsed.Type())
+		assert.Equal(t, "entry-1", parsed.Name())
+	})
+
+	t.Run("full hash and sig", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(
+			objLoc,
+			[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+			[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		)
+		require.NoError(t, err)
+
+		keys, err := layeredN.GenerateNames("entry-1")
+		require.NoError(t, err)
+		require.Len(t, keys, 3)
+		assert.Equal(t, "/settings/ldap/entry-1", keys[0].Build())
+		assert.Equal(t, "/hash/sha256/settings/ldap/entry-1", keys[1].Build())
+		assert.Equal(t, "/sig/ed25519/settings/ldap/entry-1", keys[2].Build())
+
+		// Round-trip each key.
+		for _, k := range keys {
+			parsed, err := layeredN.ParseKey(k.Build())
+			require.NoError(t, err, "ParseKey(%q)", k.Build())
+			assert.Equal(t, k.Type(), parsed.Type())
+			assert.Equal(t, k.Name(), parsed.Name())
+			assert.Equal(t, k.Property(), parsed.Property())
+		}
+	})
+
+	t.Run("compact hash and sig", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(
+			objLoc,
+			[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+			[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+			namer.CompactSingleHash(),
+			namer.CompactSingleSig(),
+		)
+		require.NoError(t, err)
+
+		keys, err := layeredN.GenerateNames("entry-1")
+		require.NoError(t, err)
+		require.Len(t, keys, 3)
+		assert.Equal(t, "/settings/ldap/entry-1", keys[0].Build())
+		assert.Equal(t, "/hash/settings/ldap/entry-1", keys[1].Build())
+		assert.Equal(t, "/sig/settings/ldap/entry-1", keys[2].Build())
+
+		for _, k := range keys {
+			parsed, err := layeredN.ParseKey(k.Build())
+			require.NoError(t, err, "ParseKey(%q)", k.Build())
+			assert.Equal(t, k.Type(), parsed.Type())
+			assert.Equal(t, k.Name(), parsed.Name())
+		}
+	})
+
+	t.Run("parse rejects mismatching prefix", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(objLoc, nil, nil)
+		require.NoError(t, err)
+
+		// Right first segment, wrong second segment — must not be misread as
+		// a value at "/settings/ldap/...".
+		_, err = layeredN.ParseKey("/settings/oauth/entry-1")
+		require.Error(t, err)
+
+		// Truncated — first segment matches, but the full prefix does not.
+		_, err = layeredN.ParseKey("/settings")
+		require.Error(t, err)
+	})
+
+	t.Run("Prefix produces correct walk root", func(t *testing.T) {
+		t.Parallel()
+
+		layeredN, err := namer.NewLayeredNamer(objLoc, nil, nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, "/settings/ldap/", layeredN.Prefix("", false))
+		assert.Equal(t, "/settings/ldap/alice", layeredN.Prefix("alice", false))
+		assert.Equal(t, "/settings/ldap/users/", layeredN.Prefix("users", true))
+	})
 }


### PR DESCRIPTION
`LayeredNamer.WithObjectLocation` rejected any value containing an inner `/`, so callers couldn't group related codecs under a shared parent (e.g. `"settings/ldap"`, `"settings/auth"`). The check was a blanket segment validator inherited from the single-segment design.

Replace the inner-slash check with a `CutPrefix`-based parser that walks the segments. The reserved-marker check now applies only to the first segment, so `"hash/foo"` and `"sig/foo"` remain rejected because they would collide with the hash/sig key dispatch — but `"settings/ldap"` and similar nested paths are accepted.

`ParseKey` round-trips multi-segment locations unambiguously. README and codec tests cover the new shapes.

Closes TNTP-7709