### PR TITLE
integrity: add SingletonStore[T] for fixed-key configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   inner `/`. The reserved-marker check still applies to the first segment,
   so `objectLocation` values like `"hash/foo"` or `"sig/foo"` remain
   rejected because they would collide with the hash/sig key dispatch.
+- integrity.SingletonStore[T] + `Codec[T].BindSingleton`: bind a codec to
+  one fixed name at construction time, then call
+  `Get`/`Put`/`Delete`/`Watch` and `TxGet`/`TxPut`/`TxDelete` without
+  threading the name through every call. Suited for configuration
+  objects that live at a single known key (e.g. `/settings/auth`)
+  instead of under a directory of `<objectLocation>/<id>` items. The
+  on-disk layout is identical to `Store[T]` for the same name — no
+  separate codec, no separate namer.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 .PHONY: testrace
 testrace:
 	@echo "Running tests with race flag"
-	@go test ./... -count=100 -race -v
+	@go test ./... -count=100 -race -v -timeout 30m
 
 .PHONY: coverage
 coverage:

--- a/README.md
+++ b/README.md
@@ -456,6 +456,49 @@ segment of `objectLocation` must not equal the reserved markers `hash` or
 per-hasher / per-signer segment when exactly one is configured. `ParseKey`
 parses a raw key back to `(name, KeyType, property)` unambiguously.
 
+##### Singleton Store: One Fixed Key per Codec
+
+For configuration objects that live at a single, known key (e.g.
+`/settings/auth`) — not under a directory of `<objectLocation>/<id>`
+items — `Codec[T].BindSingleton(storage, name)` returns a
+`*SingletonStore[T]` that bakes the name in once. All operations
+(`Get` / `Put` / `Delete` / `Watch`, plus `TxGet` / `TxPut` / `TxDelete`
+for multi-op transactions) drop the `name` parameter:
+
+```go
+codec, err := integrity.NewCodecBuilder[AuthConfig]().
+    WithObjectLocation("settings").
+    WithSignerVerifier(crypto.NewRSAPSSSignerVerifier(*privKey)).
+    Build()
+if err != nil {
+    log.Fatal(err)
+}
+
+auth, err := codec.BindSingleton(baseStorage, "auth")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Wire layout:
+//   /settings/auth                      (value)
+//   /hash/<hashLoc>/settings/auth       (hash, per hasher)
+//   /sig/<sigLoc>/settings/auth         (sig,  per signer)
+
+if err := auth.Put(ctx, AuthConfig{Issuer: "example"}); err != nil {
+    log.Fatal(err)
+}
+
+res, err := auth.Get(ctx)
+```
+
+The same `Codec[T]` can serve both shapes: `codec.Bind(storage)` for a
+directory of items keyed by name, `codec.BindSingleton(storage, name)`
+for a fixed singleton. Predicates from the codec (`ValueEqual`,
+`VersionEqual`, etc.) are name-agnostic and work as-is when passed
+through `WithPutPredicates(...)` / `WithDeletePredicates(...)`. For
+multi-op transactions, `auth.BindPredicate(pred)` resolves the predicate
+to the singleton's value-layer key for use in `Tx.If`.
+
 ##### Marshallers
 
 Beyond the default YAML marshaller, the `marshaller` package now ships:

--- a/integrity/codec.go
+++ b/integrity/codec.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 
+	storage "github.com/tarantool/go-storage"
 	"github.com/tarantool/go-storage/crypto"
 	"github.com/tarantool/go-storage/hasher"
 	"github.com/tarantool/go-storage/marshaller"
@@ -417,4 +418,21 @@ func (b CodecBuilder[T]) Build() (*Codec[T], error) {
 		namer:      topNamer,
 		marshaller: marsh,
 	}, nil
+}
+
+// Bind creates a new Store[T] by binding c to the given storage. Bind is a
+// cheap struct literal — no caching, no validation.
+func (c *Codec[T]) Bind(s storage.Storage) *Store[T] {
+	return &Store[T]{codec: c, storage: s}
+}
+
+// BindSingleton binds c to s and bakes name into every operation of the
+// returned SingletonStore[T]. The name is validated eagerly with the same
+// rules as Store[T] operations; an invalid name returns ErrInvalidName.
+func (c *Codec[T]) BindSingleton(s storage.Storage, name string) (*SingletonStore[T], error) {
+	if !checkName(name) {
+		return nil, ErrInvalidName
+	}
+
+	return &SingletonStore[T]{store: c.Bind(s), name: name}, nil
 }

--- a/integrity/store.go
+++ b/integrity/store.go
@@ -21,12 +21,6 @@ type Store[T any] struct {
 	storage storage.Storage
 }
 
-// Bind creates a new Store[T] by binding c to the given storage. Bind is a
-// cheap struct literal — no caching, no validation.
-func (c *Codec[T]) Bind(s storage.Storage) *Store[T] {
-	return &Store[T]{codec: c, storage: s}
-}
-
 // Get retrieves and validates a single named value from storage.
 func (s *Store[T]) Get(
 	ctx context.Context,

--- a/integrity/store_singleton.go
+++ b/integrity/store_singleton.go
@@ -1,0 +1,90 @@
+package integrity
+
+import (
+	"context"
+
+	"github.com/tarantool/go-storage/internal/options"
+	"github.com/tarantool/go-storage/predicate"
+	"github.com/tarantool/go-storage/watch"
+)
+
+// SingletonStore[T] is a Store[T] bound to one fixed name. It is intended for
+// configuration-style objects that live at a single, known key (e.g.
+// "/settings/auth") rather than under a directory of "/settings/auth/<id>"
+// items. The name is supplied once at bind time and threaded through every
+// operation, so call sites no longer carry the noisy identifier.
+//
+// Construct one via Codec[T].BindSingleton. The wire layout is identical to
+// what Store[T] produces for the same name — no separate codec, no separate
+// namer.
+type SingletonStore[T any] struct {
+	store *Store[T]
+	name  string
+}
+
+// Get reads the singleton's value and verifies its hashes/signatures.
+func (s *SingletonStore[T]) Get(
+	ctx context.Context,
+	opts ...options.OptionCallback[getOptions],
+) (ValidatedResult[T], error) {
+	return s.store.Get(ctx, s.name, opts...)
+}
+
+// Put writes value under the singleton's bound name with integrity protection.
+// WithPutPredicates(...) makes the write conditional; ErrPredicateFailed is
+// returned if any predicate fails.
+func (s *SingletonStore[T]) Put(
+	ctx context.Context,
+	value T,
+	opts ...options.OptionCallback[putOptions],
+) error {
+	return s.store.Put(ctx, s.name, value, opts...)
+}
+
+// Delete removes the singleton's value, hash, and signature keys.
+// WithDeletePredicates(...) makes the delete conditional; ErrPredicateFailed
+// is returned if any predicate fails.
+func (s *SingletonStore[T]) Delete(
+	ctx context.Context,
+	opts ...options.OptionCallback[deleteOptions],
+) error {
+	return s.store.Delete(ctx, s.name, opts...)
+}
+
+// Watch returns a channel that receives events when the singleton's
+// value-layer key changes. Hash and signature key changes are not surfaced —
+// consumers re-fetch on signal, which re-runs verification.
+func (s *SingletonStore[T]) Watch(ctx context.Context) (<-chan watch.Event, error) {
+	return s.store.Watch(ctx, s.name)
+}
+
+// TxGet enqueues a Get for the singleton onto branch b, returning a future
+// whose Result() is populated after Commit. Mirrors Codec[T].TxGet without
+// the name parameter — the bound name is used.
+func (s *SingletonStore[T]) TxGet(
+	b Branchable,
+	opts ...options.OptionCallback[getOptions],
+) *GetFuture[T] {
+	return s.store.codec.TxGet(b, s.name, opts...)
+}
+
+// TxPut enqueues a Put for the singleton onto branch b. Mirrors
+// Codec[T].TxPut without the name parameter.
+func (s *SingletonStore[T]) TxPut(b Branchable, value T) error {
+	return s.store.codec.TxPut(b, s.name, value)
+}
+
+// TxDelete enqueues a Delete for the singleton onto branch b. Mirrors
+// Codec[T].TxDelete without the name parameter.
+func (s *SingletonStore[T]) TxDelete(
+	b Branchable,
+	opts ...options.OptionCallback[deleteOptions],
+) error {
+	return s.store.codec.TxDelete(b, s.name, opts...)
+}
+
+// BindPredicate resolves the singleton's value-layer key and applies p to it,
+// returning a concrete predicate.Predicate ready for use in Tx.If.
+func (s *SingletonStore[T]) BindPredicate(pred Predicate) (predicate.Predicate, error) {
+	return s.store.codec.BindPredicate(s.name, pred)
+}

--- a/integrity/store_singleton_example_test.go
+++ b/integrity/store_singleton_example_test.go
@@ -1,0 +1,52 @@
+package integrity_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+)
+
+type authConfig struct {
+	Issuer string `yaml:"issuer"`
+}
+
+// ExampleCodec_BindSingleton shows the canonical fixed-key configuration
+// pattern: a single object at "/settings/auth" instead of a directory of
+// "/settings/auth/<id>" items. The bound name is supplied once; operations
+// take no name parameter.
+func ExampleCodec_BindSingleton() {
+	ctx := context.Background()
+
+	codec, err := integrity.NewCodecBuilder[authConfig]().
+		WithObjectLocation("settings").
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	if err != nil {
+		log.Fatalf("build codec: %v", err)
+	}
+
+	auth, err := codec.BindSingleton(storage.NewStorage(dummy.New()), "auth")
+	if err != nil {
+		log.Fatalf("bind singleton: %v", err)
+	}
+
+	err = auth.Put(ctx, authConfig{Issuer: "tarantool"})
+	if err != nil {
+		log.Fatalf("put: %v", err)
+	}
+
+	res, err := auth.Get(ctx)
+	if err != nil {
+		log.Fatalf("get: %v", err)
+	}
+
+	fmt.Println("issuer:", res.Value.Unwrap().Issuer)
+
+	// Output:
+	// issuer: tarantool
+}

--- a/integrity/store_singleton_test.go
+++ b/integrity/store_singleton_test.go
@@ -1,0 +1,261 @@
+package integrity_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+)
+
+// newSingletonCodec builds a Codec[SimpleStruct] with objectLocation="settings",
+// one hasher, and one signer/verifier — enough to exercise all three key
+// layers (value/hash/sig).
+func newSingletonCodec(t *testing.T) (*integrity.Codec[SimpleStruct], string) {
+	t.Helper()
+
+	signerVerifier := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().
+		WithObjectLocation("settings").
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithSignerVerifier(signerVerifier).
+		Build()
+	require.NoError(t, err)
+
+	return codec, signerVerifier.Name()
+}
+
+func TestSingletonStore_PutGet(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	auth, err := codec.BindSingleton(storage.NewStorage(dummy.New()), "auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	want := SimpleStruct{Name: "primary", Value: 42}
+
+	require.NoError(t, auth.Put(ctx, want))
+
+	got, err := auth.Get(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "auth", got.Name)
+	assert.Equal(t, want, got.Value.Unwrap())
+}
+
+func TestSingletonStore_WireLayout(t *testing.T) {
+	t.Parallel()
+
+	codec, sigName := newSingletonCodec(t)
+	backend := storage.NewStorage(dummy.New())
+
+	auth, err := codec.BindSingleton(backend, "auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, auth.Put(ctx, SimpleStruct{Name: "x", Value: 1}))
+
+	// Snapshot every key the dummy driver holds. With objectLocation="settings"
+	// and name="auth", we expect exactly the value + hash + sig layers below.
+	all, err := backend.Range(ctx, storage.WithPrefix("/"))
+	require.NoError(t, err)
+
+	keys := make([]string, 0, len(all))
+	for _, kv := range all {
+		keys = append(keys, string(kv.Key))
+	}
+
+	sort.Strings(keys)
+
+	want := []string{
+		"/hash/sha256/settings/auth",
+		"/settings/auth",
+		"/sig/" + sigName + "/settings/auth",
+	}
+	sort.Strings(want)
+
+	assert.Equal(t, want, keys)
+}
+
+func TestCodec_BindSingleton_RejectsInvalidName(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+
+	for _, bad := range []string{"", "/auth", "auth/", "/auth/"} {
+		t.Run("name="+bad, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := codec.BindSingleton(storage.NewStorage(dummy.New()), bad)
+			require.ErrorIs(t, err, integrity.ErrInvalidName)
+		})
+	}
+}
+
+func TestSingletonStore_Delete(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	backend := storage.NewStorage(dummy.New())
+
+	auth, err := codec.BindSingleton(backend, "auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, auth.Put(ctx, SimpleStruct{Name: "x", Value: 1}))
+
+	pre, err := backend.Range(ctx, storage.WithPrefix("/"))
+	require.NoError(t, err)
+	require.Len(t, pre, 3, "expected value+hash+sig keys present before delete")
+
+	require.NoError(t, auth.Delete(ctx))
+
+	post, err := backend.Range(ctx, storage.WithPrefix("/"))
+	require.NoError(t, err)
+	assert.Empty(t, post, "Delete should remove value+hash+sig keys")
+}
+
+func TestSingletonStore_Put_PredicateFails(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+
+	auth, err := codec.BindSingleton(storage.NewStorage(dummy.New()), "auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, auth.Put(ctx, SimpleStruct{Name: "v1", Value: 1}))
+
+	// Predicate matches a value we never wrote — Put must fail.
+	pred, err := codec.ValueEqual(SimpleStruct{Name: "never-written", Value: 0})
+	require.NoError(t, err)
+
+	err = auth.Put(ctx, SimpleStruct{Name: "v2", Value: 2}, integrity.WithPutPredicates(pred))
+	require.ErrorIs(t, err, integrity.ErrPredicateFailed)
+
+	// Sanity: the original value is still there.
+	got, err := auth.Get(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, SimpleStruct{Name: "v1", Value: 1}, got.Value.Unwrap())
+}
+
+func TestSingletonStore_TxRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	backend := storage.NewStorage(dummy.New())
+
+	auth, err := codec.BindSingleton(backend, "auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// TxPut and TxGet inside the same transaction-like sequence: write, commit,
+	// then a separate read transaction returns the future result.
+	writeTx := integrity.NewTx(backend)
+	require.NoError(t, auth.TxPut(writeTx, SimpleStruct{Name: "x", Value: 7}))
+
+	_, err = writeTx.Commit(ctx)
+	require.NoError(t, err)
+
+	readTx := integrity.NewTx(backend)
+	fut := auth.TxGet(readTx)
+
+	_, err = readTx.Commit(ctx)
+	require.NoError(t, err)
+
+	got, err := fut.Result()
+	require.NoError(t, err)
+	assert.Equal(t, "auth", got.Name)
+	assert.Equal(t, SimpleStruct{Name: "x", Value: 7}, got.Value.Unwrap())
+}
+
+func TestSingletonStore_TxDelete(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	backend := storage.NewStorage(dummy.New())
+
+	auth, err := codec.BindSingleton(backend, "auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, auth.Put(ctx, SimpleStruct{Name: "x", Value: 1}))
+
+	delTx := integrity.NewTx(backend)
+	require.NoError(t, auth.TxDelete(delTx))
+
+	_, err = delTx.Commit(ctx)
+	require.NoError(t, err)
+
+	post, err := backend.Range(ctx, storage.WithPrefix("/"))
+	require.NoError(t, err)
+	assert.Empty(t, post)
+}
+
+func TestSingletonStore_TxIfBindPredicate(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	backend := storage.NewStorage(dummy.New())
+
+	auth, err := codec.BindSingleton(backend, "auth")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, auth.Put(ctx, SimpleStruct{Name: "v1", Value: 1}))
+
+	// Build a predicate that will not hold (compares against an unwritten value)
+	// and gate a TxPut on it. The transaction must report Succeeded=false and
+	// the value must remain v1.
+	pred, err := codec.ValueEqual(SimpleStruct{Name: "never", Value: 0})
+	require.NoError(t, err)
+
+	bound, err := auth.BindPredicate(pred)
+	require.NoError(t, err)
+
+	txn := integrity.NewTx(backend)
+	txn.If(bound)
+
+	require.NoError(t, auth.TxPut(txn, SimpleStruct{Name: "v2", Value: 2}))
+
+	resp, err := txn.Commit(ctx)
+	require.NoError(t, err)
+	assert.False(t, resp.Succeeded, "predicate should fail and block the put")
+
+	got, err := auth.Get(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, SimpleStruct{Name: "v1", Value: 1}, got.Value.Unwrap())
+}
+
+func TestSingletonStore_Watch(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+
+	auth, err := codec.BindSingleton(storage.NewStorage(dummy.New()), "auth")
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	events, err := auth.Watch(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, auth.Put(ctx, SimpleStruct{Name: "first", Value: 1}))
+
+	select {
+	case ev, ok := <-events:
+		require.True(t, ok, "watch channel closed before delivering an event")
+		assert.NotEmpty(t, ev.Prefix)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for watch event")
+	}
+}


### PR DESCRIPTION
`Store[T]` is shaped for directories — every call threads a `name` because the codec is bound to an `objectLocation` directory of `<objectLocation>/<id>` items. Configuration objects don't fit this: they live at a single known key like `/settings/auth`, the name never varies, and threading it through every call site is just noise.

Add `Codec[T].BindSingleton(storage, name)`, returning a `*SingletonStore[T]` with the name baked in. `Get`/`Put`/`Delete`/`Watch` and `TxGet`/`TxPut`/`TxDelete` drop the name parameter. Wire layout is identical to `Store[T]` for the same name — no separate codec, no separate namer, so an existing fixed-key value can be migrated to `SingletonStore` without touching on-disk state.

`Bind` and `BindSingleton` now sit together in `codec.go`; `store_singleton.go` and tests are new.

Closes TNTP-7710