### PR TITLE
storage: reject trailing-slash prefix in Prefixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- storage.Prefixed: signature is now
+  `Prefixed(prefix, inner) (Storage, error)`. A non-empty prefix ending
+  with `/` is rejected with `ErrPrefixTrailingSlash`. The codec namer
+  prepends `/` to every key, so a trailing slash here would silently
+  produce keys like `/foo//objectLocation/name`. Empty prefix still
+  yields a transparent wrapper. Callers must update to handle the
+  returned error.
 - watch: unified all drivers (etcd, dummy, tcs) on a signal-only
   `Event.Prefix` contract. Every driver now emits the watched key with
   any trailing `/` stripped — a signal that something at or under the

--- a/integrity/integration_codec_tx_test.go
+++ b/integrity/integration_codec_tx_test.go
@@ -29,7 +29,10 @@ func integrationPrefix(t *testing.T) string {
 func scopedStorage(t *testing.T, driverInstance driver.Driver) storage.Storage {
 	t.Helper()
 
-	return storage.Prefixed(integrationPrefix(t), storage.NewStorage(driverInstance))
+	st, err := storage.Prefixed(integrationPrefix(t), storage.NewStorage(driverInstance))
+	require.NoError(t, err)
+
+	return st
 }
 
 // newIntegrationCodecStore builds a Codec[IntegrationStruct] and binds it to

--- a/integrity/store_test.go
+++ b/integrity/store_test.go
@@ -85,9 +85,18 @@ func newStoreCodecWithSignerVerifier(t *testing.T, sv crypto.SignerVerifier) *in
 	return codec
 }
 
-func newMockedStore(codec *integrity.Codec[SimpleStruct], driverMock *mocks.DriverMock) *integrity.Store[SimpleStruct] {
+func newMockedStore(
+	t *testing.T,
+	codec *integrity.Codec[SimpleStruct],
+	driverMock *mocks.DriverMock,
+) *integrity.Store[SimpleStruct] {
+	t.Helper()
+
 	st := storage.NewStorage(driverMock)
-	return codec.Bind(storage.Prefixed(storeTestPrefix, st))
+	prefixed, err := storage.Prefixed(storeTestPrefix, st)
+	require.NoError(t, err)
+
+	return codec.Bind(prefixed)
 }
 
 // newLayeredNamer reproduces the codec's internal namer so tests can compute
@@ -156,7 +165,7 @@ func TestStore_Get_InvalidName(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -177,7 +186,7 @@ func TestStore_Put_InvalidName(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -198,7 +207,7 @@ func TestStore_Delete_InvalidName(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -219,7 +228,7 @@ func TestStore_Range_InvalidName(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -232,7 +241,7 @@ func TestStore_Watch_InvalidName(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -249,7 +258,7 @@ func TestStore_Get_Success(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -305,7 +314,7 @@ func TestStore_Get_ExecutionError(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -333,7 +342,7 @@ func TestStore_Get_NotFound(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -369,7 +378,7 @@ func TestStore_Get_VerificationError(t *testing.T) {
 
 	mockH := newMockHasher("sha256")
 	codec := newStoreCodecWithHasher(t, mockH)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	ctx := context.Background()
 
@@ -423,7 +432,7 @@ func TestStore_Get_WithIgnoreVerificationError(t *testing.T) {
 
 	mockH := newMockHasher("sha256")
 	codec := newStoreCodecWithHasher(t, mockH)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	ctx := context.Background()
 
@@ -479,7 +488,7 @@ func TestStore_Get_WithIgnoreMoreThanOneResult(t *testing.T) {
 
 	driverMock := mocks.NewDriverMock(t)
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -529,7 +538,7 @@ func TestStore_Get_WithHasher(t *testing.T) {
 
 	mockH := newMockHasher("sha256")
 	codec := newStoreCodecWithHasher(t, mockH)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, []string{"sha256"}, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -592,7 +601,7 @@ func TestStore_Get_WithVerifier(t *testing.T) {
 
 	mockV := &mockVerifier{name: "rsa", verifyErr: nil}
 	codec := newStoreCodecWithVerifier(t, mockV)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, []string{"rsa"})
 	keys, err := testNamer.GenerateNames("my-object")
@@ -668,7 +677,10 @@ func TestStore_Get_NamerGenerateNamesError(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	store := codec.Bind(storage.Prefixed(storeTestPrefix, storage.NewStorage(driverMock)))
+	prefixed, errPrefix := storage.Prefixed(storeTestPrefix, storage.NewStorage(driverMock))
+	require.NoError(t, errPrefix)
+
+	store := codec.Bind(prefixed)
 
 	ctx := context.Background()
 
@@ -686,7 +698,7 @@ func TestStore_Get_PassingModRevision(t *testing.T) {
 
 	driverMock := mocks.NewDriverMock(t)
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -731,7 +743,7 @@ func TestStore_Put_Success(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	generator := integrity.NewGenerator[SimpleStruct](
@@ -770,7 +782,7 @@ func TestStore_Put_WithPutPredicates(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	generator := integrity.NewGenerator[SimpleStruct](
@@ -817,7 +829,7 @@ func TestStore_Put_WithPredicates_Failed(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	generator := integrity.NewGenerator[SimpleStruct](
@@ -862,7 +874,7 @@ func TestStore_Put_GenerationError(t *testing.T) {
 
 	failingHasher := newMockHasherWithError("sha256", "hash computation failed")
 	codec := newStoreCodecWithHasher(t, failingHasher)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	value := SimpleStruct{Name: "test", Value: 42}
 	err := store.Put(ctx, "my-object", value)
@@ -879,7 +891,7 @@ func TestStore_Put_TransactionExecutionError(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	generator := integrity.NewGenerator[SimpleStruct](
@@ -916,7 +928,7 @@ func TestStore_Put_SignerError(t *testing.T) {
 
 	failingSigner := newMockSignerWithError("rsa", "signature generation failed")
 	codec := newStoreCodecWithSigner(t, failingSigner)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	value := SimpleStruct{Name: "test", Value: 42}
 	err := store.Put(ctx, "my-object", value)
@@ -934,7 +946,7 @@ func TestStore_Put_WithSigner(t *testing.T) {
 
 	mockS := newMockSigner("rsa")
 	codec := newStoreCodecWithSigner(t, mockS)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, []string{"rsa"})
 	keys, err := testNamer.GenerateNames("my-object")
@@ -975,7 +987,7 @@ func TestStore_Put_WithSignerVerifier(t *testing.T) {
 
 	mockSV := &mockSignerVerifier{name: "rsa", signErr: nil, verifyErr: nil}
 	codec := newStoreCodecWithSignerVerifier(t, mockSV)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, []string{"rsa"})
 	keys, err := testNamer.GenerateNames("my-object")
@@ -1019,7 +1031,7 @@ func TestStore_Put_WithMarshaller(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	generator := integrity.NewGenerator[SimpleStruct](
@@ -1054,7 +1066,7 @@ func TestStore_Predicates_ValueOps(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 	codec := newStoreCodec(t)
 	// store not used — just testing predicate factory methods on codec.
-	_ = newMockedStore(codec, driverMock)
+	_ = newMockedStore(t, codec, driverMock)
 
 	// The key for the predicate is whatever the caller passes in.
 	key := []byte("/objects/my-object")
@@ -1108,7 +1120,7 @@ func TestStore_Predicates_VersionOps(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 	codec := newStoreCodec(t)
 
-	_ = newMockedStore(codec, driverMock)
+	_ = newMockedStore(t, codec, driverMock)
 
 	key := []byte("/objects/my-object")
 	version := int64(67)
@@ -1164,7 +1176,7 @@ func TestStore_Delete_Success(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -1193,7 +1205,7 @@ func TestStore_Delete_WithDeletePredicates(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -1224,7 +1236,7 @@ func TestStore_Delete_WithDeletePredicates_Failed(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -1254,7 +1266,7 @@ func TestStore_Delete_TransactionExecutionError(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("my-object")
@@ -1295,7 +1307,10 @@ func TestStore_Delete_NamerGenerateNamesError(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	store := codec.Bind(storage.Prefixed(storeTestPrefix, storage.NewStorage(driverMock)))
+	prefixed, errPrefix := storage.Prefixed(storeTestPrefix, storage.NewStorage(driverMock))
+	require.NoError(t, errPrefix)
+
+	store := codec.Bind(prefixed)
 
 	ctx := context.Background()
 
@@ -1311,7 +1326,7 @@ func TestStore_Delete_Prefix(t *testing.T) {
 	driverMock := mocks.NewDriverMock(t)
 
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	testNamer := newLayeredNamer(t, nil, nil)
 	keys, err := testNamer.GenerateNames("test/")
@@ -1341,7 +1356,7 @@ func TestStore_Delete_PrefixEmptyKey(t *testing.T) {
 	ctx := context.Background()
 	driverMock := mocks.NewDriverMock(t)
 
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	err := store.Delete(ctx, "", integrity.WithPrefix())
 	require.Error(t, err)
@@ -1353,7 +1368,7 @@ func TestStore_Delete_PrefixHasPrefix(t *testing.T) {
 	ctx := context.Background()
 	driverMock := mocks.NewDriverMock(t)
 
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	err := store.Delete(ctx, "/objs/", integrity.WithPrefix())
 	require.Error(t, err)
@@ -1365,7 +1380,7 @@ func TestStore_Delete_PrefixNoSuffix(t *testing.T) {
 	ctx := context.Background()
 	driverMock := mocks.NewDriverMock(t)
 
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	err := store.Delete(ctx, "/objs", integrity.WithPrefix())
 	require.Error(t, err)
@@ -1376,7 +1391,7 @@ func TestStore_Range_Success(t *testing.T) {
 
 	driverMock := mocks.NewDriverMock(t)
 	codec := newStoreCodec(t)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	ctx := context.Background()
 
@@ -1453,7 +1468,7 @@ func TestStore_Range_WithValidationError(t *testing.T) {
 
 	mockH := newMockHasher("sha256")
 	codec := newStoreCodecWithHasher(t, mockH)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	ctx := context.Background()
 
@@ -1497,7 +1512,7 @@ func TestStore_Range_WithIgnoreVerificationError(t *testing.T) {
 
 	mockH := newMockHasher("sha256")
 	codec := newStoreCodecWithHasher(t, mockH)
-	store := newMockedStore(codec, driverMock)
+	store := newMockedStore(t, codec, driverMock)
 
 	ctx := context.Background()
 
@@ -1545,7 +1560,7 @@ func TestStore_Range_ExecutionError(t *testing.T) {
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -1569,7 +1584,7 @@ func TestStore_Range_WithIgnoreVerificationErrorButFailedToDecode(t *testing.T) 
 	t.Parallel()
 
 	driverMock := mocks.NewDriverMock(t)
-	store := newMockedStore(newStoreCodec(t), driverMock)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
 
 	ctx := context.Background()
 
@@ -1632,7 +1647,10 @@ func TestStore_WithNamer(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 
-	store := codec.Bind(storage.Prefixed(storeTestPrefix, storage.NewStorage(driverMock)))
+	prefixed, errPrefix := storage.Prefixed(storeTestPrefix, storage.NewStorage(driverMock))
+	require.NoError(t, errPrefix)
+
+	store := codec.Bind(prefixed)
 
 	require.True(t, constructorCalled, "namer constructor should have been called")
 	require.Equal(t, "objects", capturedObjectLoc)
@@ -1684,7 +1702,7 @@ func TestStore_Watch(t *testing.T) {
 		// Use sha256 hasher so the namer knows the "sha256" location.
 		mockH := newMockHasher("sha256")
 		codec := newStoreCodecWithHasher(t, mockH)
-		store := newMockedStore(codec, driverMock)
+		store := newMockedStore(t, codec, driverMock)
 
 		// Codec namer (LayeredNamer with sha256): Prefix("my-object", false) = "/objects/my-object"
 		// Prefixed wrapper adds "/test" → driver Watch called with "/test/objects/my-object".
@@ -1742,7 +1760,7 @@ func TestStore_Watch(t *testing.T) {
 		driverMock := mocks.NewDriverMock(t)
 
 		codec := newStoreCodec(t)
-		store := newMockedStore(codec, driverMock)
+		store := newMockedStore(t, codec, driverMock)
 
 		absWatchKey := absKeyStr("/objects/my-object")
 		rawCh := make(chan watch.Event)
@@ -1772,7 +1790,7 @@ func TestStore_Watch(t *testing.T) {
 		driverMock := mocks.NewDriverMock(t)
 
 		codec := newStoreCodec(t)
-		store := newMockedStore(codec, driverMock)
+		store := newMockedStore(t, codec, driverMock)
 
 		absWatchKey := absKeyStr("/objects/my-object")
 		rawCh := make(chan watch.Event, 1)
@@ -1801,7 +1819,7 @@ func TestStore_Watch(t *testing.T) {
 
 		driverMock := mocks.NewDriverMock(t)
 		codec := newStoreCodec(t)
-		store := newMockedStore(codec, driverMock)
+		store := newMockedStore(t, codec, driverMock)
 
 		absWatchKey := absKeyStr("/objects/my-object")
 		rawCh := make(chan watch.Event)
@@ -1832,7 +1850,7 @@ func TestStore_Watch(t *testing.T) {
 
 		driverMock := mocks.NewDriverMock(t)
 		codec := newStoreCodec(t)
-		store := newMockedStore(codec, driverMock)
+		store := newMockedStore(t, codec, driverMock)
 
 		absWatchKey := absKeyStr("/objects/my-object")
 		rawCh := make(chan watch.Event, 1)
@@ -1867,7 +1885,7 @@ func TestStore_Watch(t *testing.T) {
 
 		driverMock := mocks.NewDriverMock(t)
 		codec := newStoreCodec(t)
-		store := newMockedStore(codec, driverMock)
+		store := newMockedStore(t, codec, driverMock)
 
 		absWatchKey := absKeyStr("/objects/my-object")
 		rawCh := make(chan watch.Event, 1)

--- a/prefix.go
+++ b/prefix.go
@@ -3,7 +3,9 @@ package storage
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/tarantool/go-storage/kv"
 	"github.com/tarantool/go-storage/operation"
@@ -11,6 +13,11 @@ import (
 	txPkg "github.com/tarantool/go-storage/tx"
 	"github.com/tarantool/go-storage/watch"
 )
+
+// ErrPrefixTrailingSlash is returned by Prefixed when the prefix ends with
+// "/". The codec namer prepends "/" to every key, so a trailing slash here
+// would produce keys like "/foo//objectLocation/name".
+var ErrPrefixTrailingSlash = errors.New("storage.Prefixed: prefix must not end with '/'")
 
 // Prefixed returns a Storage that scopes every operation, predicate, range,
 // and watch under prefix. Keys returned to the caller (RequestResponse.Values,
@@ -21,8 +28,15 @@ import (
 // Nested wrappers are flattened at construction so the outer prefix is the
 // leftmost segment.
 //
-// An empty prefix yields a transparent wrapper.
-func Prefixed(prefix string, inner Storage) Storage {
+// An empty prefix yields a transparent wrapper. A non-empty prefix must not
+// end with "/" (returns ErrPrefixTrailingSlash) — the codec namer prepends
+// "/" to every key, so a trailing slash here would produce keys like
+// "/foo//objectLocation/name".
+func Prefixed(prefix string, inner Storage) (Storage, error) {
+	if prefix != "" && strings.HasSuffix(prefix, "/") {
+		return nil, fmt.Errorf("%w: %q", ErrPrefixTrailingSlash, prefix)
+	}
+
 	if existing, ok := inner.(*prefixed); ok {
 		merged := make([]byte, 0, len(prefix)+len(existing.prefix))
 
@@ -32,13 +46,13 @@ func Prefixed(prefix string, inner Storage) Storage {
 		return &prefixed{
 			prefix: merged,
 			inner:  existing.inner,
-		}
+		}, nil
 	}
 
 	return &prefixed{
 		prefix: []byte(prefix),
 		inner:  inner,
-	}
+	}, nil
 }
 
 type prefixed struct {

--- a/prefix_example_test.go
+++ b/prefix_example_test.go
@@ -18,9 +18,13 @@ import (
 func ExamplePrefixed() {
 	ctx := context.Background()
 	base := storage.NewStorage(dummy.New())
-	scoped := storage.Prefixed("/ns", base)
 
-	_, err := scoped.Tx(ctx).Then(
+	scoped, err := storage.Prefixed("/ns", base)
+	if err != nil {
+		log.Fatalf("prefix: %v", err)
+	}
+
+	_, err = scoped.Tx(ctx).Then(
 		operation.Put([]byte("/cfg/version"), []byte("1.0.0")),
 	).Commit()
 	if err != nil {
@@ -48,9 +52,18 @@ func ExamplePrefixed() {
 func ExamplePrefixed_nested() {
 	ctx := context.Background()
 	base := storage.NewStorage(dummy.New())
-	outer := storage.Prefixed("/a", storage.Prefixed("/b", base))
 
-	_, err := outer.Tx(ctx).Then(
+	inner, err := storage.Prefixed("/b", base)
+	if err != nil {
+		log.Fatalf("prefix /b: %v", err)
+	}
+
+	outer, err := storage.Prefixed("/a", inner)
+	if err != nil {
+		log.Fatalf("prefix /a: %v", err)
+	}
+
+	_, err = outer.Tx(ctx).Then(
 		operation.Put([]byte("/k"), []byte("v")),
 	).Commit()
 	if err != nil {
@@ -76,9 +89,13 @@ func ExamplePrefixed_nested() {
 // the configured prefix, so conditional transactions stay scoped.
 func ExamplePrefixed_predicates() {
 	ctx := context.Background()
-	scoped := storage.Prefixed("/ns", storage.NewStorage(dummy.New()))
 
-	_, err := scoped.Tx(ctx).Then(
+	scoped, err := storage.Prefixed("/ns", storage.NewStorage(dummy.New()))
+	if err != nil {
+		log.Fatalf("prefix: %v", err)
+	}
+
+	_, err = scoped.Tx(ctx).Then(
 		operation.Put([]byte("/feature"), []byte("on")),
 	).Commit()
 	if err != nil {

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -82,6 +82,38 @@ func (t *recordingTx) Commit() (txPkg.Response, error) {
 	return t.rec.txResp, t.rec.txErr
 }
 
+func mustPrefix(t *testing.T, prefix string, inner storage.Storage) storage.Storage {
+	t.Helper()
+
+	s, err := storage.Prefixed(prefix, inner)
+	require.NoError(t, err)
+
+	return s
+}
+
+func TestPrefixed_RejectsTrailingSlash(t *testing.T) {
+	t.Parallel()
+
+	inner := &recordingStorage{
+		lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+		txResp:       txPkg.Response{Succeeded: true, Results: nil},
+		txErr:        nil,
+		lastWatchKey: nil,
+		watchEvents:  nil,
+	}
+
+	cases := []string{"/", "/ns/", "/a/b/"}
+	for _, prefix := range cases {
+		t.Run(prefix, func(t *testing.T) {
+			t.Parallel()
+
+			s, err := storage.Prefixed(prefix, inner)
+			assert.Nil(t, s)
+			require.ErrorIs(t, err, storage.ErrPrefixTrailingSlash)
+		})
+	}
+}
+
 func TestPrefixed_OperationKeyPrefixing(t *testing.T) {
 	t.Parallel()
 
@@ -99,7 +131,7 @@ func TestPrefixed_OperationKeyPrefixing(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		_, err := prefixedStore.Tx(ctx).
 			Then(operation.Put([]byte("key"), []byte("val"))).
@@ -124,7 +156,7 @@ func TestPrefixed_OperationKeyPrefixing(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		_, err := prefixedStore.Tx(ctx).
 			Then(operation.Get([]byte("foo"))).
@@ -148,7 +180,7 @@ func TestPrefixed_OperationKeyPrefixing(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		_, err := prefixedStore.Tx(ctx).
 			Else(operation.Delete([]byte("bar"))).
@@ -172,7 +204,7 @@ func TestPrefixed_OperationKeyPrefixing(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed("", inner)
+		prefixedStore := mustPrefix(t, "", inner)
 
 		_, err := prefixedStore.Tx(ctx).
 			Then(operation.Put([]byte("key"), []byte("val"))).
@@ -193,7 +225,7 @@ func TestPrefixed_OperationKeyPrefixing(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		_, err := prefixedStore.Tx(ctx).
 			Then(
@@ -284,7 +316,7 @@ func TestPrefixed_PredicateKeyPrefixing(t *testing.T) {
 				lastWatchKey: nil,
 				watchEvents:  nil,
 			}
-			prefixedStore := storage.Prefixed(namespace, inner)
+			prefixedStore := mustPrefix(t, namespace, inner)
 
 			callerKey := []byte("mykey")
 			pred := testCase.build(callerKey)
@@ -322,7 +354,7 @@ func TestPrefixed_Range(t *testing.T) {
 
 		mockDriver := mocks.NewDriverMock(t)
 		inner := storage.NewStorage(mockDriver)
-		prefixedStore := storage.Prefixed("/test", inner)
+		prefixedStore := mustPrefix(t, "/test", inner)
 
 		// "/test" + "/foo" + trailing "/" added by storage.go.
 		combinedKey := []byte("/test/foo/")
@@ -355,7 +387,7 @@ func TestPrefixed_Range(t *testing.T) {
 		// not invoke the driver at all — hence no ExecuteMock expectation.
 		mockDriver := mocks.NewDriverMock(t)
 		inner := storage.NewStorage(mockDriver)
-		prefixedStore := storage.Prefixed("/test", inner)
+		prefixedStore := mustPrefix(t, "/test", inner)
 
 		kvs, err := prefixedStore.Range(ctx)
 		require.NoError(t, err)
@@ -369,7 +401,7 @@ func TestPrefixed_Range(t *testing.T) {
 
 		mockDriver := mocks.NewDriverMock(t)
 		inner := storage.NewStorage(mockDriver)
-		prefixedStore := storage.Prefixed("/ns", inner)
+		prefixedStore := mustPrefix(t, "/ns", inner)
 
 		absKVs := []kv.KeyValue{
 			{Key: []byte("/ns/obj/x"), Value: []byte("val-x"), ModRevision: 1},
@@ -415,7 +447,7 @@ func TestPrefixed_Watch(t *testing.T) {
 				{Prefix: []byte("/testfoo")},
 			},
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		watchCh := prefixedStore.Watch(ctx, []byte("foo"))
 
@@ -441,7 +473,7 @@ func TestPrefixed_Watch(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		watchCh := prefixedStore.Watch(ctx, []byte("k"))
 
@@ -463,7 +495,7 @@ func TestPrefixed_Watch(t *testing.T) {
 		// goroutine has nothing to drain and can only exit via ctx.Done().
 		blockCh := make(chan watch.Event)
 		blockInner := &blockingWatchStorage{ch: blockCh}
-		prefixedStore := storage.Prefixed(namespace, blockInner)
+		prefixedStore := mustPrefix(t, namespace, blockInner)
 
 		ctx2, cancel := context.WithCancel(ctx)
 
@@ -524,7 +556,7 @@ func TestPrefixed_Composition(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		composed := storage.Prefixed("/a", storage.Prefixed("/b", base))
+		composed := mustPrefix(t, "/a", mustPrefix(t, "/b", base))
 
 		_, err := composed.Tx(ctx).
 			Then(operation.Put([]byte("k"), []byte("v"))).
@@ -554,8 +586,8 @@ func TestPrefixed_Composition(t *testing.T) {
 			watchEvents:  nil,
 		}
 
-		composed := storage.Prefixed("/a", storage.Prefixed("/b", base1))
-		flat := storage.Prefixed("/a/b", base2)
+		composed := mustPrefix(t, "/a", mustPrefix(t, "/b", base1))
+		flat := mustPrefix(t, "/a/b", base2)
 
 		callerKey := []byte("/obj/name")
 		callerVal := []byte("data")
@@ -583,7 +615,7 @@ func TestPrefixed_Composition(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		composed := storage.Prefixed("/a", storage.Prefixed("/b", storage.Prefixed("/c", base)))
+		composed := mustPrefix(t, "/a", mustPrefix(t, "/b", mustPrefix(t, "/c", base)))
 
 		_, err := composed.Tx(ctx).
 			Then(operation.Put([]byte("x"), []byte("v"))).
@@ -623,7 +655,7 @@ func TestPrefixed_ResultKeyStripping(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		resp, err := prefixedStore.Tx(ctx).
 			Then(operation.Get([]byte("a")), operation.Get([]byte("c"))).
@@ -658,7 +690,7 @@ func TestPrefixed_ResultKeyStripping(t *testing.T) {
 			lastWatchKey: nil,
 			watchEvents:  nil,
 		}
-		prefixedStore := storage.Prefixed(namespace, inner)
+		prefixedStore := mustPrefix(t, namespace, inner)
 
 		resp, err := prefixedStore.Tx(ctx).Then(operation.Get([]byte("x"))).Commit()
 		require.NoError(t, err)
@@ -672,7 +704,7 @@ func TestPrefixed_ResultKeyStripping(t *testing.T) {
 
 		mockDriver := mocks.NewDriverMock(t)
 		inner := storage.NewStorage(mockDriver)
-		prefixedStore := storage.Prefixed("/ns", inner)
+		prefixedStore := mustPrefix(t, "/ns", inner)
 
 		absKVs := []kv.KeyValue{
 			{Key: []byte("/ns/objects/myname"), Value: []byte("data"), ModRevision: 1},


### PR DESCRIPTION
- `storage.Prefixed` now returns `(Storage, error)` and rejects a non-empty prefix ending with `/` via `ErrPrefixTrailingSlash`.
- The codec namer prepends `/` to every key, so a trailing slash here silently produced keys like `/foo//objectLocation/name` (caught by Georgy in review).
- Empty prefix still yields a transparent wrapper.
- All in-tree callers updated; tests gain a `mustPrefix` helper to keep the new error return out of every test body.