### PR TITLE
integrity: fix empty Range dropping every result under integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- namer.Namer: new `Prefixes(val, isPrefix) []string` method returning one
+  range prefix per key category (value, hash, sig). `Prefix` only covered
+  the value layer, which makes `Range` miss hash/sig keys when an integrity
+  validator is attached. Both `DefaultNamer` and `LayeredNamer` implement
+  it; third-party implementations of `Namer` must add the method.
 - namer.LayeredNamer: `objectLocation` may now be a multi-segment path
   (e.g. `"settings/ldap"`). Previously the segment validator rejected any
   inner `/`. The reserved-marker check still applies to the first segment,
@@ -35,6 +40,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- integrity: `Store[T].Range(ctx, "")` and `Typed[T].Range(ctx, "")`
+  returned an empty slice as soon as a hasher or signer/verifier was
+  configured. The empty-name branch fetched only the value-layer prefix,
+  so the validator saw no hash/sig keys and dropped every result with a
+  "missing signature/hash" error. Both methods now fan out across every
+  category prefix via the new `Namer.Prefixes` method. With
+  `LayeredNamer` (the `Codec` default) hash and sig keys live at separate
+  roots, so this reproduced for every empty `Range`; with `DefaultNamer`
+  the bug was masked because all categories share a single root prefix.
 - watch: prefix-shaped Watch calls (e.g. `Watch(ctx, "acl/")`) used to
   silently drop every event because drivers emitted the watched key
   with the trailing `/` intact and the integrity layer's `ParseKey`

--- a/integrity/codec_test.go
+++ b/integrity/codec_test.go
@@ -334,6 +334,10 @@ func (n *sentinelNamer) Prefix(val string, _ bool) string {
 	return "/sentinel/" + strings.Trim(val, "/")
 }
 
+func (n *sentinelNamer) Prefixes(val string, isPrefix bool) []string {
+	return []string{n.Prefix(val, isPrefix)}
+}
+
 func TestCodecBuilder_WithNamer(t *testing.T) {
 	t.Parallel()
 

--- a/integrity/integration_codec_tx_test.go
+++ b/integrity/integration_codec_tx_test.go
@@ -225,6 +225,63 @@ func TestStoreIntegration_Range(t *testing.T) {
 	})
 }
 
+// TestStoreIntegration_Range_EmptyWithSignerVerifier is a regression test for
+// the bug where Range(ctx, "") returned no items as soon as a hasher or
+// signer/verifier was configured: the empty-name branch fetched only the
+// value-layer prefix, so validation always reported missing hash/sig keys and
+// every result was filtered out.
+func TestStoreIntegration_Range_EmptyWithSignerVerifier(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		shaHash := hasher.NewSHA256Hasher()
+		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+
+		_, store := newIntegrationCodecStore(t, driverInstance,
+			func(b integrity.CodecBuilder[IntegrationStruct]) integrity.CodecBuilder[IntegrationStruct] {
+				return b.
+					WithHasher(shaHash).
+					WithSignerVerifier(rsaSV).
+					WithObjectLocation("haha")
+			})
+
+		seed := map[string]IntegrationStruct{
+			"key1": {Name: "obj1", Value: 100},
+			"key2": {Name: "obj2", Value: 200},
+		}
+		for name, value := range seed {
+			require.NoError(t, store.Put(ctx, name, value))
+		}
+
+		defer cleanupStore(t, store, "key1", "key2")
+
+		results, err := store.Range(ctx, "")
+		require.NoError(t, err)
+		require.Len(t, results, len(seed))
+
+		for i := range results {
+			results[i].ModRevision = 0
+		}
+
+		expected := []integrity.ValidatedResult[IntegrationStruct]{
+			{
+				Name:        "key1",
+				Value:       option.Some(seed["key1"]),
+				ModRevision: 0,
+				Error:       nil,
+			},
+			{
+				Name:        "key2",
+				Value:       option.Some(seed["key2"]),
+				ModRevision: 0,
+				Error:       nil,
+			},
+		}
+		require.ElementsMatch(t, expected, results)
+	})
+}
+
 // TestStoreIntegration_WithSignerVerifier round-trips a value through a codec
 // with both a hasher and an RSA-PSS signer/verifier; Get must verify cleanly.
 func TestStoreIntegration_WithSignerVerifier(t *testing.T) {

--- a/integrity/integration_test.go
+++ b/integrity/integration_test.go
@@ -605,6 +605,77 @@ func TestTypedIntegration_EmptyRange(t *testing.T) {
 	})
 }
 
+// TestTypedIntegration_EmptyRangeWithVerification is a regression test for
+// Typed.Range(ctx, "") with a hasher and signer/verifier configured: the
+// empty-name branch previously fetched only the value-layer prefix, so
+// validation reported missing hash/sig keys for every entry and the result
+// slice came back empty.
+func TestTypedIntegration_EmptyRangeWithVerification(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		shaHash := hasher.NewSHA256Hasher()
+		rsaVer := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+
+		fillDataOptions := FillDataOptions{
+			Prefix: "/test",
+			Names:  []string{"object1", "object2"},
+			Records: []IntegrationStruct{
+				{
+					Name:  "obj1",
+					Value: 100,
+				},
+				{
+					Name:  "obj2",
+					Value: 200,
+				},
+			},
+			Hashers: []hasher.Hasher{shaHash},
+			Signers: []crypto.Signer{rsaVer},
+		}
+
+		cleanup := fillData(t, driverInstance, fillDataOptions)
+		defer cleanup()
+
+		ctx := t.Context()
+		storageInstance := storage.NewStorage(driverInstance)
+		typed := integrity.NewTypedBuilder[IntegrationStruct](storageInstance).
+			WithPrefix("/test").
+			WithHasher(shaHash).
+			WithSignerVerifier(rsaVer).
+			Build()
+
+		results, err := typed.Range(ctx, "")
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		for i := range results {
+			results[i].ModRevision = 0
+		}
+
+		require.ElementsMatch(t, results, []integrity.ValidatedResult[IntegrationStruct]{
+			{
+				Name: "object1",
+				Value: option.Some[IntegrationStruct](IntegrationStruct{
+					Name:  "obj1",
+					Value: 100,
+				}),
+				ModRevision: 0,
+				Error:       nil,
+			},
+			{
+				Name: "object2",
+				Value: option.Some[IntegrationStruct](IntegrationStruct{
+					Name:  "obj2",
+					Value: 200,
+				}),
+				ModRevision: 0,
+				Error:       nil,
+			},
+		})
+	})
+}
+
 func TestTypedIntegration_RangeWithTrailingSlash(t *testing.T) {
 	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
 		t.Helper()

--- a/integrity/store_test.go
+++ b/integrity/store_test.go
@@ -1471,14 +1471,24 @@ func TestStore_Range_WithValidationError(t *testing.T) {
 	require.Len(t, kvs, 2)
 
 	// Only data KV — hash missing → validation error (object skipped).
+	// Empty Range fans out one Get per category prefix (value + hash); the
+	// hash-prefix Get returns nothing, which is the missing-hash signal.
 	dataKV := kvs[0]
 
-	expectedPrefix := testNamer.Prefix("", true)
-	expectedOps := []operation.Operation{makeAbsoluteGetOp(expectedPrefix)}
+	expectedPrefixes := testNamer.Prefixes("", true)
+	require.Len(t, expectedPrefixes, 2)
+
+	expectedOps := make([]operation.Operation, 0, len(expectedPrefixes))
+	for _, prefix := range expectedPrefixes {
+		expectedOps = append(expectedOps, makeAbsoluteGetOp(prefix))
+	}
 
 	response := tx.Response{
 		Succeeded: true,
-		Results:   []tx.RequestResponse{{Values: []kv.KeyValue{dataKV}}},
+		Results: []tx.RequestResponse{
+			{Values: []kv.KeyValue{dataKV}}, // value-prefix Get: data present.
+			{Values: nil},                   // hash-prefix Get: empty.
+		},
 	}
 
 	driverMock.ExecuteMock.Expect(ctx, []predicate.Predicate{}, expectedOps, nil).Return(response, nil)
@@ -1516,12 +1526,20 @@ func TestStore_Range_WithIgnoreVerificationError(t *testing.T) {
 
 	dataKV := kvs[0]
 
-	expectedPrefix := testNamer.Prefix("", true)
-	expectedOps := []operation.Operation{makeAbsoluteGetOp(expectedPrefix)}
+	expectedPrefixes := testNamer.Prefixes("", true)
+	require.Len(t, expectedPrefixes, 2)
+
+	expectedOps := make([]operation.Operation, 0, len(expectedPrefixes))
+	for _, prefix := range expectedPrefixes {
+		expectedOps = append(expectedOps, makeAbsoluteGetOp(prefix))
+	}
 
 	response := tx.Response{
 		Succeeded: true,
-		Results:   []tx.RequestResponse{{Values: []kv.KeyValue{dataKV}}},
+		Results: []tx.RequestResponse{
+			{Values: []kv.KeyValue{dataKV}}, // value-prefix Get: data present.
+			{Values: nil},                   // hash-prefix Get: empty.
+		},
 	}
 
 	driverMock.ExecuteMock.Expect(ctx, []predicate.Predicate{}, expectedOps, nil).Return(response, nil)

--- a/integrity/tx.go
+++ b/integrity/tx.go
@@ -416,9 +416,12 @@ func (c *Codec[T]) TxRange(
 
 	switch name {
 	case "":
-		prefix := c.namer.Prefix("", true)
-
-		branch.ops = append(branch.ops, operation.Get([]byte(prefix)))
+		// Empty name fans out across every key category — value, hash, sig.
+		// A single Prefix("", true) only covers the value layer, which makes
+		// the validator report missing hash/sig keys for every entry.
+		for _, prefix := range c.namer.Prefixes("", true) {
+			branch.ops = append(branch.ops, operation.Get([]byte(prefix)))
+		}
 	default:
 		keys, err := c.namer.GenerateNames(name)
 		if err != nil {

--- a/integrity/tx_test.go
+++ b/integrity/tx_test.go
@@ -603,6 +603,10 @@ func (n *hashOnlyNamer) ParseKeys(_ []string, _ bool) (namer.Results, error) {
 
 func (n *hashOnlyNamer) Prefix(_ string, _ bool) string { return "/sha256/" }
 
+func (n *hashOnlyNamer) Prefixes(val string, isPrefix bool) []string {
+	return []string{n.Prefix(val, isPrefix)}
+}
+
 func TestTx_ResultDispatchIsolatesCodecs(t *testing.T) {
 	t.Parallel()
 

--- a/integrity/typed.go
+++ b/integrity/typed.go
@@ -387,9 +387,15 @@ func (t *Typed[T]) Range(
 
 	switch name {
 	case "":
-		prefix := t.namer.Prefix(name, true)
+		// Empty name fans out across every key category — value, hash, sig.
+		// A single Prefix(name, true) only covers the value layer, which
+		// makes the validator report missing hash/sig keys for every entry.
+		prefixes := t.namer.Prefixes(name, true)
 
-		ops = []operation.Operation{operation.Get([]byte(prefix))}
+		ops = make([]operation.Operation, 0, len(prefixes))
+		for _, prefix := range prefixes {
+			ops = append(ops, operation.Get([]byte(prefix)))
+		}
 	default:
 		keys, err := t.namer.GenerateNames(name)
 		if err != nil {

--- a/integrity/typed_test.go
+++ b/integrity/typed_test.go
@@ -74,6 +74,10 @@ func (m *mockNamer) Prefix(val string, isPrefix bool) string {
 	}
 }
 
+func (m *mockNamer) Prefixes(val string, isPrefix bool) []string {
+	return []string{m.Prefix(val, isPrefix)}
+}
+
 func TestTypedGet_InvalidName(t *testing.T) {
 	t.Parallel()
 

--- a/namer/layered.go
+++ b/namer/layered.go
@@ -352,6 +352,58 @@ func (n *layeredNamer) Prefix(val string, isPrefix bool) string {
 	return builder.String()
 }
 
+// Prefixes returns one range prefix per key category — value, then one per
+// configured hasher, then one per configured signer. Hash and sig keys live
+// under their own roots (/hash/... and /sig/...), so a single Prefix() call
+// covering only /<objectLocation>/ misses them; this method emits the full
+// fan-out a validating range walk needs.
+func (n *layeredNamer) Prefixes(val string, isPrefix bool) []string {
+	suffix := strings.Trim(val, "/")
+	out := make([]string, 0, 1+len(n.hashLocations)+len(n.sigLocations))
+
+	out = append(out, n.layerPrefix("/"+n.objectLocation+"/", suffix, isPrefix))
+
+	for _, hl := range n.hashLocations {
+		root := "/" + layeredHashMarker + "/"
+		if !n.compactHash {
+			root += hl.Location + "/"
+		}
+
+		root += n.objectLocation + "/"
+
+		out = append(out, n.layerPrefix(root, suffix, isPrefix))
+	}
+
+	for _, sl := range n.sigLocations {
+		root := "/" + layeredSigMarker + "/"
+		if !n.compactSig {
+			root += sl.Location + "/"
+		}
+
+		root += n.objectLocation + "/"
+
+		out = append(out, n.layerPrefix(root, suffix, isPrefix))
+	}
+
+	return out
+}
+
+// layerPrefix appends suffix to a category root, optionally tacking on a
+// trailing slash. Empty suffix returns the root unchanged — the root already
+// ends in "/", so a range scan on it covers the whole category.
+func (n *layeredNamer) layerPrefix(root, suffix string, isPrefix bool) string {
+	if suffix == "" {
+		return root
+	}
+
+	out := root + suffix
+	if isPrefix {
+		out += "/"
+	}
+
+	return out
+}
+
 func (n *layeredNamer) buildHashKey(hashLocation, name string) string {
 	if n.compactHash {
 		return "/" + layeredHashMarker + "/" + n.objectLocation + "/" + name

--- a/namer/layered_test.go
+++ b/namer/layered_test.go
@@ -749,6 +749,78 @@ func TestLayeredNamer_Prefix(t *testing.T) {
 	}
 }
 
+func TestLayeredNamer_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newTestLayeredNamer(t)
+
+	tests := []struct {
+		name     string
+		val      string
+		isPrefix bool
+		expected []string
+	}{
+		{
+			name:     "empty val emits one prefix per category root",
+			val:      "",
+			isPrefix: true,
+			expected: []string{
+				"/objects/",
+				"/hash/sha256/objects/",
+				"/sig/ed25519/objects/",
+			},
+		},
+		{
+			name:     "non-empty val with isPrefix true",
+			val:      "alice",
+			isPrefix: true,
+			expected: []string{
+				"/objects/alice/",
+				"/hash/sha256/objects/alice/",
+				"/sig/ed25519/objects/alice/",
+			},
+		},
+		{
+			name:     "non-empty val with isPrefix false",
+			val:      "alice",
+			isPrefix: false,
+			expected: []string{
+				"/objects/alice",
+				"/hash/sha256/objects/alice",
+				"/sig/ed25519/objects/alice",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.expected, layeredN.Prefixes(tt.val, tt.isPrefix))
+		})
+	}
+}
+
+func TestLayeredNamer_Prefixes_Compact(t *testing.T) {
+	t.Parallel()
+
+	layeredN, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		namer.CompactSingleHash(),
+		namer.CompactSingleSig(),
+	)
+	require.NoError(t, err)
+
+	expected := []string{
+		"/objects/",
+		"/hash/objects/",
+		"/sig/objects/",
+	}
+	assert.Equal(t, expected, layeredN.Prefixes("", true))
+}
+
 // TestLayeredNamer_MultiSegmentObjectLocation covers the round-trip of value,
 // hash, and sig keys when objectLocation is itself a multi-segment path
 // (e.g. "settings/ldap"). The full and compact layouts are both exercised.

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -17,6 +17,13 @@ type Namer interface {
 	ParseKey(name string) (DefaultKey, error)
 	ParseKeys(names []string, ignoreError bool) (Results, error)
 	Prefix(val string, isPrefix bool) string
+	// Prefixes returns one prefix per key category (value, hash, sig) so a
+	// range walk can fetch every key the namer owns. For namers whose
+	// categories share a single root (DefaultNamer) the returned slice may
+	// have a single element. Use this instead of Prefix when validating
+	// integrity-protected data — Prefix only covers the value layer, which
+	// makes the validator report missing hash/sig keys.
+	Prefixes(val string, isPrefix bool) []string
 }
 
 // DefaultNamer represents default namer.
@@ -145,6 +152,43 @@ func (n *DefaultNamer) Prefix(val string, isPrefix bool) string {
 	}
 
 	return builder.String()
+}
+
+// Prefixes returns the range prefixes for every key category. DefaultNamer
+// stores all categories under a single /<prefix>/ root, so the empty-name
+// case collapses to a single prefix. For non-empty names the per-category
+// fan-out matters because each category interleaves an extra path segment.
+func (n *DefaultNamer) Prefixes(val string, isPrefix bool) []string {
+	suffix := strings.Trim(val, "/")
+	if suffix == "" {
+		return []string{n.Prefix(val, isPrefix)}
+	}
+
+	out := make([]string, 0, 1+len(n.hashNames)+len(n.sigNames))
+
+	out = append(out, n.prefixWith(isPrefix, suffix))
+
+	for _, h := range n.hashNames {
+		out = append(out, n.prefixWith(isPrefix, hashName, h, suffix))
+	}
+
+	for _, s := range n.sigNames {
+		out = append(out, n.prefixWith(isPrefix, signatureName, s, suffix))
+	}
+
+	return out
+}
+
+// prefixWith builds a /<prefix>/<elems...> path, optionally suffixed with "/"
+// when isPrefix is true. The trailing slash matches the convention used by
+// Prefix() — callers compose Get(prefix) range scans on this output.
+func (n *DefaultNamer) prefixWith(isPrefix bool, elems ...string) string {
+	out := n.join(elems...)
+	if isPrefix {
+		out += "/"
+	}
+
+	return out
 }
 
 func (n *DefaultNamer) join(elems ...string) string {

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -344,3 +344,71 @@ func TestDefaultNamer_Prefix(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultNamer_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		prefix    string
+		hashNames []string
+		sigNames  []string
+		val       string
+		isPrefix  bool
+		expected  []string
+	}{
+		{
+			name:      "empty val collapses to single root regardless of categories",
+			prefix:    "/storage",
+			hashNames: nil,
+			sigNames:  nil,
+			val:       "",
+			isPrefix:  true,
+			expected:  []string{"/storage/"},
+		},
+		{
+			name:      "empty val with hashers and signers still collapses",
+			prefix:    "/storage",
+			hashNames: []string{"sha256"},
+			sigNames:  []string{"rsa"},
+			val:       "",
+			isPrefix:  true,
+			expected:  []string{"/storage/"},
+		},
+		{
+			name:      "non-empty val fans out per category as prefix",
+			prefix:    "/storage",
+			hashNames: []string{"sha256"},
+			sigNames:  []string{"rsa"},
+			val:       "alice",
+			isPrefix:  true,
+			expected: []string{
+				"/storage/alice/",
+				"/storage/hash/sha256/alice/",
+				"/storage/sig/rsa/alice/",
+			},
+		},
+		{
+			name:      "non-empty val fans out per category, no trailing slash",
+			prefix:    "/storage",
+			hashNames: []string{"sha256"},
+			sigNames:  []string{"rsa"},
+			val:       "alice",
+			isPrefix:  false,
+			expected: []string{
+				"/storage/alice",
+				"/storage/hash/sha256/alice",
+				"/storage/sig/rsa/alice",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			dn := namer.NewDefaultNamer(tt.prefix, tt.hashNames, tt.sigNames)
+			assert.Equal(t, tt.expected, dn.Prefixes(tt.val, tt.isPrefix))
+		})
+	}
+}


### PR DESCRIPTION
`Store[T].Range(ctx, "")` and `Typed[T].Range(ctx, "")` returned an empty slice as soon as a hasher or signer/verifier was attached. The empty-name branch fetched only the value-layer prefix, so when the validator looked for a hash or signature it found nothing and dropped every result with a `missing signature/hash` error. With `LayeredNamer` (the `Codec` default) hash and sig keys live at separate roots, so this reproduced for every empty `Range`; with `DefaultNamer` it was masked because all categories share a single root prefix.

Add `Namer.Prefixes(val, isPrefix) []string` returning one prefix per key category (value, hash, sig). `DefaultNamer` returns its single shared root; `LayeredNamer` returns per-category roots. Both `Range` implementations now fan out via `Prefixes` for the empty-name branch.

Breaking change for third-party `Namer` implementations — they must add `Prefixes`.

Closes TNTP-7707