### PR TITLE
integrity: fix empty-name Watch dropping every event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   rejected it. Drivers now strip the trailing `/`; the integrity store
   filter strips it from the user-supplied name as well so the
   neighbour-codec filter matches both single-key and prefix watches.
+- integrity: `Store[T].Watch(ctx, "")` and `Typed[T].Watch(ctx, "")`
+  (the "watch the whole codec" case) silently dropped every event.
+  Under the signal-only `Event.Prefix` contract drivers always emit
+  the watched prefix verbatim, but the integrity layer was running
+  `ParseKey` on it and dropping anything that did not look like a key
+  — and `/<objectLocation>` is a single segment, which `ParseKey`
+  rejects. The filter was a no-op under the new contract anyway, so
+  both methods now forward driver events as-is.
 
 ## [v1.3.0] - 2026-05-05
 

--- a/integrity/integration_codec_tx_test.go
+++ b/integrity/integration_codec_tx_test.go
@@ -338,6 +338,38 @@ func TestStoreIntegration_Watch(t *testing.T) {
 	})
 }
 
+// Regression: Store[T].Watch with an empty name (the "watch the whole codec"
+// case) used to silently drop every event. Drivers emit the watched prefix
+// with any trailing "/" stripped, so the value reaching the integrity filter
+// was "/<objectLocation>" — a single segment. ParseKey requires at least two
+// segments, so it errored and the filter dropped the event. Watching the
+// empty prefix must deliver events for any key under the codec.
+func TestStoreIntegration_Watch_EmptyName(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		_, store := newIntegrationCodecStore(t, driverInstance, nil)
+
+		eventCh, err := store.Watch(ctx, "")
+		require.NoError(t, err)
+
+		// Give the watch channel time to register before the first write.
+		time.Sleep(200 * time.Millisecond)
+
+		require.NoError(t, store.Put(ctx, "object1", IntegrationStruct{Name: "obj1", Value: 100}))
+
+		select {
+		case ev := <-eventCh:
+			assert.Equal(t, []byte("/objects"), ev.Prefix)
+		case <-time.After(defaultWaitTimeout):
+			t.Fatal("regression: empty-name Watch delivered no events")
+		}
+
+		cleanupStore(t, store, "object1")
+	})
+}
+
 // TestTxIntegration_MultiOpAtomic enqueues multiple TxPut calls onto a single
 // Tx and verifies they all land in one commit.
 func TestTxIntegration_MultiOpAtomic(t *testing.T) {

--- a/integrity/store.go
+++ b/integrity/store.go
@@ -135,6 +135,10 @@ func (s *Store[T]) Range(
 // Watch returns a channel that receives events for values under the given
 // name prefix. Watch is not transactional and bypasses Tx; it calls
 // s.storage.Watch directly.
+//
+// Under the signal-only Event.Prefix contract every event carries the watched
+// prefix verbatim (driver-stripped of its trailing "/"), so filtering on
+// event.Prefix is a no-op — callers must Range/Get to learn what changed.
 func (s *Store[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, error) {
 	if !checkRangeName(name) {
 		return storeClosedChan, ErrInvalidName
@@ -142,45 +146,7 @@ func (s *Store[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, 
 
 	key := s.codec.namer.Prefix(name, strings.HasSuffix(name, "/"))
 
-	rawCh := s.storage.Watch(ctx, []byte(key))
-	filteredCh := make(chan watch.Event)
-
-	// Drivers strip the trailing "/" from event.Prefix; mirror that here.
-	filterName := strings.TrimSuffix(name, "/")
-
-	go func() {
-		defer close(filteredCh)
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event, ok := <-rawCh:
-				if !ok {
-					return
-				}
-
-				parsedKey, err := s.codec.namer.ParseKey(string(event.Prefix))
-				if err != nil {
-					// Drop events on keys this codec does not own (e.g., a
-					// neighbour codec writing under the same storage prefix).
-					continue
-				}
-
-				if !strings.HasPrefix(parsedKey.Name(), filterName) {
-					continue
-				}
-
-				select {
-				case <-ctx.Done():
-					return
-				case filteredCh <- event:
-				}
-			}
-		}
-	}()
-
-	return filteredCh, nil
+	return s.storage.Watch(ctx, []byte(key)), nil
 }
 
 func (s *Store[T]) bindPredicates(name string, preds []Predicate) ([]predicate.Predicate, error) {

--- a/integrity/store_test.go
+++ b/integrity/store_test.go
@@ -1711,18 +1711,16 @@ func TestStore_WithNamer(t *testing.T) {
 func TestStore_Watch(t *testing.T) {
 	t.Parallel()
 
-	t.Run("basic event filtering", func(t *testing.T) {
+	t.Run("event pass-through", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := context.Background()
 		driverMock := mocks.NewDriverMock(t)
 
-		// Use sha256 hasher so the namer knows the "sha256" location.
-		mockH := newMockHasher("sha256")
-		codec := newStoreCodecWithHasher(t, mockH)
+		codec := newStoreCodec(t)
 		store := newMockedStore(t, codec, driverMock)
 
-		// Codec namer (LayeredNamer with sha256): Prefix("my-object", false) = "/objects/my-object"
+		// Codec namer (LayeredNamer): Prefix("my-object", false) = "/objects/my-object"
 		// Prefixed wrapper adds "/test" → driver Watch called with "/test/objects/my-object".
 		absWatchKey := absKeyStr("/objects/my-object")
 		rawCh := make(chan watch.Event, 10)
@@ -1733,40 +1731,17 @@ func TestStore_Watch(t *testing.T) {
 		eventCh, err := store.Watch(ctx, "my-object")
 		require.NoError(t, err)
 
-		// Prefixed wrapper strips "/test" from event.Prefix before forwarding.
-		// Events on rawCh carry absolute keys; Store.Watch goroutine sees stripped keys.
-		events := []watch.Event{
-			// value key for "my-object" → stripped: /objects/my-object → name "my-object" → passes.
-			{Prefix: absKeyStr("/objects/my-object")},
-			// value key for "my-object2" → stripped: /objects/my-object2 → name "my-object2" → passes (prefix match).
-			{Prefix: absKeyStr("/objects/my-object2")},
-			// hash key for "my-object" (sha256) → stripped: /hash/sha256/objects/my-object → name "my-object" → passes.
-			{Prefix: absKeyStr("/hash/sha256/objects/my-object")},
-			// value key for "other-object" → stripped: /objects/other-object → filtered.
-			{Prefix: absKeyStr("/objects/other-object")},
+		// Under the signal-only contract every event reaching the integrity
+		// layer carries the watched prefix verbatim — Store.Watch must forward
+		// it as-is (the Prefixed wrapper has already stripped its own prefix).
+		rawCh <- watch.Event{Prefix: absKeyStr("/objects/my-object")}
+
+		select {
+		case e := <-eventCh:
+			assert.Equal(t, []byte("/objects/my-object"), e.Prefix)
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("expected event to be forwarded")
 		}
-
-		for _, e := range events {
-			rawCh <- e
-		}
-
-		var received []watch.Event
-
-	loop:
-		for range 3 {
-			select {
-			case e := <-eventCh:
-				received = append(received, e)
-			case <-time.After(100 * time.Millisecond):
-				break loop
-			}
-		}
-
-		require.Len(t, received, 3)
-		// Events are forwarded with prefix already stripped (Prefixed wrapper does it).
-		assert.Equal(t, []byte("/objects/my-object"), received[0].Prefix)
-		assert.Equal(t, []byte("/objects/my-object2"), received[1].Prefix)
-		assert.Equal(t, []byte("/hash/sha256/objects/my-object"), received[2].Prefix)
 
 		driverMock.MinimockFinish()
 	})
@@ -1801,37 +1776,6 @@ func TestStore_Watch(t *testing.T) {
 		driverMock.MinimockFinish()
 	})
 
-	t.Run("ParseKey error skips event", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := context.Background()
-		driverMock := mocks.NewDriverMock(t)
-
-		codec := newStoreCodec(t)
-		store := newMockedStore(t, codec, driverMock)
-
-		absWatchKey := absKeyStr("/objects/my-object")
-		rawCh := make(chan watch.Event, 1)
-		cleanup := func() {}
-
-		driverMock.WatchMock.Expect(ctx, absWatchKey).Return(rawCh, cleanup, nil)
-
-		eventCh, err := store.Watch(ctx, "my-object")
-		require.NoError(t, err)
-
-		// After stripping "/test", this becomes "/invalid/key" which ParseKey rejects
-		// (no "invalid" location in namer).
-		rawCh <- watch.Event{Prefix: absKeyStr("/invalid/key")}
-
-		select {
-		case <-eventCh:
-			t.Fatal("unexpected event forwarded")
-		case <-time.After(100 * time.Millisecond):
-		}
-
-		driverMock.MinimockFinish()
-	})
-
 	t.Run("context cancellation while waiting", func(t *testing.T) {
 		t.Parallel()
 
@@ -1850,77 +1794,6 @@ func TestStore_Watch(t *testing.T) {
 
 		eventCh, err := store.Watch(ctx, "my-object")
 		require.NoError(t, err)
-
-		cancel()
-
-		select {
-		case _, ok := <-eventCh:
-			assert.False(t, ok, "channel should be closed after context cancellation")
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("expected channel to be closed after context cancellation")
-		}
-
-		driverMock.MinimockFinish()
-	})
-
-	t.Run("context cancellation while sending", func(t *testing.T) {
-		t.Parallel()
-
-		driverMock := mocks.NewDriverMock(t)
-		codec := newStoreCodec(t)
-		store := newMockedStore(t, codec, driverMock)
-
-		absWatchKey := absKeyStr("/objects/my-object")
-		rawCh := make(chan watch.Event, 1)
-		cleanup := func() {}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		driverMock.WatchMock.Expect(ctx, absWatchKey).Return(rawCh, cleanup, nil)
-
-		eventCh, err := store.Watch(ctx, "my-object")
-		require.NoError(t, err)
-
-		// Valid key but not matching "my-object" — filtered. Goroutine loops back.
-		rawCh <- watch.Event{Prefix: absKeyStr("/objects/other-object")}
-
-		cancel()
-		time.Sleep(50 * time.Millisecond)
-
-		select {
-		case _, ok := <-eventCh:
-			assert.False(t, ok, "channel should be closed after context cancellation")
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("expected channel to be closed after context cancellation")
-		}
-
-		driverMock.MinimockFinish()
-	})
-
-	t.Run("inner select context cancellation", func(t *testing.T) {
-		t.Parallel()
-
-		driverMock := mocks.NewDriverMock(t)
-		codec := newStoreCodec(t)
-		store := newMockedStore(t, codec, driverMock)
-
-		absWatchKey := absKeyStr("/objects/my-object")
-		rawCh := make(chan watch.Event, 1)
-		cleanup := func() {}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		driverMock.WatchMock.Expect(ctx, absWatchKey).Return(rawCh, cleanup, nil)
-
-		eventCh, err := store.Watch(ctx, "my-object")
-		require.NoError(t, err)
-
-		// Valid matching event → goroutine enters inner select, blocks on unbuffered filteredCh.
-		rawCh <- watch.Event{Prefix: absKeyStr("/objects/my-object")}
-
-		time.Sleep(10 * time.Millisecond)
 
 		cancel()
 

--- a/integrity/typed.go
+++ b/integrity/typed.go
@@ -442,6 +442,10 @@ func (t *Typed[T]) Range(
 }
 
 // Watch returns a channel for watching changes to values under the given name prefix.
+//
+// Under the signal-only Event.Prefix contract every event carries the watched
+// prefix verbatim (driver-stripped of its trailing "/"), so filtering on
+// event.Prefix is a no-op — callers must Range/Get to learn what changed.
 func (t *Typed[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, error) {
 	if !checkRangeName(name) {
 		return closedChan, ErrInvalidName
@@ -449,47 +453,7 @@ func (t *Typed[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, 
 
 	key := t.namer.Prefix(name, strings.HasSuffix(name, "/"))
 
-	rawCh := t.base.Watch(ctx, []byte(key))
-	filteredCh := make(chan watch.Event)
-
-	// Drivers strip the trailing "/" from event.Prefix; mirror that here.
-	filterName := strings.TrimSuffix(name, "/")
-
-	go func() {
-		defer close(filteredCh)
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event, ok := <-rawCh:
-				if !ok {
-					return
-				}
-
-				// Parse the key from the event prefix.
-				key, err := t.namer.ParseKey(string(event.Prefix))
-				if err != nil {
-					// Skip events for non-integrity keys.
-					continue
-				}
-
-				// Filter by name prefix.
-				if !strings.HasPrefix(key.Name(), filterName) {
-					continue
-				}
-
-				// Forward the event.
-				select {
-				case <-ctx.Done():
-					return
-				case filteredCh <- event:
-				}
-			}
-		}
-	}()
-
-	return filteredCh, nil
+	return t.base.Watch(ctx, []byte(key)), nil
 }
 
 var (

--- a/integrity/typed_test.go
+++ b/integrity/typed_test.go
@@ -1821,7 +1821,7 @@ func TestTypedBuilder_WithMarshaller(t *testing.T) {
 func TestTypedWatch(t *testing.T) {
 	t.Parallel()
 
-	t.Run("basic event filtering", func(t *testing.T) {
+	t.Run("event pass-through", func(t *testing.T) {
 		t.Parallel()
 
 		ctx := t.Context()
@@ -1844,35 +1844,18 @@ func TestTypedWatch(t *testing.T) {
 		eventCh, err := typed.Watch(ctx, "my-object")
 		require.NoError(t, err)
 
-		// Send events.
-		events := []watch.Event{
-			{Prefix: []byte("/test/my-object")},             // value key, name "my-object" passes.
-			{Prefix: []byte("/test/my-object2")},            // value key, name "my-object2" passes (prefix match).
-			{Prefix: []byte("/test/hash/sha256/my-object")}, // hash key, name "my-object" passes.
-			{Prefix: []byte("/test/other-object")},          // name "other-object" filtered out (no prefix match).
+		// Under the signal-only contract every event reaching the integrity
+		// layer carries the watched prefix verbatim — Typed.Watch must
+		// forward it as-is.
+		event := watch.Event{Prefix: []byte("/test/my-object")}
+		rawCh <- event
+
+		select {
+		case e := <-eventCh:
+			assert.Equal(t, event, e)
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("expected event to be forwarded")
 		}
-
-		for _, e := range events {
-			rawCh <- e
-		}
-
-		// Read events from filtered channel.
-		var received []watch.Event
-
-	loop:
-		for range 3 {
-			select {
-			case e := <-eventCh:
-				received = append(received, e)
-			case <-time.After(100 * time.Millisecond):
-				break loop
-			}
-		}
-
-		require.Len(t, received, 3)
-		assert.Equal(t, events[0], received[0])
-		assert.Equal(t, events[1], received[1])
-		assert.Equal(t, events[2], received[2])
 
 		driverMock.MinimockFinish()
 	})
@@ -1913,43 +1896,6 @@ func TestTypedWatch(t *testing.T) {
 		driverMock.MinimockFinish()
 	})
 
-	t.Run("ParseKey error skips event", func(t *testing.T) {
-		t.Parallel()
-
-		ctx := t.Context()
-
-		driverMock := mocks.NewDriverMock(t)
-		st := storage.NewStorage(driverMock)
-
-		typed := integrity.NewTypedBuilder[SimpleStruct](st).
-			WithPrefix("/test").
-			Build()
-
-		namerInstance := namer.NewDefaultNamer("/test", []string{}, []string{})
-		key := namerInstance.Prefix("my-object", false)
-
-		rawCh := make(chan watch.Event, 1)
-		cleanup := func() {} // no-op.
-
-		driverMock.WatchMock.Expect(ctx, []byte(key)).Return(rawCh, cleanup, nil)
-
-		eventCh, err := typed.Watch(ctx, "my-object")
-		require.NoError(t, err)
-
-		// Send an event with malformed prefix that will cause ParseKey error.
-		rawCh <- watch.Event{Prefix: []byte("/invalid/key")}
-
-		// No event should be forwarded.
-		select {
-		case <-eventCh:
-			t.Fatal("unexpected event forwarded")
-		case <-time.After(100 * time.Millisecond):
-			// Expected - event filtered out.
-		}
-
-		driverMock.MinimockFinish()
-	})
-
 	t.Run("context cancellation while waiting", func(t *testing.T) {
 		t.Parallel()
 
@@ -1975,96 +1921,6 @@ func TestTypedWatch(t *testing.T) {
 		require.NoError(t, err)
 
 		// Cancel context.
-		cancel()
-
-		// filteredCh should be closed.
-		select {
-		case _, ok := <-eventCh:
-			assert.False(t, ok, "channel should be closed after context cancellation")
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("expected channel to be closed after context cancellation")
-		}
-
-		driverMock.MinimockFinish()
-	})
-
-	t.Run("context cancellation while sending", func(t *testing.T) {
-		t.Parallel()
-
-		driverMock := mocks.NewDriverMock(t)
-		st := storage.NewStorage(driverMock)
-
-		typed := integrity.NewTypedBuilder[SimpleStruct](st).
-			WithPrefix("/test").
-			Build()
-
-		namerInstance := namer.NewDefaultNamer("/test", []string{}, []string{})
-		key := namerInstance.Prefix("my-object", false)
-
-		rawCh := make(chan watch.Event, 1)
-		cleanup := func() {} // no-op.
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		driverMock.WatchMock.Expect(ctx, []byte(key)).Return(rawCh, cleanup, nil)
-
-		eventCh, err := typed.Watch(ctx, "my-object")
-		require.NoError(t, err)
-
-		// Send an event that will be filtered (valid key but not matching name).
-		rawCh <- watch.Event{Prefix: []byte("/test/other-object")}
-
-		// Cancel context while goroutine is trying to send to filteredCh (which nobody reads).
-		// Since filteredCh is unbuffered and we're not reading, the send will block.
-		// Cancelling context should cause goroutine to exit.
-		cancel()
-
-		// Wait a bit for goroutine to exit.
-		time.Sleep(50 * time.Millisecond)
-
-		// filteredCh should be closed.
-		select {
-		case _, ok := <-eventCh:
-			assert.False(t, ok, "channel should be closed after context cancellation")
-		case <-time.After(100 * time.Millisecond):
-			t.Fatal("expected channel to be closed after context cancellation")
-		}
-
-		driverMock.MinimockFinish()
-	})
-
-	t.Run("inner select context cancellation", func(t *testing.T) {
-		t.Parallel()
-
-		driverMock := mocks.NewDriverMock(t)
-		st := storage.NewStorage(driverMock)
-
-		typed := integrity.NewTypedBuilder[SimpleStruct](st).
-			WithPrefix("/test").
-			Build()
-
-		namerInstance := namer.NewDefaultNamer("/test", []string{}, []string{})
-		key := namerInstance.Prefix("my-object", false)
-
-		rawCh := make(chan watch.Event, 1)
-		cleanup := func() {} // no-op.
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		driverMock.WatchMock.Expect(ctx, []byte(key)).Return(rawCh, cleanup, nil)
-
-		eventCh, err := typed.Watch(ctx, "my-object")
-		require.NoError(t, err)
-
-		// Send a valid event that passes all filters.
-		rawCh <- watch.Event{Prefix: []byte("/test/my-object")}
-
-		// Give goroutine time to receive event and enter inner select.
-		time.Sleep(10 * time.Millisecond)
-
-		// Cancel context while goroutine is blocked trying to send to filteredCh.
 		cancel()
 
 		// filteredCh should be closed.


### PR DESCRIPTION
`Store[T].Watch(ctx, "")` and `Typed[T].Watch(ctx, "")` (the "watch the whole codec" case) silently dropped every event across all three drivers. The integrity layer was running `event.Prefix` through `ParseKey` to filter neighbour-codec events, but under the signal-only `Event.Prefix` contract drivers always emit the watched prefix verbatim — and `/<objectLocation>` is a single segment, which `ParseKey` rejects.

Under the new contract the filter is a no-op anyway, so both methods now forward driver events as-is. The bulk of the diff is the now-redundant filtering plumbing being removed from `store.go` and `typed.go`.

Closes TNTP-7706