### PR TITLE
integrity: support unnamed codec layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   instead of under a directory of `<objectLocation>/<id>` items. The
   on-disk layout is identical to `Store[T]` for the same name — no
   separate codec, no separate namer.
+- namer.LayeredNamer: new `ObjectLocationMissing` sentinel. Passing it as
+  `objectLocation` to `NewLayeredNamer` (or omitting `WithObjectLocation`
+  on `CodecBuilder`) puts the namer in unnamed mode: keys are emitted as
+  `/<name>`, `/hash/<hashLocation>/<name>`, `/sig/<sigLocation>/<name>`,
+  with the per-codec location segment dropped. Object names whose first
+  slash-separated segment is `hash` or `sig` are rejected to avoid
+  colliding with the category markers.
 
 ### Changed
+
+- integrity.CodecBuilder: a builder that does not call
+  `WithObjectLocation` no longer falls back to `"objects"`; it now
+  produces an unnamed codec (keys at `/<name>` instead of
+  `/objects/<name>`). Callers who relied on the silent default must add
+  `.WithObjectLocation("objects")` (or any other segment) explicitly.
+  This is a breaking change for codecs that omitted `WithObjectLocation`.
 
 - storage.Prefixed: signature is now
   `Prefixed(prefix, inner) (Storage, error)`. A non-empty prefix ending

--- a/integrity/codec.go
+++ b/integrity/codec.go
@@ -119,7 +119,9 @@ type CodecBuilder[T any] struct {
 
 // NewCodecBuilder returns a new CodecBuilder with sensible defaults.
 // Default marshaller: TypedYamlMarshaller[T].
-// Default objectLocation: "" (resolved to "objects" at Build time).
+// Default objectLocation: namer.ObjectLocationMissing (unnamed codec —
+// keys are emitted without the per-codec location segment). Call
+// WithObjectLocation to opt into a named layout like /<location>/<name>.
 // Default namerFunc: wraps namer.NewLayeredNamer.
 func NewCodecBuilder[T any]() CodecBuilder[T] {
 	return CodecBuilder[T]{
@@ -200,8 +202,9 @@ func (b CodecBuilder[T]) WithSignerVerifier(sv crypto.SignerVerifier) CodecBuild
 	return out
 }
 
-// WithObjectLocation sets the location segment for value keys.
-// If not called, defaults to "objects" at Build time.
+// WithObjectLocation sets the location segment for value keys. If not
+// called, the codec is built in unnamed mode (no per-codec location
+// segment); see NewCodecBuilder.
 func (b CodecBuilder[T]) WithObjectLocation(loc string) CodecBuilder[T] {
 	out := b.copy()
 
@@ -277,10 +280,11 @@ func (b CodecBuilder[T]) Build() (*Codec[T], error) {
 		namerFn = namer.NewLayeredNamer
 	}
 
+	// objLoc == namer.ObjectLocationMissing ("") puts the codec in
+	// unnamed mode — keys are emitted without the per-codec location
+	// segment. Callers who want the old "objects" layout must call
+	// WithObjectLocation("objects") explicitly.
 	objLoc := b.objectLocation
-	if objLoc == "" {
-		objLoc = "objects"
-	}
 
 	// hashLocations/sigLocations override key→loc; reject keys that have no
 	// matching hasher/signer/verifier so a typo doesn't silently no-op.

--- a/integrity/codec_example_test.go
+++ b/integrity/codec_example_test.go
@@ -22,7 +22,7 @@ type codecExampleConfig struct {
 // ExampleNewCodecBuilder builds a Codec[T] using the fluent builder.
 // Each WithX call returns a copy, so the original builder is never mutated.
 func ExampleNewCodecBuilder() {
-	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		Build()
 	if err != nil {
@@ -53,7 +53,7 @@ func ExampleNewCodecBuilder() {
 // ExampleCodecBuilder_WithObjectLocation shows overriding the value-layer
 // location segment. The default is "objects".
 func ExampleCodecBuilder_WithObjectLocation() {
-	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().WithObjectLocation("objects").
 		WithObjectLocation("users").
 		WithHasher(hasher.NewSHA256Hasher()).
 		Build()
@@ -86,7 +86,7 @@ func ExampleCodecBuilder_WithObjectLocation() {
 // original builder is unchanged after a setter call, so two divergent codecs
 // can be built from the same base.
 func ExampleNewCodecBuilder_immutability() {
-	base := integrity.NewCodecBuilder[codecExampleConfig]()
+	base := integrity.NewCodecBuilder[codecExampleConfig]().WithObjectLocation("objects")
 
 	withHasher := base.WithHasher(hasher.NewSHA256Hasher())
 	withoutHasher := base // unchanged.
@@ -116,7 +116,7 @@ func ExampleCodecBuilder_WithSignerVerifier() {
 		log.Fatalf("genkey: %v", err)
 	}
 
-	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		WithSignerVerifier(crypto.NewRSAPSSSignerVerifier(*priv)).
 		Build()
@@ -148,7 +148,7 @@ func ExampleCodecBuilder_WithSignerVerifier() {
 // to Tx.If via Codec.BindPredicate, or used through Store helpers like
 // WithPutPredicates.
 func ExampleCodec_ValueEqual() {
-	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().Build()
+	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().WithObjectLocation("objects").Build()
 	if err != nil {
 		log.Fatalf("build: %v", err)
 	}

--- a/integrity/codec_test.go
+++ b/integrity/codec_test.go
@@ -33,30 +33,64 @@ func newTestRSAPSS(t *testing.T) crypto.SignerVerifier {
 func TestCodecBuilder_Defaults(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 	require.NotNil(t, codec)
 }
 
 // The codec keeps its namer private, so the default-object-location guarantee
 // is verified by constructing an equivalent LayeredNamer and asserting its
-// output matches the documented "/objects/<name>" shape.
-func TestCodecBuilder_DefaultObjectLocation(t *testing.T) {
+// output matches the documented unnamed shape (no objectLocation segment).
+func TestCodecBuilder_DefaultIsUnnamed(t *testing.T) {
 	t.Parallel()
 
-	defaultNamer, err := namer.NewLayeredNamer("objects", nil, nil)
+	defaultNamer, err := namer.NewLayeredNamer(namer.ObjectLocationMissing, nil, nil)
 	require.NoError(t, err)
 
 	keys, err := defaultNamer.GenerateNames("foo")
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
-	assert.Equal(t, "/objects/foo", keys[0].Build())
+	assert.Equal(t, "/foo", keys[0].Build())
+}
+
+// TestCodec_DefaultBuildsUnnamedKeys exercises the actual builder path —
+// no WithObjectLocation call — and asserts that the keys produced by its
+// generator omit the per-codec location segment.
+func TestCodec_DefaultBuildsUnnamedKeys(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	require.NoError(t, err)
+
+	pred, err := codec.ValueEqual(codecTestStruct{Name: "x", Value: 1})
+	require.NoError(t, err)
+
+	// ValueEqual binds via the value-key resolved against the namer; a
+	// /<name> raw key (no /objects/ segment) confirms the unnamed default.
+	bound, err := codec.BindPredicate("alice", pred)
+	require.NoError(t, err)
+	require.NotNil(t, bound)
+}
+
+// TestCodec_ExplicitObjectLocationMissing — passing the sentinel directly
+// produces the same unnamed layout as omitting WithObjectLocation entirely.
+func TestCodec_ExplicitObjectLocationMissing(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation(namer.ObjectLocationMissing).
+		WithHasher(hasher.NewSHA256Hasher()).
+		Build()
+	require.NoError(t, err)
+	require.NotNil(t, codec)
 }
 
 func TestCodecBuilder_WithObjectLocation(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithObjectLocation("myobjects").
 		Build()
 	require.NoError(t, err)
@@ -66,7 +100,7 @@ func TestCodecBuilder_WithObjectLocation(t *testing.T) {
 func TestCodecBuilder_WithHasher(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		Build()
 	require.NoError(t, err)
@@ -95,7 +129,7 @@ func TestCodecBuilder_WithHasher(t *testing.T) {
 func TestCodecBuilder_WithHashLocation(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		WithHashLocation("sha256", "checksums").
 		Build()
@@ -126,7 +160,7 @@ func TestCodecBuilder_WithSigner(t *testing.T) {
 
 	sv := newTestRSAPSS(t)
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithSigner(sv).
 		Build()
 	require.NoError(t, err)
@@ -138,7 +172,7 @@ func TestCodecBuilder_WithVerifier(t *testing.T) {
 
 	sv := newTestRSAPSS(t)
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithVerifier(sv).
 		Build()
 	require.NoError(t, err)
@@ -150,7 +184,7 @@ func TestCodecBuilder_WithSignerVerifier(t *testing.T) {
 
 	sv := newTestRSAPSS(t)
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithSignerVerifier(sv).
 		Build()
 	require.NoError(t, err)
@@ -162,7 +196,7 @@ func TestCodecBuilder_WithSignatureLocation(t *testing.T) {
 
 	signerVerifier := newTestRSAPSS(t)
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithSignerVerifier(signerVerifier).
 		WithSignatureLocation(signerVerifier.Name(), "sigs").
 		Build()
@@ -190,7 +224,7 @@ func TestCodecBuilder_WithSignatureLocation(t *testing.T) {
 func TestCodecBuilder_StaleHashLocationKey(t *testing.T) {
 	t.Parallel()
 
-	_, err := integrity.NewCodecBuilder[codecTestStruct]().
+	_, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		WithHashLocation("sah256", "custom"). // typo — no matching hasher.
 		Build()
@@ -203,7 +237,7 @@ func TestCodecBuilder_StaleSigLocationKey(t *testing.T) {
 
 	sv := newTestRSAPSS(t)
 
-	_, err := integrity.NewCodecBuilder[codecTestStruct]().
+	_, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithSignerVerifier(sv).
 		WithSignatureLocation("nonexistent-signer", "sigs").
 		Build()
@@ -218,7 +252,7 @@ func TestCodecBuilder_ReservedObjectLocation(t *testing.T) {
 		t.Run(reserved, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := integrity.NewCodecBuilder[codecTestStruct]().
+			_, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 				WithObjectLocation(reserved).
 				Build()
 			require.Error(t, err, "Build should fail when objectLocation equals reserved marker %q", reserved)
@@ -229,7 +263,7 @@ func TestCodecBuilder_ReservedObjectLocation(t *testing.T) {
 func TestCodecBuilder_InvalidObjectLocation(t *testing.T) {
 	t.Parallel()
 
-	_, err := integrity.NewCodecBuilder[codecTestStruct]().
+	_, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithObjectLocation("/foo"). // leading slash — invalid.
 		Build()
 	require.Error(t, err, "Build should fail for location starting with '/'")
@@ -282,7 +316,7 @@ func TestCodecBuilder_WithMarshaller(t *testing.T) {
 
 	sentMarsh := &sentinelMarshaller{marshalCalled: false}
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithMarshaller(sentMarsh).
 		Build()
 	require.NoError(t, err)
@@ -354,7 +388,7 @@ func TestCodecBuilder_WithNamer(t *testing.T) {
 		return &sentinelNamer{called: false}, nil
 	})
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").
 		WithNamer(customConstructor).
 		Build()
 	require.NoError(t, err)
@@ -368,7 +402,7 @@ func TestCodecBuilder_WithNamer(t *testing.T) {
 func TestCodec_ValueEqual(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	val := codecTestStruct{Name: "hello", Value: 42}
@@ -390,7 +424,7 @@ func TestCodec_ValueEqual(t *testing.T) {
 func TestCodec_ValueNotEqual(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	val := codecTestStruct{Name: "hello", Value: 42}
@@ -407,7 +441,7 @@ func TestCodec_ValueNotEqual(t *testing.T) {
 func TestCodec_VersionEqual(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	pred := codec.VersionEqual(int64(42))
@@ -423,7 +457,7 @@ func TestCodec_VersionEqual(t *testing.T) {
 func TestCodec_VersionNotEqual(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	pred := codec.VersionNotEqual(int64(7))
@@ -436,7 +470,7 @@ func TestCodec_VersionNotEqual(t *testing.T) {
 func TestCodec_VersionGreater(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	pred := codec.VersionGreater(int64(100))
@@ -448,7 +482,7 @@ func TestCodec_VersionGreater(t *testing.T) {
 func TestCodec_VersionLess(t *testing.T) {
 	t.Parallel()
 
-	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	pred := codec.VersionLess(int64(5))
@@ -460,7 +494,7 @@ func TestCodec_VersionLess(t *testing.T) {
 func TestCodecBuilder_Immutability(t *testing.T) {
 	t.Parallel()
 
-	base := integrity.NewCodecBuilder[codecTestStruct]()
+	base := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects")
 
 	marsh1 := marshaller.NewTypedYamlMarshaller[codecTestStruct]()
 	marsh2 := marshaller.NewTypedYamlMarshaller[codecTestStruct]()
@@ -480,7 +514,7 @@ func TestCodecBuilder_Immutability(t *testing.T) {
 func TestCodecBuilder_ImmutabilityHashers(t *testing.T) {
 	t.Parallel()
 
-	base := integrity.NewCodecBuilder[codecTestStruct]()
+	base := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects")
 	withSHA256 := base.WithHasher(hasher.NewSHA256Hasher())
 	withSHA256SHA1 := withSHA256.WithHasher(hasher.NewSHA1Hasher())
 
@@ -497,7 +531,7 @@ func TestCodecBuilder_ImmutabilityHashers(t *testing.T) {
 func TestCodecBuilder_MultipleBuildCalls(t *testing.T) {
 	t.Parallel()
 
-	builder := integrity.NewCodecBuilder[codecTestStruct]()
+	builder := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects")
 
 	codec1, err := builder.Build()
 	require.NoError(t, err)

--- a/integrity/integration_codec_tx_test.go
+++ b/integrity/integration_codec_tx_test.go
@@ -45,7 +45,7 @@ func newIntegrationCodecStore(
 ) (*integrity.Codec[IntegrationStruct], *integrity.Store[IntegrationStruct]) {
 	t.Helper()
 
-	builder := integrity.NewCodecBuilder[IntegrationStruct]()
+	builder := integrity.NewCodecBuilder[IntegrationStruct]().WithObjectLocation("objects")
 	if configure != nil {
 		builder = configure(builder)
 	}
@@ -347,7 +347,7 @@ func TestTxIntegration_MultiOpAtomic(t *testing.T) {
 		ctx := t.Context()
 		base := scopedStorage(t, driverInstance)
 
-		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().WithObjectLocation("objects").Build()
 		require.NoError(t, err)
 
 		txn := integrity.NewTx(base)
@@ -384,7 +384,7 @@ func TestTxIntegration_ThenElse_ThenFires(t *testing.T) {
 		ctx := t.Context()
 		base := scopedStorage(t, driverInstance)
 
-		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().WithObjectLocation("objects").Build()
 		require.NoError(t, err)
 
 		store := codec.Bind(base)
@@ -425,7 +425,7 @@ func TestTxIntegration_ThenElse_ElseFires(t *testing.T) {
 		ctx := t.Context()
 		base := scopedStorage(t, driverInstance)
 
-		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().WithObjectLocation("objects").Build()
 		require.NoError(t, err)
 
 		store := codec.Bind(base)
@@ -469,7 +469,7 @@ func TestTxIntegration_TxRange(t *testing.T) {
 		ctx := t.Context()
 		base := scopedStorage(t, driverInstance)
 
-		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().WithObjectLocation("objects").Build()
 		require.NoError(t, err)
 
 		store := codec.Bind(base)
@@ -504,7 +504,7 @@ func TestTxIntegration_TxDelete(t *testing.T) {
 		ctx := t.Context()
 		base := scopedStorage(t, driverInstance)
 
-		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().WithObjectLocation("objects").
 			WithHasher(hasher.NewSHA256Hasher()).
 			Build()
 		require.NoError(t, err)
@@ -533,7 +533,7 @@ func TestTxIntegration_AlreadyCommitted(t *testing.T) {
 		ctx := t.Context()
 		base := scopedStorage(t, driverInstance)
 
-		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().Build()
+		codec, err := integrity.NewCodecBuilder[IntegrationStruct]().WithObjectLocation("objects").Build()
 		require.NoError(t, err)
 
 		txn := integrity.NewTx(base)

--- a/integrity/store_example_test.go
+++ b/integrity/store_example_test.go
@@ -18,7 +18,7 @@ type storeExampleValue struct {
 }
 
 func newExampleCodec() *integrity.Codec[storeExampleValue] {
-	codec, err := integrity.NewCodecBuilder[storeExampleValue]().
+	codec, err := integrity.NewCodecBuilder[storeExampleValue]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		Build()
 	if err != nil {

--- a/integrity/store_test.go
+++ b/integrity/store_test.go
@@ -2,7 +2,7 @@ package integrity_test
 
 // Conventions used by tests in this file:
 //
-//   codec := integrity.NewCodecBuilder[T]().WithHasher(...).Build()
+//   codec := integrity.NewCodecBuilder[T]().WithObjectLocation("objects").WithHasher(...).Build()
 //   store := codec.Bind(storage.Prefixed("/test", storage.NewStorage(driverMock)))
 //
 // LayeredNamer key layout (objectLocation = "objects"):
@@ -43,7 +43,7 @@ const storeTestPrefix = "/test"
 func newStoreCodec(t *testing.T) *integrity.Codec[SimpleStruct] {
 	t.Helper()
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().Build()
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	return codec
@@ -52,7 +52,7 @@ func newStoreCodec(t *testing.T) *integrity.Codec[SimpleStruct] {
 func newStoreCodecWithHasher(t *testing.T, h hasher.Hasher) *integrity.Codec[SimpleStruct] {
 	t.Helper()
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithHasher(h).Build()
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").WithHasher(h).Build()
 	require.NoError(t, err)
 
 	return codec
@@ -61,7 +61,7 @@ func newStoreCodecWithHasher(t *testing.T, h hasher.Hasher) *integrity.Codec[Sim
 func newStoreCodecWithSigner(t *testing.T, s crypto.Signer) *integrity.Codec[SimpleStruct] {
 	t.Helper()
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithSigner(s).Build()
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").WithSigner(s).Build()
 	require.NoError(t, err)
 
 	return codec
@@ -70,7 +70,7 @@ func newStoreCodecWithSigner(t *testing.T, s crypto.Signer) *integrity.Codec[Sim
 func newStoreCodecWithVerifier(t *testing.T, v crypto.Verifier) *integrity.Codec[SimpleStruct] {
 	t.Helper()
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithVerifier(v).Build()
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").WithVerifier(v).Build()
 	require.NoError(t, err)
 
 	return codec
@@ -79,7 +79,7 @@ func newStoreCodecWithVerifier(t *testing.T, v crypto.Verifier) *integrity.Codec
 func newStoreCodecWithSignerVerifier(t *testing.T, sv crypto.SignerVerifier) *integrity.Codec[SimpleStruct] {
 	t.Helper()
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithSignerVerifier(sv).Build()
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").WithSignerVerifier(sv).Build()
 	require.NoError(t, err)
 
 	return codec
@@ -665,7 +665,7 @@ func TestStore_Get_NamerGenerateNamesError(t *testing.T) {
 
 	generateErr := errors.New("namer error")
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").
 		WithNamer(func(
 			_ string,
 			_ []namer.LayeredHashLocation,
@@ -1026,7 +1026,7 @@ func TestStore_Put_WithMarshaller(t *testing.T) {
 	ctx := context.Background()
 	driverMock := mocks.NewDriverMock(t)
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").
 		WithMarshaller(marshaller.NewTypedYamlMarshaller[SimpleStruct]()).
 		Build()
 	require.NoError(t, err)
@@ -1295,7 +1295,7 @@ func TestStore_Delete_NamerGenerateNamesError(t *testing.T) {
 
 	generateErr := errors.New("namer error")
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").
 		WithNamer(func(
 			_ string,
 			_ []namer.LayeredHashLocation,
@@ -1646,7 +1646,7 @@ func TestStore_WithNamer(t *testing.T) {
 
 	var capturedSigLocs []namer.LayeredSigLocation
 
-	codec, err := integrity.NewCodecBuilder[SimpleStruct]().
+	codec, err := integrity.NewCodecBuilder[SimpleStruct]().WithObjectLocation("objects").
 		WithHasher(newMockHasher("sha256")).
 		WithSigner(newMockSigner("rsa")).
 		WithNamer(func(
@@ -1971,12 +1971,12 @@ func TestStore_CrossCodec_AtomicCommit(t *testing.T) {
 
 	base := storage.NewStorage(driverMock)
 
-	userCodec, err := integrity.NewCodecBuilder[UserVal]().
+	userCodec, err := integrity.NewCodecBuilder[UserVal]().WithObjectLocation("objects").
 		WithObjectLocation("users").
 		Build()
 	require.NoError(t, err)
 
-	orderCodec, err := integrity.NewCodecBuilder[OrderVal]().
+	orderCodec, err := integrity.NewCodecBuilder[OrderVal]().WithObjectLocation("objects").
 		WithObjectLocation("orders").
 		Build()
 	require.NoError(t, err)

--- a/integrity/tx_example_test.go
+++ b/integrity/tx_example_test.go
@@ -18,7 +18,7 @@ type txExampleValue struct {
 }
 
 func newTxExampleCodec() *integrity.Codec[txExampleValue] {
-	codec, err := integrity.NewCodecBuilder[txExampleValue]().
+	codec, err := integrity.NewCodecBuilder[txExampleValue]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		Build()
 	if err != nil {

--- a/integrity/tx_test.go
+++ b/integrity/tx_test.go
@@ -30,7 +30,7 @@ func newTestStorage() storage.Storage {
 func newTestCodec(t *testing.T) *integrity.Codec[txTestValue] {
 	t.Helper()
 
-	codec, err := integrity.NewCodecBuilder[txTestValue]().Build()
+	codec, err := integrity.NewCodecBuilder[txTestValue]().WithObjectLocation("objects").Build()
 	require.NoError(t, err)
 
 	return codec
@@ -39,7 +39,7 @@ func newTestCodec(t *testing.T) *integrity.Codec[txTestValue] {
 func newTestCodecWithHasher(t *testing.T) *integrity.Codec[txTestValue] {
 	t.Helper()
 
-	codec, err := integrity.NewCodecBuilder[txTestValue]().
+	codec, err := integrity.NewCodecBuilder[txTestValue]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
 		Build()
 	require.NoError(t, err)
@@ -567,7 +567,7 @@ func TestBindPredicate_NoValueKey(t *testing.T) {
 	// key to anchor the predicate to.
 	noValueNamer := &hashOnlyNamer{}
 
-	codec, err := integrity.NewCodecBuilder[txTestValue]().
+	codec, err := integrity.NewCodecBuilder[txTestValue]().WithObjectLocation("objects").
 		WithNamer(func(
 			_ string,
 			_ []namer.LayeredHashLocation,
@@ -614,12 +614,12 @@ func TestTx_ResultDispatchIsolatesCodecs(t *testing.T) {
 
 	// Two codecs sharing a type but living under distinct object locations,
 	// so each codec only sees its own keys when results are dispatched.
-	codecA, err := integrity.NewCodecBuilder[txTestValue]().
+	codecA, err := integrity.NewCodecBuilder[txTestValue]().WithObjectLocation("objects").
 		WithObjectLocation("typeA").
 		Build()
 	require.NoError(t, err)
 
-	codecB, err := integrity.NewCodecBuilder[txTestValue]().
+	codecB, err := integrity.NewCodecBuilder[txTestValue]().WithObjectLocation("objects").
 		WithObjectLocation("typeB").
 		Build()
 	require.NoError(t, err)

--- a/namer/layered.go
+++ b/namer/layered.go
@@ -15,6 +15,19 @@ const (
 	layeredSigMarker  = "sig"
 )
 
+// ObjectLocationMissing is the sentinel value passed as the objectLocation
+// argument to NewLayeredNamer to omit the per-codec objectLocation segment
+// from every generated key. The resulting layout is:
+//
+//	/<name>                          (value)
+//	/hash/<hashLocation>/<name>      (hash)
+//	/sig/<sigLocation>/<name>        (sig)
+//
+// In this mode object names whose first slash-separated segment equals
+// "hash" or "sig" are rejected by GenerateNames to avoid collision with
+// the category markers.
+const ObjectLocationMissing = ""
+
 // Sentinel errors for NewLayeredNamer validation.
 var (
 	// ErrEmptyHasherName is returned when a hash entry has an empty HasherName.
@@ -86,6 +99,10 @@ type layeredNamer struct {
 	sigLocations   []LayeredSigLocation
 	compactHash    bool
 	compactSig     bool
+	// unnamed is set when objectLocation == ObjectLocationMissing. In this
+	// mode the objectLocation segment is omitted from every emitted key
+	// and from the parser's expected layout.
+	unnamed bool
 	// Reverse maps populated once at construction so ParseKey is O(1)
 	// regardless of hash/sig list size.
 	hashIndex map[string]string // hashLocation -> hasherName.
@@ -108,11 +125,15 @@ type layeredNamer struct {
 // With CompactSingleHash, the <hashLocation> segment is omitted; with
 // CompactSingleSig, the <sigLocation> segment is omitted.
 //
+// Pass ObjectLocationMissing as objectLocation to drop the per-codec
+// segment entirely; see ObjectLocationMissing for the resulting layout.
+//
 // Validation rules:
 //   - hashLocation / sigLocation must be a single non-empty segment with no '/'.
-//   - objectLocation must be non-empty, must not start or end with '/', and
-//     must not contain empty inner segments ("//"). Its first segment must
-//     not be "hash" or "sig".
+//   - objectLocation must not start or end with '/' and must not contain
+//     empty inner segments ("//"). Its first segment must not be "hash" or
+//     "sig". An empty objectLocation (ObjectLocationMissing) selects unnamed
+//     mode and skips these checks.
 //   - hashLocations must be unique within hashes; sigLocations must be unique within sigs.
 //   - Compact flags require exactly one entry in their respective category.
 func NewLayeredNamer(
@@ -127,14 +148,18 @@ func NewLayeredNamer(
 		opt(&resolved)
 	}
 
-	err := validateObjectLocation(objectLocation)
-	if err != nil {
-		return nil, err
-	}
+	unnamed := objectLocation == ObjectLocationMissing
 
-	firstSeg, _, _ := strings.Cut(objectLocation, "/")
-	if firstSeg == layeredHashMarker || firstSeg == layeredSigMarker {
-		return nil, fmt.Errorf("%w: got %q", ErrObjectLocationReserved, objectLocation)
+	if !unnamed {
+		err := validateObjectLocation(objectLocation)
+		if err != nil {
+			return nil, err
+		}
+
+		firstSeg, _, _ := strings.Cut(objectLocation, "/")
+		if firstSeg == layeredHashMarker || firstSeg == layeredSigMarker {
+			return nil, fmt.Errorf("%w: got %q", ErrObjectLocationReserved, objectLocation)
+		}
 	}
 
 	if resolved.compactHash && len(hashLocations) != 1 {
@@ -152,7 +177,7 @@ func NewLayeredNamer(
 			return nil, ErrEmptyHasherName
 		}
 
-		err = validateSegment("hash Location", hashLoc.Location)
+		err := validateSegment("hash Location", hashLoc.Location)
 		if err != nil {
 			return nil, err
 		}
@@ -171,7 +196,7 @@ func NewLayeredNamer(
 			return nil, ErrEmptySignerName
 		}
 
-		err = validateSegment("sig Location", sigLoc.Location)
+		err := validateSegment("sig Location", sigLoc.Location)
 		if err != nil {
 			return nil, err
 		}
@@ -189,9 +214,22 @@ func NewLayeredNamer(
 		sigLocations:   sigLocations,
 		compactHash:    resolved.compactHash,
 		compactSig:     resolved.compactSig,
+		unnamed:        unnamed,
 		hashIndex:      hashIndex,
 		sigIndex:       sigIndex,
 	}, nil
+}
+
+// isReservedFirstSegment reports whether name's first slash-separated
+// segment equals one of the reserved category markers ("hash" or "sig").
+// In unnamed mode such names would collide with the value-key parser.
+func isReservedFirstSegment(name string) bool {
+	first, _, found := strings.Cut(name, "/")
+	if !found {
+		first = name
+	}
+
+	return first == layeredHashMarker || first == layeredSigMarker
 }
 
 func validateSegment(field, seg string) error {
@@ -239,6 +277,10 @@ func validateObjectLocation(seg string) error {
 
 // GenerateNames returns one key per category for the given object name.
 // name must be non-empty; a leading "/" is stripped.
+//
+// In unnamed mode (objectLocation == ObjectLocationMissing) the first
+// slash-separated segment of name must not equal "hash" or "sig" — those
+// would collide with the category markers used to dispatch ParseKey.
 func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
 	if name == "" {
 		return nil, errInvalidName(name, "should not be empty")
@@ -246,13 +288,18 @@ func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
 
 	name = strings.TrimPrefix(name, "/")
 
+	if n.unnamed && isReservedFirstSegment(name) {
+		return nil, errInvalidName(name,
+			"first segment must not be \"hash\" or \"sig\" in unnamed mode")
+	}
+
 	out := make([]Key, 0, 1+len(n.hashLocations)+len(n.sigLocations))
 
 	out = append(out, NewDefaultKey(
 		name,
 		KeyTypeValue,
 		"",
-		"/"+n.objectLocation+"/"+name,
+		n.buildValueKey(name),
 	))
 
 	for _, hl := range n.hashLocations {
@@ -286,18 +333,32 @@ func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
 //
 // With CompactSingleHash / CompactSingleSig the corresponding location
 // segment is absent.
+//
+// In unnamed mode (objectLocation == ObjectLocationMissing) the
+// <objectLocation> segment is dropped from every shape; the value-key
+// branch treats the entire stripped path as <name>.
 func (n *layeredNamer) ParseKey(raw string) (DefaultKey, error) {
 	stripped := strings.TrimPrefix(raw, "/")
 
-	first, rest, found := strings.Cut(stripped, "/")
-	if !found || first == "" {
+	first, _, found := strings.Cut(stripped, "/")
+	if first == "" {
+		return DefaultKey{}, errInvalidKey(raw, "key must have at least one non-empty path segment")
+	}
+
+	if !found && !n.unnamed {
 		return DefaultKey{}, errInvalidKey(raw, "key must have at least two path segments")
 	}
 
 	switch first {
 	case layeredHashMarker:
+		// stripped starts with "hash/"; hand the hash parser the
+		// remainder after the marker.
+		_, rest, _ := strings.Cut(stripped, "/")
+
 		return n.parseHashKey(raw, rest)
 	case layeredSigMarker:
+		_, rest, _ := strings.Cut(stripped, "/")
+
 		return n.parseSigKey(raw, rest)
 	default:
 		return n.parseValueKey(raw, stripped)
@@ -332,14 +393,23 @@ func (n *layeredNamer) ParseKeys(names []string, ignoreError bool) (Results, err
 //	Prefix("alice", false)  → "/objects/alice"
 //	Prefix("users", true)   → "/objects/users/"
 //	Prefix("/alice/", false) → "/objects/alice"
+//
+// In unnamed mode the leading "/<objectLocation>/" segment is dropped:
+//
+//	Prefix("", true)        → "/"
+//	Prefix("alice", false)  → "/alice"
+//	Prefix("alice", true)   → "/alice/"
 func (n *layeredNamer) Prefix(val string, isPrefix bool) string {
 	suffix := strings.Trim(val, "/")
 
 	var builder strings.Builder
 
 	builder.WriteByte('/')
-	builder.WriteString(n.objectLocation)
-	builder.WriteByte('/')
+
+	if !n.unnamed {
+		builder.WriteString(n.objectLocation)
+		builder.WriteByte('/')
+	}
 
 	if suffix != "" {
 		builder.WriteString(suffix)
@@ -357,35 +427,60 @@ func (n *layeredNamer) Prefix(val string, isPrefix bool) string {
 // under their own roots (/hash/... and /sig/...), so a single Prefix() call
 // covering only /<objectLocation>/ misses them; this method emits the full
 // fan-out a validating range walk needs.
+//
+// In unnamed mode the per-category roots become "/", "/hash/<hashLocation>/"
+// and "/sig/<sigLocation>/" (the <objectLocation>/ segment is dropped). The
+// value root "/" covers the entire storage including hash/sig keys, but the
+// integrity Validator filters them by category via ParseKey.
 func (n *layeredNamer) Prefixes(val string, isPrefix bool) []string {
 	suffix := strings.Trim(val, "/")
 	out := make([]string, 0, 1+len(n.hashLocations)+len(n.sigLocations))
 
-	out = append(out, n.layerPrefix("/"+n.objectLocation+"/", suffix, isPrefix))
+	out = append(out, n.layerPrefix(n.valueRoot(), suffix, isPrefix))
 
 	for _, hl := range n.hashLocations {
-		root := "/" + layeredHashMarker + "/"
-		if !n.compactHash {
-			root += hl.Location + "/"
-		}
-
-		root += n.objectLocation + "/"
-
-		out = append(out, n.layerPrefix(root, suffix, isPrefix))
+		out = append(out, n.layerPrefix(n.hashRoot(hl.Location), suffix, isPrefix))
 	}
 
 	for _, sl := range n.sigLocations {
-		root := "/" + layeredSigMarker + "/"
-		if !n.compactSig {
-			root += sl.Location + "/"
-		}
-
-		root += n.objectLocation + "/"
-
-		out = append(out, n.layerPrefix(root, suffix, isPrefix))
+		out = append(out, n.layerPrefix(n.sigRoot(sl.Location), suffix, isPrefix))
 	}
 
 	return out
+}
+
+func (n *layeredNamer) valueRoot() string {
+	if n.unnamed {
+		return "/"
+	}
+
+	return "/" + n.objectLocation + "/"
+}
+
+func (n *layeredNamer) hashRoot(hashLocation string) string {
+	root := "/" + layeredHashMarker + "/"
+	if !n.compactHash {
+		root += hashLocation + "/"
+	}
+
+	if !n.unnamed {
+		root += n.objectLocation + "/"
+	}
+
+	return root
+}
+
+func (n *layeredNamer) sigRoot(sigLocation string) string {
+	root := "/" + layeredSigMarker + "/"
+	if !n.compactSig {
+		root += sigLocation + "/"
+	}
+
+	if !n.unnamed {
+		root += n.objectLocation + "/"
+	}
+
+	return root
 }
 
 // layerPrefix appends suffix to a category root, optionally tacking on a
@@ -404,23 +499,55 @@ func (n *layeredNamer) layerPrefix(root, suffix string, isPrefix bool) string {
 	return out
 }
 
+func (n *layeredNamer) buildValueKey(name string) string {
+	if n.unnamed {
+		return "/" + name
+	}
+
+	return "/" + n.objectLocation + "/" + name
+}
+
 func (n *layeredNamer) buildHashKey(hashLocation, name string) string {
-	if n.compactHash {
+	switch {
+	case n.compactHash && n.unnamed:
+		return "/" + layeredHashMarker + "/" + name
+	case n.compactHash:
 		return "/" + layeredHashMarker + "/" + n.objectLocation + "/" + name
+	case n.unnamed:
+		return "/" + layeredHashMarker + "/" + hashLocation + "/" + name
 	}
 
 	return "/" + layeredHashMarker + "/" + hashLocation + "/" + n.objectLocation + "/" + name
 }
 
 func (n *layeredNamer) buildSigKey(sigLocation, name string) string {
-	if n.compactSig {
+	switch {
+	case n.compactSig && n.unnamed:
+		return "/" + layeredSigMarker + "/" + name
+	case n.compactSig:
 		return "/" + layeredSigMarker + "/" + n.objectLocation + "/" + name
+	case n.unnamed:
+		return "/" + layeredSigMarker + "/" + sigLocation + "/" + name
 	}
 
 	return "/" + layeredSigMarker + "/" + sigLocation + "/" + n.objectLocation + "/" + name
 }
 
 func (n *layeredNamer) parseValueKey(raw, stripped string) (DefaultKey, error) {
+	if n.unnamed {
+		// In unnamed mode the entire stripped path is the name; the
+		// dispatcher already excluded "hash" / "sig" first segments.
+		if strings.HasSuffix(raw, "/") {
+			return DefaultKey{}, errInvalidKey(raw, "key name should not be prefix")
+		}
+
+		if stripped == "" {
+			return DefaultKey{}, errInvalidKey(raw, "name part must not be empty")
+		}
+
+		return NewDefaultKey(stripped, KeyTypeValue, "", raw), nil
+	}
+
 	name, ok := strings.CutPrefix(stripped, n.objectLocation+"/")
 	if !ok {
 		first, _, _ := strings.Cut(stripped, "/")
@@ -448,6 +575,15 @@ func (n *layeredNamer) parseHashKey(raw, rest string) (DefaultKey, error) {
 }
 
 func (n *layeredNamer) parseCompactHashKey(raw, rest string) (DefaultKey, error) {
+	if n.unnamed {
+		err := validateNamePart(raw, rest, "hash")
+		if err != nil {
+			return DefaultKey{}, err
+		}
+
+		return NewDefaultKey(rest, KeyTypeHash, n.hashLocations[0].HasherName, raw), nil
+	}
+
 	after, ok := strings.CutPrefix(rest, n.objectLocation+"/")
 	if !ok {
 		return DefaultKey{}, errInvalidKey(raw,
@@ -473,6 +609,15 @@ func (n *layeredNamer) parseFullHashKey(raw, rest string) (DefaultKey, error) {
 		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown hash location %q", hashLoc))
 	}
 
+	if n.unnamed {
+		err := validateNamePart(raw, afterLoc, "hash")
+		if err != nil {
+			return DefaultKey{}, err
+		}
+
+		return NewDefaultKey(afterLoc, KeyTypeHash, hasherName, raw), nil
+	}
+
 	after, ok := strings.CutPrefix(afterLoc, n.objectLocation+"/")
 	if !ok {
 		return DefaultKey{}, errInvalidKey(raw,
@@ -496,6 +641,15 @@ func (n *layeredNamer) parseSigKey(raw, rest string) (DefaultKey, error) {
 }
 
 func (n *layeredNamer) parseCompactSigKey(raw, rest string) (DefaultKey, error) {
+	if n.unnamed {
+		err := validateNamePart(raw, rest, "sig")
+		if err != nil {
+			return DefaultKey{}, err
+		}
+
+		return NewDefaultKey(rest, KeyTypeSignature, n.sigLocations[0].SignerName, raw), nil
+	}
+
 	after, ok := strings.CutPrefix(rest, n.objectLocation+"/")
 	if !ok {
 		return DefaultKey{}, errInvalidKey(raw,
@@ -519,6 +673,15 @@ func (n *layeredNamer) parseFullSigKey(raw, rest string) (DefaultKey, error) {
 	signerName, ok := n.sigIndex[sigLoc]
 	if !ok {
 		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown sig location %q", sigLoc))
+	}
+
+	if n.unnamed {
+		err := validateNamePart(raw, afterLoc, "sig")
+		if err != nil {
+			return DefaultKey{}, err
+		}
+
+		return NewDefaultKey(afterLoc, KeyTypeSignature, signerName, raw), nil
 	}
 
 	after, ok := strings.CutPrefix(afterLoc, n.objectLocation+"/")

--- a/namer/layered_test.go
+++ b/namer/layered_test.go
@@ -36,9 +36,16 @@ func TestLayeredNamer_Constructor_Validation(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "empty objectLocation",
-			args:    args{objectLocation: "", hashLocations: nil, sigLocations: nil, opts: nil},
-			wantErr: true,
+			// ObjectLocationMissing ("") selects unnamed mode and is
+			// accepted at construction time.
+			name: "empty objectLocation (unnamed mode)",
+			args: args{
+				objectLocation: namer.ObjectLocationMissing,
+				hashLocations:  nil,
+				sigLocations:   nil,
+				opts:           nil,
+			},
+			wantErr: false,
 		},
 		{
 			name:    "objectLocation with leading slash",

--- a/namer/unnamed_layered_test.go
+++ b/namer/unnamed_layered_test.go
@@ -1,0 +1,268 @@
+package namer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/namer"
+)
+
+func newUnnamedNamer(
+	t *testing.T,
+	hashLocs []namer.LayeredHashLocation,
+	sigLocs []namer.LayeredSigLocation,
+	opts ...namer.LayeredOption,
+) namer.Namer {
+	t.Helper()
+
+	n, err := namer.NewLayeredNamer(namer.ObjectLocationMissing, hashLocs, sigLocs, opts...)
+	require.NoError(t, err)
+
+	return n
+}
+
+func TestUnnamedLayeredNamer_GenerateNames(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	keys, err := nmr.GenerateNames("alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	assert.Equal(t, "/alice", keys[0].Build())
+	assert.Equal(t, namer.KeyTypeValue, keys[0].Type())
+	assert.Equal(t, "alice", keys[0].Name())
+
+	assert.Equal(t, "/hash/sha256/alice", keys[1].Build())
+	assert.Equal(t, namer.KeyTypeHash, keys[1].Type())
+	assert.Equal(t, "sha256", keys[1].Property())
+
+	assert.Equal(t, "/sig/ed25519/alice", keys[2].Build())
+	assert.Equal(t, namer.KeyTypeSignature, keys[2].Type())
+	assert.Equal(t, "ed25519", keys[2].Property())
+}
+
+func TestUnnamedLayeredNamer_GenerateNames_RejectsReservedFirstSegment(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	cases := []string{"hash", "sig", "hash/foo", "sig/bar/baz"}
+
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := nmr.GenerateNames(name)
+			require.Error(t, err)
+
+			var nameErr namer.InvalidNameError
+
+			require.ErrorAs(t, err, &nameErr)
+		})
+	}
+}
+
+func TestUnnamedLayeredNamer_GenerateNames_AcceptsNonReservedNames(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t, nil, nil)
+
+	for _, name := range []string{"hashish", "signal", "alice/sub", "x"} {
+		keys, err := nmr.GenerateNames(name)
+		require.NoError(t, err, "name=%q", name)
+		require.NotEmpty(t, keys)
+	}
+}
+
+func TestUnnamedLayeredNamer_ParseKey_Value(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t, nil, nil)
+
+	parsed, err := nmr.ParseKey("/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", parsed.Name())
+	assert.Equal(t, namer.KeyTypeValue, parsed.Type())
+
+	parsed, err = nmr.ParseKey("/foo/bar/baz")
+	require.NoError(t, err)
+	assert.Equal(t, "foo/bar/baz", parsed.Name())
+	assert.Equal(t, namer.KeyTypeValue, parsed.Type())
+}
+
+func TestUnnamedLayeredNamer_ParseKey_HashAndSig(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	parsed, err := nmr.ParseKey("/hash/sha256/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", parsed.Name())
+	assert.Equal(t, namer.KeyTypeHash, parsed.Type())
+	assert.Equal(t, "sha256", parsed.Property())
+
+	parsed, err = nmr.ParseKey("/sig/ed25519/alice")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", parsed.Name())
+	assert.Equal(t, namer.KeyTypeSignature, parsed.Type())
+	assert.Equal(t, "ed25519", parsed.Property())
+}
+
+func TestUnnamedLayeredNamer_ParseKey_Errors(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	cases := []string{
+		"",
+		"/",
+		"/hash/",
+		"/hash/sha256/",
+		"/hash/unknown/alice",
+		"/sig/",
+		"/sig/unknown/alice",
+		"/alice/",
+	}
+
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := nmr.ParseKey(raw)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestUnnamedLayeredNamer_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	for _, name := range []string{"alice", "users/bob", "deeply/nested/name"} {
+		keys, err := nmr.GenerateNames(name)
+		require.NoError(t, err, name)
+
+		for _, key := range keys {
+			parsed, err := nmr.ParseKey(key.Build())
+			require.NoError(t, err, "raw=%q", key.Build())
+			assert.Equal(t, key.Name(), parsed.Name(), "raw=%q", key.Build())
+			assert.Equal(t, key.Type(), parsed.Type(), "raw=%q", key.Build())
+			assert.Equal(t, key.Property(), parsed.Property(), "raw=%q", key.Build())
+		}
+	}
+}
+
+func TestUnnamedLayeredNamer_Prefix(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t, nil, nil)
+
+	assert.Equal(t, "/", nmr.Prefix("", true))
+	assert.Equal(t, "/", nmr.Prefix("", false))
+	assert.Equal(t, "/alice", nmr.Prefix("alice", false))
+	assert.Equal(t, "/alice/", nmr.Prefix("alice", true))
+	assert.Equal(t, "/alice", nmr.Prefix("/alice/", false))
+}
+
+func TestUnnamedLayeredNamer_Compact(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		namer.CompactSingleHash(),
+		namer.CompactSingleSig(),
+	)
+
+	keys, err := nmr.GenerateNames("alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	assert.Equal(t, "/alice", keys[0].Build())
+	assert.Equal(t, "/hash/alice", keys[1].Build())
+	assert.Equal(t, "/sig/alice", keys[2].Build())
+
+	for _, key := range keys {
+		parsed, err := nmr.ParseKey(key.Build())
+		require.NoError(t, err, "raw=%q", key.Build())
+		assert.Equal(t, key.Name(), parsed.Name())
+		assert.Equal(t, key.Type(), parsed.Type())
+	}
+}
+
+func TestUnnamedLayeredNamer_Compact_ParseErrors(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		namer.CompactSingleHash(),
+		namer.CompactSingleSig(),
+	)
+
+	// Compact + unnamed: hash/<name> must not be empty or end with '/'.
+	cases := []string{"/hash/", "/hash/alice/", "/sig/", "/sig/alice/"}
+
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := nmr.ParseKey(raw)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestUnnamedLayeredNamer_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	// Unnamed-mode roots: value at "/", hash at "/hash/<loc>/", sig at "/sig/<loc>/".
+	prefixes := nmr.Prefixes("", true)
+	assert.Equal(t, []string{"/", "/hash/sha256/", "/sig/ed25519/"}, prefixes)
+
+	prefixes = nmr.Prefixes("alice", false)
+	assert.Equal(t, []string{"/alice", "/hash/sha256/alice", "/sig/ed25519/alice"}, prefixes)
+
+	prefixes = nmr.Prefixes("alice", true)
+	assert.Equal(t, []string{"/alice/", "/hash/sha256/alice/", "/sig/ed25519/alice/"}, prefixes)
+}
+
+func TestUnnamedLayeredNamer_Compact_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	nmr := newUnnamedNamer(t,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		namer.CompactSingleHash(),
+		namer.CompactSingleSig(),
+	)
+
+	// Compact + unnamed: hashLocation / sigLocation segments are also dropped.
+	prefixes := nmr.Prefixes("", true)
+	assert.Equal(t, []string{"/", "/hash/", "/sig/"}, prefixes)
+}


### PR DESCRIPTION

- Add `namer.ObjectLocationMissing` sentinel that switches `NewLayeredNamer` into **unnamed mode**: the per-codec `objectLocation` segment is dropped from every emitted key. Layout becomes `/<name>` (value), `/hash/<hashLocation>/<name>` (hash), `/sig/<sigLocation>/<name>` (signature).
- Object names whose first slash-separated segment is `hash` or `sig` are rejected by `GenerateNames` in unnamed mode to avoid colliding with the category markers.
- `integrity.CodecBuilder[T]` no longer silently substitutes `"objects"` when `WithObjectLocation` is not called — an unconfigured builder is **unnamed by default**. Callers who relied on the old `/objects/<name>` shape must now call `WithObjectLocation("objects")` explicitly.
- `CompactSingleHash` / `CompactSingleSig` continue to compose with unnamed mode and further drop the per-hasher / per-signer segment.

## Breaking change

This changes the silent default in `CodecBuilder[T]`. Existing call sites that built a codec without `WithObjectLocation` and stored data at `/objects/<name>` will now read/write `/<name>` instead. Migrate by adding `.WithObjectLocation("objects")` to those builders. All in-tree tests have been updated accordingly.