### PR TITLE
connect: add a TCS ping when connected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `/objects/<name>`). Callers who relied on the silent default must add
   `.WithObjectLocation("objects")` (or any other segment) explicitly.
   This is a breaking change for codecs that omitted `WithObjectLocation`.
+- connect: tcs now pings the server on connect to detect valid credentials.
 
 - storage.Prefixed: signature is now
   `Prefixed(prefix, inner) (Storage, error)`. A non-empty prefix ending

--- a/connect/error.go
+++ b/connect/error.go
@@ -10,6 +10,8 @@ var (
 	// ErrInvalidSSLConfig is returned when SSL configuration is invalid.
 	ErrInvalidSSLConfig = errors.New("invalid SSL configuration")
 
+	errFailedTarantoolProbe = errors.New("failed to probe Tarantool")
+
 	errNoCACerts         = errors.New("failed to append CA certificates")
 	errFailedReadCAFile  = errors.New("failed to read CA file")
 	errFailedReadCAPath  = errors.New("failed to read CA path")

--- a/connect/tcs.go
+++ b/connect/tcs.go
@@ -42,5 +42,25 @@ func createTCSConnection(ctx context.Context, cfg Config) (tcsdriver.DoerWatcher
 
 	wrapper := pool.NewConnectorAdapter(conn, pool.RW)
 
+	err = probeTCSConnection(ctx, wrapper)
+	if err != nil {
+		_ = wrapper.Close()
+
+		return nil, nil, err
+	}
+
 	return wrapper, func() { _ = wrapper.Close() }, nil
+}
+
+func probeTCSConnection(ctx context.Context, conn tcsdriver.DoerWatcher) error {
+	req := tarantool.NewCallRequest("config.storage.get").
+		Args([]any{"/"}).
+		Context(ctx)
+
+	_, err := conn.Do(req).GetResponse()
+	if err != nil {
+		return fmt.Errorf("%w: %w", errFailedTarantoolProbe, err)
+	}
+
+	return nil
 }

--- a/connect/tcs_test.go
+++ b/connect/tcs_test.go
@@ -1,0 +1,51 @@
+//nolint:testpackage
+package connect
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tarantool/go-tarantool/v2"
+)
+
+type doerWatcherStub struct {
+	doErr error
+	doN   int
+}
+
+func (s *doerWatcherStub) Do(req tarantool.Request) *tarantool.Future {
+	s.doN++
+
+	fut := tarantool.NewFuture(req)
+	fut.SetError(s.doErr)
+
+	return fut
+}
+
+func (s *doerWatcherStub) NewWatcher(_ string, _ tarantool.WatchCallback) (tarantool.Watcher, error) {
+	return nil, errors.New("not implemented")
+}
+
+func TestProbeTCSConnection_OK(t *testing.T) {
+	t.Parallel()
+
+	stub := &doerWatcherStub{doErr: nil, doN: 0}
+	err := probeTCSConnection(context.Background(), stub)
+	require.NoError(t, err)
+	require.Equal(t, 1, stub.doN)
+}
+
+func TestProbeTCSConnection_ErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	stubErr := errors.New("dial/auth failed")
+	stub := &doerWatcherStub{doErr: stubErr, doN: 0}
+
+	err := probeTCSConnection(context.Background(), stub)
+	require.Error(t, err)
+	require.ErrorIs(t, err, errFailedTarantoolProbe)
+	require.ErrorIs(t, err, stubErr)
+	require.Equal(t, 1, stub.doN)
+}


### PR DESCRIPTION
Currently, there is no validation when creating a connection, so incorrect data can only be detected after the first request. This has been changed.

Part of TNTP-7387
