### PR TITLE
connect: fix probe return errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,8 @@ linters:
             # for etcd LazyCluster reimplementation
             - "go.etcd.io/etcd/client/pkg/v3"
             - "go.etcd.io/etcd/tests/v3/"
+            # for mute etcd warn output
+            - "go.uber.org/zap"
         test:
           files:
             - "$test"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   — and `/<objectLocation>` is a single segment, which `ParseKey`
   rejects. The filter was a no-op under the new contract anyway, so
   both methods now forward driver events as-is.
+- connect: NewEtcdStorage stuck in infinite loop with bad endpoints.
+- connect: NewTCSStorage didn't check credentials validity.
 
 ## [v1.3.0] - 2026-05-05
 

--- a/connect/config.go
+++ b/connect/config.go
@@ -1,6 +1,8 @@
 package connect
 
-import "time"
+import (
+	"time"
+)
 
 const (
 	defaultDialTimeout = 5 * time.Second

--- a/connect/error.go
+++ b/connect/error.go
@@ -16,7 +16,6 @@ var (
 	errFailedLoadKeyPair = errors.New("failed to load key pair")
 	errFailedTLSConfig   = errors.New("failed to build TLS config")
 	errFailedEtcdClient  = errors.New("failed to create etcd client")
-	errFailedEtcdProbe   = errors.New("failed to probe etcd cluster")
 	errFailedTarantool   = errors.New("failed to connect to Tarantool")
 	errCertFileRead      = errors.New("failed to read certificate file")
 	errUnknownCipher     = errors.New("unknown cipher")

--- a/connect/etcd.go
+++ b/connect/etcd.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	etcdclient "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
 )
 
 func createEtcdClient(ctx context.Context, cfg Config) (*etcdclient.Client, CleanupFunc, error) {
@@ -28,6 +29,7 @@ func createEtcdClient(ctx context.Context, cfg Config) (*etcdclient.Client, Clea
 		DialTimeout: cfg.dialTimeout(),
 		Username:    cfg.Username,
 		Password:    cfg.Password,
+		Logger:      zap.NewNop(),
 	}
 
 	if cfg.SSL.Enable {
@@ -44,11 +46,14 @@ func createEtcdClient(ctx context.Context, cfg Config) (*etcdclient.Client, Clea
 		return nil, nil, fmt.Errorf("%w: %w", errFailedEtcdClient, clientErr)
 	}
 
-	_, statusErr := client.Status(ctx, cfg.Endpoints[0])
+	statusCtx, statusCancel := context.WithTimeout(ctx, cfg.dialTimeout())
+	defer statusCancel()
+
+	_, statusErr := client.Status(statusCtx, cfg.Endpoints[0])
 	if statusErr != nil {
 		_ = client.Close()
 
-		return nil, nil, fmt.Errorf("%w: %w", errFailedEtcdProbe, statusErr)
+		return nil, nil, fmt.Errorf("%w: %w", errFailedEtcdClient, statusErr)
 	}
 
 	return client, func() { _ = client.Close() }, nil

--- a/connect/integration_test.go
+++ b/connect/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	tcshelper "github.com/tarantool/go-tarantool/v2/test_helpers/tcs"
 	"go.etcd.io/etcd/client/pkg/v3/transport" //nolint:depguard
+	etcdclient "go.etcd.io/etcd/client/v3"
 	etcdfintegration "go.etcd.io/etcd/tests/v3/framework/integration"
 	etcdlazy "go.etcd.io/etcd/tests/v3/integration"
 
@@ -69,6 +70,43 @@ func createEtcdTestConfig(t *testing.T) connect.Config {
 	return connect.Config{ //nolint:exhaustruct
 		Endpoints: cluster.EndpointsGRPC(),
 	}
+}
+
+func createEtcdAuthTestConfig(t *testing.T) connect.Config {
+	t.Helper()
+
+	cfg := createEtcdTestConfig(t)
+
+	client, err := etcdclient.New(etcdclient.Config{ //nolint:exhaustruct
+		Endpoints:   cfg.Endpoints,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = client.Auth.UserAdd(ctx, "root", "root")
+	require.NoError(t, err)
+
+	_, err = client.Auth.UserGrantRole(ctx, "root", "root")
+	require.NoError(t, err)
+
+	_, err = client.Auth.UserAdd(ctx, "client", "secret")
+	require.NoError(t, err)
+
+	_, err = client.Auth.UserGrantRole(ctx, "client", "root")
+	require.NoError(t, err)
+
+	_, err = client.Auth.AuthEnable(ctx)
+	require.NoError(t, err)
+
+	cfg.Username = "client"
+	cfg.Password = "secret"
+
+	return cfg
 }
 
 func TestNewEtcdStorage_PutAndGet(t *testing.T) {
@@ -383,6 +421,18 @@ func TestNewEtcdStorage_CanceledContext(t *testing.T) {
 	assert.ErrorIs(t, err, context.Canceled)
 }
 
+func TestNewEtcdStorage_InvalidCredentials(t *testing.T) {
+	cfg := createEtcdAuthTestConfig(t)
+	cfg.Username = "invalid_user"
+	cfg.Password = "invalid_pass"
+
+	ctx := context.Background()
+
+	_, _, err := connect.NewEtcdStorage(ctx, cfg)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "authentication failed, invalid user ID or password")
+}
+
 func TestNewTCSStorage_CanceledContext(t *testing.T) {
 	if !haveTCS {
 		t.Skip("TCS is unsupported or Tarantool isn't found")
@@ -395,6 +445,26 @@ func TestNewTCSStorage_CanceledContext(t *testing.T) {
 		Endpoints: tcsEndpoints,
 	})
 	require.Error(t, err)
+}
+
+func TestNewTCSStorage_InvalidCredentials(t *testing.T) {
+	if !haveTCS {
+		t.Skip("TCS is unsupported or Tarantool isn't found")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping integration tests in short mode")
+	}
+
+	ctx := context.Background()
+
+	_, _, err := connect.NewTCSStorage(ctx, connect.Config{ //nolint:exhaustruct
+		Endpoints: tcsEndpoints,
+		Username:  "invalid_user",
+		Password:  "invalid_pass",
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "supplied credentials are invalid")
 }
 
 func TestNewEtcdStorage_WithTLSEncryptedKeyAndPassword(t *testing.T) {

--- a/connect/tcs.go
+++ b/connect/tcs.go
@@ -35,6 +35,24 @@ func createTCSConnection(ctx context.Context, cfg Config) (tcsdriver.DoerWatcher
 		})
 	}
 
+	// Probe the connections to ensure that we have at least one working connection.
+	//
+	// Go-tarantool pool doesn't return connection failures, just logs it.
+	// Check go-tarantool/v2@v2.4.1/pool/connection_pool.go:200,
+	// So we need to check it ourselves.
+	probeCtx, cancel := context.WithTimeout(ctx, cfg.dialTimeout())
+	probeConn, err := tarantool.Connect(probeCtx, instances[0].Dialer, tarantool.Opts{ //nolint:exhaustruct
+		Timeout: cfg.dialTimeout(),
+	})
+
+	cancel()
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", errFailedTarantool, err)
+	}
+
+	_ = probeConn.Close()
+
 	conn, connErr := pool.Connect(ctx, instances)
 	if connErr != nil {
 		return nil, nil, fmt.Errorf("%w: %w", errFailedTarantool, connErr)

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.6.5
 	go.etcd.io/etcd/client/v3 v3.6.5
 	go.etcd.io/etcd/tests/v3 v3.6.5
+	go.uber.org/zap v1.27.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -85,7 +86,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.48.0 // indirect


### PR DESCRIPTION
In current implementation connect has two errors:

1) with invalid connection to etcd (includes tcs args in connect.NewStorage) in probe connection method go into infinity loop.

2) go-tarantool pool doesn't returns connection errors, so on the first tcs operation we get "no rw instances" instead connection errors including invalid credentials.

This two errors were fixed.

Part of TNTP-7387
