### PR TITLE
tx: add Factory type and Storage.TxFactory binding

### DIFF
--- a/prefix.go
+++ b/prefix.go
@@ -99,6 +99,10 @@ func (p *prefixed) Tx(ctx context.Context) txPkg.Tx {
 	}
 }
 
+func (p *prefixed) TxFactory() txPkg.Factory {
+	return p.Tx
+}
+
 func (p *prefixed) Range(ctx context.Context, opts ...RangeOption) ([]kv.KeyValue, error) {
 	rangeOpts := &rangeOptions{Prefix: "", Limit: 0}
 	for _, opt := range opts {

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -39,6 +39,10 @@ func (s *recordingStorage) Tx(_ context.Context) txPkg.Tx {
 	return &recordingTx{rec: s, call: recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil}}
 }
 
+func (s *recordingStorage) TxFactory() txPkg.Factory {
+	return s.Tx
+}
+
 func (s *recordingStorage) Range(_ context.Context, _ ...storage.RangeOption) ([]kv.KeyValue, error) {
 	panic("recordingStorage.Range: use DriverMock-based tests for Range")
 }
@@ -533,6 +537,10 @@ func (b *blockingWatchStorage) Tx(_ context.Context) txPkg.Tx {
 	}
 }
 
+func (b *blockingWatchStorage) TxFactory() txPkg.Factory {
+	return b.Tx
+}
+
 func (b *blockingWatchStorage) Range(_ context.Context, _ ...storage.RangeOption) ([]kv.KeyValue, error) {
 	return nil, nil
 }
@@ -723,5 +731,64 @@ func TestPrefixed_ResultKeyStripping(t *testing.T) {
 		assert.Equal(t, []byte("/objects/myname"), kvs[0].Key)
 
 		mockDriver.MinimockFinish()
+	})
+}
+
+func TestPrefixed_TxFactory(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	const namespace = "/ns"
+
+	t.Run("factory rewrites operation keys with prefix", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+		prefixedStore := mustPrefix(t, namespace, inner)
+
+		factory := prefixedStore.TxFactory()
+		require.NotNil(t, factory)
+
+		_, err := factory(ctx).
+			Then(operation.Put([]byte("key"), []byte("val"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, inner.lastTx.thenOps, 1)
+		assert.Equal(t, []byte(namespace+"key"), inner.lastTx.thenOps[0].Key())
+	})
+
+	t.Run("factory survives outliving the Storage handle", func(t *testing.T) {
+		t.Parallel()
+
+		inner := &recordingStorage{
+			lastTx:       recordedTxCall{predicates: nil, thenOps: nil, elseOps: nil},
+			txResp:       txPkg.Response{Succeeded: true, Results: nil},
+			txErr:        nil,
+			lastWatchKey: nil,
+			watchEvents:  nil,
+		}
+
+		// Bind the factory once, then drop the Storage reference. The closure
+		// over the receiver must keep the prefix-rewrite path alive.
+		factory := func() txPkg.Factory {
+			s := mustPrefix(t, namespace, inner)
+			return s.TxFactory()
+		}()
+
+		_, err := factory(ctx).
+			Then(operation.Delete([]byte("key"))).
+			Commit()
+		require.NoError(t, err)
+
+		require.Len(t, inner.lastTx.thenOps, 1)
+		assert.Equal(t, []byte(namespace+"key"), inner.lastTx.thenOps[0].Key())
 	})
 }

--- a/storage.go
+++ b/storage.go
@@ -51,6 +51,11 @@ type Storage interface {
 	// The context manages timeouts and cancellation for the transaction.
 	Tx(ctx context.Context) txPkg.Tx
 
+	// TxFactory returns a tx.Factory bound to this Storage. Use it to hand
+	// "begin transaction" capability to components that do not need the full
+	// Storage interface.
+	TxFactory() txPkg.Factory
+
 	// Range queries a range of keys with optional filtering.
 	// Options:
 	//   - WithPrefix: filter keys by prefix
@@ -142,6 +147,11 @@ func (s storage) Watch(ctx context.Context, key []byte, opts ...watch.Option) <-
 // Tx implements the Storage interface for transaction creation.
 func (s storage) Tx(ctx context.Context) txPkg.Tx {
 	return newTx(ctx, s.driver)
+}
+
+// TxFactory implements the Storage interface for transaction-factory creation.
+func (s storage) TxFactory() txPkg.Factory {
+	return s.Tx
 }
 
 // Range implements the Storage interface for range queries.

--- a/storage_test.go
+++ b/storage_test.go
@@ -30,6 +30,71 @@ func TestStorage_Tx(t *testing.T) {
 	assert.NotNil(t, txInstance)
 }
 
+func TestStorage_TxFactory(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns non-nil factory that produces transactions", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDriver := mocks.NewDriverMock(t)
+		strg := storage.NewStorage(mockDriver)
+
+		factory := strg.TxFactory()
+		require.NotNil(t, factory)
+
+		txInstance := factory(ctx)
+		assert.NotNil(t, txInstance)
+	})
+
+	t.Run("factory routes to driver same as Storage.Tx", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDriver := mocks.NewDriverMock(t)
+		strg := storage.NewStorage(mockDriver)
+
+		thenOp := operation.Put([]byte("key"), []byte("value"))
+		expected := tx.Response{Succeeded: true, Results: []tx.RequestResponse{}}
+
+		mockDriver.ExecuteMock.Expect(ctx, nil, []operation.Operation{thenOp}, nil).
+			Return(expected, nil)
+
+		factory := strg.TxFactory()
+		resp, err := factory(ctx).Then(thenOp).Commit()
+
+		require.NoError(t, err)
+		assert.Equal(t, expected, resp)
+		mockDriver.MinimockFinish()
+	})
+
+	t.Run("each invocation returns an independent transaction", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		mockDriver := mocks.NewDriverMock(t)
+		strg := storage.NewStorage(mockDriver)
+
+		factory := strg.TxFactory()
+		tx1 := factory(ctx)
+		tx2 := factory(ctx)
+
+		assert.NotSame(t, tx1, tx2, "factory must produce distinct tx instances")
+	})
+
+	t.Run("Storage.Tx method-value satisfies tx.Factory", func(t *testing.T) {
+		t.Parallel()
+
+		mockDriver := mocks.NewDriverMock(t)
+		strg := storage.NewStorage(mockDriver)
+
+		// Compile-time + runtime check: a method value of Tx is assignable to
+		// tx.Factory, which is the documented "alternative way to bind".
+		var factory tx.Factory = strg.Tx
+		require.NotNil(t, factory)
+	})
+}
+
 func TestTx_If(t *testing.T) {
 	t.Parallel()
 

--- a/tx/tx.go
+++ b/tx/tx.go
@@ -3,6 +3,8 @@
 package tx
 
 import (
+	"context"
+
 	"github.com/tarantool/go-storage/operation"
 	"github.com/tarantool/go-storage/predicate"
 )
@@ -22,3 +24,12 @@ type Tx interface {
 	// Commit atomically executes the transaction and returns the result.
 	Commit() (Response, error)
 }
+
+// Factory creates new transactions bound to a storage instance.
+//
+// It is the lightest "begin a transaction" surface — bind once via
+// Storage.TxFactory and pass the resulting Factory around to components that
+// only need to start transactions, instead of handing out the full Storage.
+// A Storage's Tx method satisfies this signature directly, so a Factory can
+// also be obtained as a method value: var f tx.Factory = s.Tx.
+type Factory func(ctx context.Context) Tx


### PR DESCRIPTION
- Introduce `tx.Factory` — the lightest "begin a transaction" surface — as a `func(ctx) tx.Tx`.
- Add `Storage.TxFactory()` to hand that capability to components that don't need the full `Storage` interface.
- `prefixed` implements `TxFactory()` so factory-issued transactions keep the prefix-rewrite path.

A `Storage`'s `Tx` method value already satisfies `tx.Factory`, so a factory can also be obtained as `var f tx.Factory = s.Tx`.
