### PR TITLE
namer: rename hash path marker from "hash" to "hashes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- **BREAKING:** namer: hash key path marker changed from `hash` to
+  `hashes`. The default layout is now
+  `/<objectLocation>/hashes/<hashLocation>/<name>` (default namer) and
+  `/hashes/<hashLocation>/<objectLocation>/<name>` (layered namer); the
+  unnamed-layered and compact-hash variants follow the same rename.
+  Existing keys written under `/hash/...` will not be parsed by the new
+  namer — operators upgrading must migrate stored keys to the new prefix.
+  The reserved-marker check on `objectLocation` and the unnamed-mode
+  reserved-first-segment check now reject `hashes` instead of `hash`.
+
 ### Fixed
 
 ## [v1.4.0] - 2026-05-12

--- a/README.md
+++ b/README.md
@@ -440,16 +440,16 @@ The new API uses `namer.LayeredNamer` by default, which places each key
 category under its own top-level location segment:
 
 ```
-/<objectLocation>/<name>                       (value)
-/hash/<hashLocation>/<objectLocation>/<name>   (one per hasher)
-/sig/<sigLocation>/<objectLocation>/<name>     (one per signer)
+/<objectLocation>/<name>                         (value)
+/hashes/<hashLocation>/<objectLocation>/<name>   (one per hasher)
+/sig/<sigLocation>/<objectLocation>/<name>       (one per signer)
 ```
 
 `objectLocation` may itself be a multi-segment path (e.g. `"settings/ldap"`)
 — useful when the on-disk hierarchy of a feature is fixed at codec build
 time rather than per item. `hashLocation` and `sigLocation` are still
 single tokens because they index per-hasher / per-signer maps. The first
-segment of `objectLocation` must not equal the reserved markers `hash` or
+segment of `objectLocation` must not equal the reserved markers `hashes` or
 `sig` (they would collide with the parser's category dispatch).
 
 `namer.CompactSingleHash()` and `namer.CompactSingleSig()` drop the
@@ -480,9 +480,9 @@ if err != nil {
 }
 
 // Wire layout:
-//   /settings/auth                      (value)
-//   /hash/<hashLoc>/settings/auth       (hash, per hasher)
-//   /sig/<sigLoc>/settings/auth         (sig,  per signer)
+//   /settings/auth                        (value)
+//   /hashes/<hashLoc>/settings/auth       (hash, per hasher)
+//   /sig/<sigLoc>/settings/auth           (sig,  per signer)
 
 if err := auth.Put(ctx, AuthConfig{Issuer: "example"}); err != nil {
     log.Fatal(err)

--- a/integrity/codec.go
+++ b/integrity/codec.go
@@ -245,7 +245,7 @@ func (b CodecBuilder[T]) WithNamer(f CodecNamerConstructor) CodecBuilder[T] {
 }
 
 // WithSingleHashCompact opts the codec into the compact hash key layout
-// (/hash/<objectLocation>/<name>, dropping the per-hasher segment). Build
+// (/hashes/<objectLocation>/<name>, dropping the per-hasher segment). Build
 // returns ErrSingleHashCompactCardinality if exactly one hasher is not
 // configured.
 func (b CodecBuilder[T]) WithSingleHashCompact() CodecBuilder[T] {

--- a/integrity/codec_test.go
+++ b/integrity/codec_test.go
@@ -118,12 +118,12 @@ func TestCodecBuilder_WithHasher(t *testing.T) {
 	var foundHash bool
 
 	for _, k := range keys {
-		if k.Build() == "/hash/sha256/objects/foo" {
+		if k.Build() == "/hashes/sha256/objects/foo" {
 			foundHash = true
 		}
 	}
 
-	assert.True(t, foundHash, "expected hash key at /hash/sha256/objects/foo")
+	assert.True(t, foundHash, "expected hash key at /hashes/sha256/objects/foo")
 }
 
 func TestCodecBuilder_WithHashLocation(t *testing.T) {
@@ -147,12 +147,12 @@ func TestCodecBuilder_WithHashLocation(t *testing.T) {
 	var foundCustom bool
 
 	for _, k := range keys {
-		if k.Build() == "/hash/checksums/objects/foo" {
+		if k.Build() == "/hashes/checksums/objects/foo" {
 			foundCustom = true
 		}
 	}
 
-	assert.True(t, foundCustom, "expected hash key at /hash/checksums/objects/foo")
+	assert.True(t, foundCustom, "expected hash key at /hashes/checksums/objects/foo")
 }
 
 func TestCodecBuilder_WithSigner(t *testing.T) {
@@ -248,7 +248,7 @@ func TestCodecBuilder_StaleSigLocationKey(t *testing.T) {
 func TestCodecBuilder_ReservedObjectLocation(t *testing.T) {
 	t.Parallel()
 
-	for _, reserved := range []string{"hash", "sig"} {
+	for _, reserved := range []string{"hashes", "sig"} {
 		t.Run(reserved, func(t *testing.T) {
 			t.Parallel()
 

--- a/integrity/generator_test.go
+++ b/integrity/generator_test.go
@@ -178,13 +178,13 @@ func TestGeneratorGenerate_SuccessWithHashes(t *testing.T) {
 	hashPairs := 0
 
 	for _, pair := range pairs {
-		if string(pair.Key) == "/test/hash/sha256/my-object" {
+		if string(pair.Key) == "/test/hashes/sha256/my-object" {
 			hashPairs++
 
 			assert.Equal(t, "mock-hash-sha256", string(pair.Value))
 		}
 
-		if string(pair.Key) == "/test/hash/md5/my-object" {
+		if string(pair.Key) == "/test/hashes/md5/my-object" {
 			hashPairs++
 
 			assert.Equal(t, "mock-hash-md5", string(pair.Value))
@@ -271,7 +271,7 @@ func TestGeneratorGenerate_SuccessWithHashesAndSignatures(t *testing.T) {
 	}
 
 	assert.True(t, keys["/test/my-object"])
-	assert.True(t, keys["/test/hash/sha256/my-object"])
+	assert.True(t, keys["/test/hashes/sha256/my-object"])
 	assert.True(t, keys["/test/sig/rsa/my-object"])
 }
 
@@ -404,9 +404,9 @@ func TestGeneratorGenerate_OutputStructure(t *testing.T) {
 
 	// Verify key patterns.
 	expectedKeys := map[string]bool{
-		"/storage/config/app":             true,
-		"/storage/hash/sha256/config/app": true,
-		"/storage/sig/rsa/config/app":     true,
+		"/storage/config/app":               true,
+		"/storage/hashes/sha256/config/app": true,
+		"/storage/sig/rsa/config/app":       true,
 	}
 
 	for _, pair := range pairs {

--- a/integrity/store_singleton_test.go
+++ b/integrity/store_singleton_test.go
@@ -17,7 +17,7 @@ import (
 
 // newSingletonCodec builds a Codec[SimpleStruct] with objectLocation="settings",
 // one hasher, and one signer/verifier — enough to exercise all three key
-// layers (value/hash/sig).
+// layers (value/hashes/sig).
 func newSingletonCodec(t *testing.T) (*integrity.Codec[SimpleStruct], string) {
 	t.Helper()
 
@@ -76,7 +76,7 @@ func TestSingletonStore_WireLayout(t *testing.T) {
 	sort.Strings(keys)
 
 	want := []string{
-		"/hash/sha256/settings/auth",
+		"/hashes/sha256/settings/auth",
 		"/settings/auth",
 		"/sig/" + sigName + "/settings/auth",
 	}

--- a/integrity/validator_test.go
+++ b/integrity/validator_test.go
@@ -65,7 +65,7 @@ func TestValidatorValidate_Success(t *testing.T) {
 			ModRevision: expectedModRevision,
 		},
 		{
-			Key: []byte("/test/hash/sha256/my-object"),
+			Key: []byte("/test/hashes/sha256/my-object"),
 			Value: []byte{
 				0x86, 0x1c, 0xdf, 0xcd, 0x76, 0x2f, 0x0a, 0x8c, 0xc0, 0xc7, 0xfc, 0x44, 0xcb, 0xfa, 0x5d, 0x29, 0xde,
 				0xed, 0x36, 0xa2, 0x5c, 0x73, 0xf7, 0xa4, 0xc6, 0x7a, 0xd6, 0x37, 0xf7, 0x1b, 0xab, 0x39,
@@ -114,7 +114,7 @@ func TestValidatorValidate_MissingHash(t *testing.T) {
 			Value:       []byte("name: test\nvalue: 42\n"),
 			ModRevision: 0,
 		},
-		// Missing hash key: /test/hash/sha256/my-object.
+		// Missing hash key: /test/hashes/sha256/my-object.
 	}
 
 	// Should fail because sha256 hash is expected but missing.
@@ -155,7 +155,7 @@ func TestValidatorValidate_HashMismatch(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key:         []byte("/test/hash/sha256/my-object"),
+			Key:         []byte("/test/hashes/sha256/my-object"),
 			Value:       []byte("corrupted-hash"), // Wrong hash.
 			ModRevision: 0,
 		},
@@ -199,7 +199,7 @@ func TestValidatorValidate_MultipleObjects(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key: []byte("/test/hash/sha256/object1"),
+			Key: []byte("/test/hashes/sha256/object1"),
 			Value: []byte{
 				0xf3, 0x88, 0x82, 0x49, 0x59, 0x8f, 0xbf, 0x4e, 0xcd, 0x8a, 0x47, 0x7a, 0x6b, 0xc3, 0x83, 0xe9, 0xa8,
 				0x8f, 0x6c, 0x13, 0xd7, 0x2a, 0x44, 0x86, 0xba, 0x6d, 0xe4, 0xf0, 0xbe, 0x7d, 0x18, 0xa9,
@@ -213,7 +213,7 @@ func TestValidatorValidate_MultipleObjects(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key: []byte("/test/hash/sha256/object2"),
+			Key: []byte("/test/hashes/sha256/object2"),
 			Value: []byte{
 				0x1c, 0x47, 0x13, 0x01, 0xf9, 0x1b, 0x97, 0x9e, 0xa2, 0x92, 0x3e, 0xd2, 0x95, 0x67, 0x46, 0x6c, 0xad,
 				0x09, 0x7d, 0xc6, 0x33, 0xb4, 0x10, 0xac, 0x9d, 0x88, 0xdb, 0xc8, 0xf2, 0xb2, 0x3f, 0x7b,
@@ -278,7 +278,7 @@ func TestValidatorValidate_PartialSuccess(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key: []byte("/test/hash/sha256/object1"),
+			Key: []byte("/test/hashes/sha256/object1"),
 			Value: []byte{
 				0xf3, 0x88, 0x82, 0x49, 0x59, 0x8f, 0xbf, 0x4e, 0xcd, 0x8a, 0x47, 0x7a, 0x6b, 0xc3, 0x83, 0xe9, 0xa8,
 				0x8f, 0x6c, 0x13, 0xd7, 0x2a, 0x44, 0x86, 0xba, 0x6d, 0xe4, 0xf0, 0xbe, 0x7d, 0x18, 0xa9,
@@ -292,7 +292,7 @@ func TestValidatorValidate_PartialSuccess(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key:         []byte("/test/hash/sha256/object2"),
+			Key:         []byte("/test/hashes/sha256/object2"),
 			Value:       []byte("corrupted-hash"), // Wrong hash.
 			ModRevision: 0,
 		},
@@ -442,7 +442,7 @@ func TestValidatorValidate_HashComputationError(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key: []byte("/test/hash/sha256/my-object"),
+			Key: []byte("/test/hashes/sha256/my-object"),
 			Value: []byte{
 				0x86, 0x1c, 0xdf, 0xcd, 0x76, 0x2f, 0x0a, 0x8c, 0xc0, 0xc7, 0xfc, 0x44, 0xcb, 0xfa, 0x5d, 0x29, 0xde,
 				0xed, 0x36, 0xa2, 0x5c, 0x73, 0xf7, 0xa4, 0xc6, 0x7a, 0xd6, 0x37, 0xf7, 0x1b, 0xab, 0x39,
@@ -510,7 +510,7 @@ func TestValidatorValidate_HasherNotAvailable(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key: []byte("/test/hash/sha256/my-object"),
+			Key: []byte("/test/hashes/sha256/my-object"),
 			Value: []byte{
 				0x86, 0x1c, 0xdf, 0xcd, 0x76, 0x2f, 0x0a, 0x8c, 0xc0, 0xc7, 0xfc, 0x44, 0xcb, 0xfa, 0x5d, 0x29, 0xde,
 				0xed, 0x36, 0xa2, 0x5c, 0x73, 0xf7, 0xa4, 0xc6, 0x7a, 0xd6, 0x37, 0xf7, 0x1b, 0xab, 0x39,
@@ -518,7 +518,7 @@ func TestValidatorValidate_HasherNotAvailable(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key:         []byte("/test/hash/sha1/my-object"),
+			Key:         []byte("/test/hashes/sha1/my-object"),
 			Value:       []byte("mock-sha1-hash"),
 			ModRevision: 0,
 		},
@@ -629,7 +629,7 @@ func TestValidatorValidate_MissingValueKey(t *testing.T) {
 
 	// Create KVs with only hash key, no value key.
 	missingValueKVs := []kv.KeyValue{
-		{Key: []byte("/test/hash/sha256/my-object"), Value: []byte("some-hash"), ModRevision: 0},
+		{Key: []byte("/test/hashes/sha256/my-object"), Value: []byte("some-hash"), ModRevision: 0},
 	}
 
 	// Should fail because value key is missing.
@@ -673,7 +673,7 @@ func TestValidatorValidate_UnmarshalError(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key: []byte("/test/hash/sha256/my-object"),
+			Key: []byte("/test/hashes/sha256/my-object"),
 			Value: []byte{
 				0x86, 0x1c, 0xdf, 0xcd, 0x76, 0x2f, 0x0a, 0x8c, 0xc0, 0xc7, 0xfc, 0x44, 0xcb, 0xfa, 0x5d, 0x29, 0xde,
 				0xed, 0x36, 0xa2, 0x5c, 0x73, 0xf7, 0xa4, 0xc6, 0x7a, 0xd6, 0x37, 0xf7, 0x1b, 0xab, 0x39,
@@ -716,14 +716,14 @@ func TestValidatorValidate_HashKeyNotFound(t *testing.T) {
 			ModRevision: 0,
 		},
 		{
-			Key: []byte("/test/hash/sha256/my-object"),
+			Key: []byte("/test/hashes/sha256/my-object"),
 			Value: []byte{
 				0x86, 0x1c, 0xdf, 0xcd, 0x76, 0x2f, 0x0a, 0x8c, 0xc0, 0xc7, 0xfc, 0x44, 0xcb, 0xfa, 0x5d, 0x29, 0xde,
 				0xed, 0x36, 0xa2, 0x5c, 0x73, 0xf7, 0xa4, 0xc6, 0x7a, 0xd6, 0x37, 0xf7, 0x1b, 0xab, 0x39,
 			},
 			ModRevision: 0,
 		},
-		// Missing sha1 hash key: /test/hash/sha1/my-object .
+		// Missing sha1 hash key: /test/hashes/sha1/my-object .
 	}
 
 	// Should fail because sha1 hash key is missing.

--- a/namer/key_test.go
+++ b/namer/key_test.go
@@ -13,7 +13,7 @@ const (
 	defaultName     = "all"
 	defaultType     = namer.KeyTypeHash
 	defaultProperty = "sha256"
-	defaultRaw      = "/config/hash/sha256/all"
+	defaultRaw      = "/config/hashes/sha256/all"
 )
 
 func TestNewDefaultKey(t *testing.T) {

--- a/namer/layered.go
+++ b/namer/layered.go
@@ -11,7 +11,7 @@ import (
 // segment sits between the marker and the objectLocation. Mirrors the
 // hashName / signatureName constants used by DefaultNamer.
 const (
-	layeredHashMarker = "hash"
+	layeredHashMarker = "hashes"
 	layeredSigMarker  = "sig"
 )
 
@@ -19,12 +19,12 @@ const (
 // argument to NewLayeredNamer to omit the per-codec objectLocation segment
 // from every generated key. The resulting layout is:
 //
-//	/<name>                          (value)
-//	/hash/<hashLocation>/<name>      (hash)
-//	/sig/<sigLocation>/<name>        (sig)
+//	/<name>                            (value)
+//	/hashes/<hashLocation>/<name>      (hash)
+//	/sig/<sigLocation>/<name>          (sig)
 //
 // In this mode object names whose first slash-separated segment equals
-// "hash" or "sig" are rejected by GenerateNames to avoid collision with
+// "hashes" or "sig" are rejected by GenerateNames to avoid collision with
 // the category markers.
 const ObjectLocationMissing = ""
 
@@ -45,10 +45,10 @@ var (
 	// ErrSegmentInnerSlash is returned when a segment contains '/'.
 	ErrSegmentInnerSlash = errors.New("namer: segment must not contain '/'")
 	// ErrObjectLocationReserved is returned when objectLocation's first segment
-	// is one of the reserved category markers ("hash" or "sig"), which would
+	// is one of the reserved category markers ("hashes" or "sig"), which would
 	// collide with hash/sig key paths during parsing.
 	ErrObjectLocationReserved = errors.New(
-		"namer: objectLocation must not start with reserved segment \"hash\" or \"sig\"")
+		"namer: objectLocation must not start with reserved segment \"hashes\" or \"sig\"")
 	// ErrCompactSingleHashCardinality is returned when CompactSingleHash is set
 	// but the configured hash list does not have exactly one entry.
 	ErrCompactSingleHashCardinality = errors.New("namer: CompactSingleHash requires exactly one hash entry")
@@ -78,7 +78,7 @@ type layeredOpts struct {
 }
 
 // CompactSingleHash drops the per-hasher location segment in generated and
-// parsed hash keys. Layout becomes /hash/<objectLocation>/<name>.
+// parsed hash keys. Layout becomes /hashes/<objectLocation>/<name>.
 // NewLayeredNamer returns ErrCompactSingleHashCardinality if the hash list
 // does not have exactly one entry.
 func CompactSingleHash() LayeredOption {
@@ -114,9 +114,9 @@ type layeredNamer struct {
 //
 // Layout (default):
 //
-//	/<objectLocation>/<name>                          (value)
-//	/hash/<hashLocation>/<objectLocation>/<name>      (hash, one per hasher)
-//	/sig/<sigLocation>/<objectLocation>/<name>        (sig, one per signer)
+//	/<objectLocation>/<name>                            (value)
+//	/hashes/<hashLocation>/<objectLocation>/<name>      (hash, one per hasher)
+//	/sig/<sigLocation>/<objectLocation>/<name>          (sig, one per signer)
 //
 // objectLocation may itself be a multi-segment path (e.g. "settings/ldap").
 // hashLocation and sigLocation are still single tokens since they index
@@ -131,7 +131,7 @@ type layeredNamer struct {
 // Validation rules:
 //   - hashLocation / sigLocation must be a single non-empty segment with no '/'.
 //   - objectLocation must not start or end with '/' and must not contain
-//     empty inner segments ("//"). Its first segment must not be "hash" or
+//     empty inner segments ("//"). Its first segment must not be "hashes" or
 //     "sig". An empty objectLocation (ObjectLocationMissing) selects unnamed
 //     mode and skips these checks.
 //   - hashLocations must be unique within hashes; sigLocations must be unique within sigs.
@@ -221,7 +221,7 @@ func NewLayeredNamer(
 }
 
 // isReservedFirstSegment reports whether name's first slash-separated
-// segment equals one of the reserved category markers ("hash" or "sig").
+// segment equals one of the reserved category markers ("hashes" or "sig").
 // In unnamed mode such names would collide with the value-key parser.
 func isReservedFirstSegment(name string) bool {
 	first, _, found := strings.Cut(name, "/")
@@ -279,7 +279,7 @@ func validateObjectLocation(seg string) error {
 // name must be non-empty; a leading "/" is stripped.
 //
 // In unnamed mode (objectLocation == ObjectLocationMissing) the first
-// slash-separated segment of name must not equal "hash" or "sig" — those
+// slash-separated segment of name must not equal "hashes" or "sig" — those
 // would collide with the category markers used to dispatch ParseKey.
 func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
 	if name == "" {
@@ -290,7 +290,7 @@ func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
 
 	if n.unnamed && isReservedFirstSegment(name) {
 		return nil, errInvalidName(name,
-			"first segment must not be \"hash\" or \"sig\" in unnamed mode")
+			"first segment must not be \"hashes\" or \"sig\" in unnamed mode")
 	}
 
 	out := make([]Key, 0, 1+len(n.hashLocations)+len(n.sigLocations))
@@ -327,9 +327,9 @@ func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
 //
 // Recognized shapes (must match the namer's configured layout):
 //
-//	/<objectLocation>/<name>                          → KeyTypeValue
-//	/hash/<hashLocation>/<objectLocation>/<name>      → KeyTypeHash
-//	/sig/<sigLocation>/<objectLocation>/<name>        → KeyTypeSignature
+//	/<objectLocation>/<name>                            → KeyTypeValue
+//	/hashes/<hashLocation>/<objectLocation>/<name>      → KeyTypeHash
+//	/sig/<sigLocation>/<objectLocation>/<name>          → KeyTypeSignature
 //
 // With CompactSingleHash / CompactSingleSig the corresponding location
 // segment is absent.
@@ -351,7 +351,7 @@ func (n *layeredNamer) ParseKey(raw string) (DefaultKey, error) {
 
 	switch first {
 	case layeredHashMarker:
-		// stripped starts with "hash/"; hand the hash parser the
+		// stripped starts with "hashes/"; hand the hash parser the
 		// remainder after the marker.
 		_, rest, _ := strings.Cut(stripped, "/")
 
@@ -424,11 +424,11 @@ func (n *layeredNamer) Prefix(val string, isPrefix bool) string {
 
 // Prefixes returns one range prefix per key category — value, then one per
 // configured hasher, then one per configured signer. Hash and sig keys live
-// under their own roots (/hash/... and /sig/...), so a single Prefix() call
+// under their own roots (/hashes/... and /sig/...), so a single Prefix() call
 // covering only /<objectLocation>/ misses them; this method emits the full
 // fan-out a validating range walk needs.
 //
-// In unnamed mode the per-category roots become "/", "/hash/<hashLocation>/"
+// In unnamed mode the per-category roots become "/", "/hashes/<hashLocation>/"
 // and "/sig/<sigLocation>/" (the <objectLocation>/ segment is dropped). The
 // value root "/" covers the entire storage including hash/sig keys, but the
 // integrity Validator filters them by category via ParseKey.
@@ -536,7 +536,7 @@ func (n *layeredNamer) buildSigKey(sigLocation, name string) string {
 func (n *layeredNamer) parseValueKey(raw, stripped string) (DefaultKey, error) {
 	if n.unnamed {
 		// In unnamed mode the entire stripped path is the name; the
-		// dispatcher already excluded "hash" / "sig" first segments.
+		// dispatcher already excluded "hashes" / "sig" first segments.
 		if strings.HasSuffix(raw, "/") {
 			return DefaultKey{}, errInvalidKey(raw, "key name should not be prefix")
 		}

--- a/namer/layered_example_test.go
+++ b/namer/layered_example_test.go
@@ -10,7 +10,7 @@ import (
 // ExampleNewLayeredNamer demonstrates the default layered key layout:
 //
 //	/<obj>/<name>                       (value)
-//	/hash/<hashLoc>/<obj>/<name>        (one per hasher)
+//	/hashes/<hashLoc>/<obj>/<name>        (one per hasher)
 //	/sig/<sigLoc>/<obj>/<name>          (one per signer)
 func ExampleNewLayeredNamer() {
 	layered, err := namer.NewLayeredNamer(
@@ -33,7 +33,7 @@ func ExampleNewLayeredNamer() {
 
 	// Output:
 	// KeyTypeValue -> /objects/alice
-	// KeyTypeHash -> /hash/sha256/objects/alice
+	// KeyTypeHash -> /hashes/sha256/objects/alice
 	// KeyTypeSignature -> /sig/rsa/objects/alice
 }
 
@@ -61,7 +61,7 @@ func ExampleCompactSingleHash() {
 
 	// Output:
 	// KeyTypeValue -> /objects/alice
-	// KeyTypeHash -> /hash/objects/alice
+	// KeyTypeHash -> /hashes/objects/alice
 }
 
 // ExampleCompactSingleSig shows the compact sig layout, which drops the
@@ -105,7 +105,7 @@ func ExampleNewLayeredNamer_parse() {
 
 	for _, raw := range []string{
 		"/objects/alice",
-		"/hash/sha256/objects/alice",
+		"/hashes/sha256/objects/alice",
 	} {
 		k, err := layered.ParseKey(raw)
 		if err != nil {

--- a/namer/layered_test.go
+++ b/namer/layered_test.go
@@ -68,8 +68,8 @@ func TestLayeredNamer_Constructor_Validation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "objectLocation reserved: hash",
-			args:    args{objectLocation: "hash", hashLocations: nil, sigLocations: nil, opts: nil},
+			name:    "objectLocation reserved: hashes",
+			args:    args{objectLocation: "hashes", hashLocations: nil, sigLocations: nil, opts: nil},
 			wantErr: true,
 		},
 		{
@@ -78,8 +78,8 @@ func TestLayeredNamer_Constructor_Validation(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "objectLocation with reserved first segment: hash/foo",
-			args:    args{objectLocation: "hash/foo", hashLocations: nil, sigLocations: nil, opts: nil},
+			name:    "objectLocation with reserved first segment: hashes/foo",
+			args:    args{objectLocation: "hashes/foo", hashLocations: nil, sigLocations: nil, opts: nil},
 			wantErr: true,
 		},
 		{
@@ -362,7 +362,7 @@ func TestLayeredNamer_Constructor_CompactErrors_Sentinels(t *testing.T) {
 	t.Run("reserved objectLocation error is sentinel", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := namer.NewLayeredNamer("hash", nil, nil)
+		_, err := namer.NewLayeredNamer("hashes", nil, nil)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, namer.ErrObjectLocationReserved)
 	})
@@ -397,7 +397,7 @@ func TestLayeredNamer_GenerateNames_Success(t *testing.T) {
 		name     string
 	}{
 		{"/objects/alice", namer.KeyTypeValue, "", "alice"},
-		{"/hash/sha256/objects/alice", namer.KeyTypeHash, "sha256", "alice"},
+		{"/hashes/sha256/objects/alice", namer.KeyTypeHash, "sha256", "alice"},
 		{"/sig/ed25519/objects/alice", namer.KeyTypeSignature, "ed25519", "alice"},
 	}
 
@@ -453,7 +453,7 @@ func TestLayeredNamer_GenerateNames_Compact(t *testing.T) {
 		require.Len(t, keys, 2)
 
 		assert.Equal(t, "/objects/alice", keys[0].Build())
-		assert.Equal(t, "/hash/objects/alice", keys[1].Build())
+		assert.Equal(t, "/hashes/objects/alice", keys[1].Build())
 		assert.Equal(t, namer.KeyTypeHash, keys[1].Type())
 		assert.Equal(t, "sha256", keys[1].Property())
 	})
@@ -496,7 +496,7 @@ func TestLayeredNamer_GenerateNames_Compact(t *testing.T) {
 		require.Len(t, keys, 3)
 
 		assert.Equal(t, "/objects/alice", keys[0].Build())
-		assert.Equal(t, "/hash/objects/alice", keys[1].Build())
+		assert.Equal(t, "/hashes/objects/alice", keys[1].Build())
 		assert.Equal(t, "/sig/objects/alice", keys[2].Build())
 	})
 }
@@ -585,19 +585,19 @@ func TestLayeredNamer_ParseKey_Errors(t *testing.T) {
 		},
 		{
 			name: "hash key with unknown hashLocation",
-			raw:  "/hash/unknown/objects/alice",
+			raw:  "/hashes/unknown/objects/alice",
 		},
 		{
 			name: "hash key with mismatched objectLocation",
-			raw:  "/hash/sha256/wrong/alice",
+			raw:  "/hashes/sha256/wrong/alice",
 		},
 		{
 			name: "hash key missing objectLocation segment",
-			raw:  "/hash/sha256/alice",
+			raw:  "/hashes/sha256/alice",
 		},
 		{
 			name: "hash key missing name",
-			raw:  "/hash/sha256/objects",
+			raw:  "/hashes/sha256/objects",
 		},
 		{
 			name: "hash key missing hashLocation",
@@ -637,10 +637,10 @@ func TestLayeredNamer_ParseKeys_Grouping(t *testing.T) {
 
 		input := []string{
 			"/objects/alice",
-			"/hash/sha256/objects/alice",
+			"/hashes/sha256/objects/alice",
 			"/sig/ed25519/objects/alice",
 			"/objects/bob",
-			"/hash/sha256/objects/bob",
+			"/hashes/sha256/objects/bob",
 			"/sig/ed25519/objects/bob",
 		}
 
@@ -662,7 +662,7 @@ func TestLayeredNamer_ParseKeys_Grouping(t *testing.T) {
 
 		input := []string{
 			"/objects/alice",
-			"/hash/sha256/objects/alice",
+			"/hashes/sha256/objects/alice",
 			"/sig/ed25519/objects/alice",
 		}
 
@@ -773,7 +773,7 @@ func TestLayeredNamer_Prefixes(t *testing.T) {
 			isPrefix: true,
 			expected: []string{
 				"/objects/",
-				"/hash/sha256/objects/",
+				"/hashes/sha256/objects/",
 				"/sig/ed25519/objects/",
 			},
 		},
@@ -783,7 +783,7 @@ func TestLayeredNamer_Prefixes(t *testing.T) {
 			isPrefix: true,
 			expected: []string{
 				"/objects/alice/",
-				"/hash/sha256/objects/alice/",
+				"/hashes/sha256/objects/alice/",
 				"/sig/ed25519/objects/alice/",
 			},
 		},
@@ -793,7 +793,7 @@ func TestLayeredNamer_Prefixes(t *testing.T) {
 			isPrefix: false,
 			expected: []string{
 				"/objects/alice",
-				"/hash/sha256/objects/alice",
+				"/hashes/sha256/objects/alice",
 				"/sig/ed25519/objects/alice",
 			},
 		},
@@ -822,7 +822,7 @@ func TestLayeredNamer_Prefixes_Compact(t *testing.T) {
 
 	expected := []string{
 		"/objects/",
-		"/hash/objects/",
+		"/hashes/objects/",
 		"/sig/objects/",
 	}
 	assert.Equal(t, expected, layeredN.Prefixes("", true))
@@ -867,7 +867,7 @@ func TestLayeredNamer_MultiSegmentObjectLocation(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, keys, 3)
 		assert.Equal(t, "/settings/ldap/entry-1", keys[0].Build())
-		assert.Equal(t, "/hash/sha256/settings/ldap/entry-1", keys[1].Build())
+		assert.Equal(t, "/hashes/sha256/settings/ldap/entry-1", keys[1].Build())
 		assert.Equal(t, "/sig/ed25519/settings/ldap/entry-1", keys[2].Build())
 
 		// Round-trip each key.
@@ -896,7 +896,7 @@ func TestLayeredNamer_MultiSegmentObjectLocation(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, keys, 3)
 		assert.Equal(t, "/settings/ldap/entry-1", keys[0].Build())
-		assert.Equal(t, "/hash/settings/ldap/entry-1", keys[1].Build())
+		assert.Equal(t, "/hashes/settings/ldap/entry-1", keys[1].Build())
 		assert.Equal(t, "/sig/settings/ldap/entry-1", keys[2].Build())
 
 		for _, k := range keys {

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	hashName      = "hash"
+	hashName      = "hashes"
 	signatureName = "sig"
 	maxKeyParts   = 3
 )

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -47,7 +47,7 @@ func TestDefaultNamer_GenerateNames_Success(t *testing.T) {
 					"all",
 					namer.KeyTypeHash,
 					"sha256",
-					"/storage/hash/sha256/all",
+					"/storage/hashes/sha256/all",
 				),
 				namer.NewDefaultKey(
 					"all",
@@ -73,7 +73,7 @@ func TestDefaultNamer_GenerateNames_Success(t *testing.T) {
 					"all_keys/",
 					namer.KeyTypeHash,
 					"sha256",
-					"/storage/hash/sha256/all_keys/",
+					"/storage/hashes/sha256/all_keys/",
 				),
 				namer.NewDefaultKey(
 					"all_keys/",
@@ -116,7 +116,7 @@ func TestDefaultNamer_ParseKey_Success(t *testing.T) {
 			property: "",
 		},
 		{
-			input:    "/storage/hash/sha256/all",
+			input:    "/storage/hashes/sha256/all",
 			name:     "all",
 			tp:       namer.KeyTypeHash,
 			property: "sha256",
@@ -152,11 +152,11 @@ func TestDefaultNamer_ParseKey_Failed(t *testing.T) {
 
 	tests := []string{
 		"/not-storage/value",
-		"/storage/hash",
-		"/storage/hash/sha256",
-		"/storage/hash//all",
-		"/storage/hash/sha256/",
-		"/storage/hash/sha256/suffix/",
+		"/storage/hashes",
+		"/storage/hashes/sha256",
+		"/storage/hashes//all",
+		"/storage/hashes/sha256/",
+		"/storage/hashes/sha256/suffix/",
 		"/storage/sig",
 		"/storage/sig/rsa",
 		"/storage/sig//all",
@@ -192,7 +192,7 @@ func TestDefaultNamer_ParseKeys_Success(t *testing.T) {
 			input: []string{
 				"/storage/value",
 				"/storage/sig/signame/value",
-				"/storage/hash/hashname/value",
+				"/storage/hashes/hashname/value",
 			},
 			countMap:   map[string]int{"value": 3},
 			singleName: "value",
@@ -202,10 +202,10 @@ func TestDefaultNamer_ParseKeys_Success(t *testing.T) {
 			input: []string{
 				"/storage/key1",
 				"/storage/sig/rsa/key1",
-				"/storage/hash/sha256/key1",
+				"/storage/hashes/sha256/key1",
 				"/storage/key2",
 				"/storage/sig/rsa/key2",
-				"/storage/hash/sha256/key2",
+				"/storage/hashes/sha256/key2",
 			},
 			countMap:   map[string]int{"key1": 3, "key2": 3},
 			singleName: "",
@@ -384,7 +384,7 @@ func TestDefaultNamer_Prefixes(t *testing.T) {
 			isPrefix:  true,
 			expected: []string{
 				"/storage/alice/",
-				"/storage/hash/sha256/alice/",
+				"/storage/hashes/sha256/alice/",
 				"/storage/sig/rsa/alice/",
 			},
 		},
@@ -397,7 +397,7 @@ func TestDefaultNamer_Prefixes(t *testing.T) {
 			isPrefix:  false,
 			expected: []string{
 				"/storage/alice",
-				"/storage/hash/sha256/alice",
+				"/storage/hashes/sha256/alice",
 				"/storage/sig/rsa/alice",
 			},
 		},

--- a/namer/unnamed_layered_test.go
+++ b/namer/unnamed_layered_test.go
@@ -39,7 +39,7 @@ func TestUnnamedLayeredNamer_GenerateNames(t *testing.T) {
 	assert.Equal(t, namer.KeyTypeValue, keys[0].Type())
 	assert.Equal(t, "alice", keys[0].Name())
 
-	assert.Equal(t, "/hash/sha256/alice", keys[1].Build())
+	assert.Equal(t, "/hashes/sha256/alice", keys[1].Build())
 	assert.Equal(t, namer.KeyTypeHash, keys[1].Type())
 	assert.Equal(t, "sha256", keys[1].Property())
 
@@ -56,7 +56,7 @@ func TestUnnamedLayeredNamer_GenerateNames_RejectsReservedFirstSegment(t *testin
 		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
 	)
 
-	cases := []string{"hash", "sig", "hash/foo", "sig/bar/baz"}
+	cases := []string{"hashes", "sig", "hashes/foo", "sig/bar/baz"}
 
 	for _, name := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -108,7 +108,7 @@ func TestUnnamedLayeredNamer_ParseKey_HashAndSig(t *testing.T) {
 		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
 	)
 
-	parsed, err := nmr.ParseKey("/hash/sha256/alice")
+	parsed, err := nmr.ParseKey("/hashes/sha256/alice")
 	require.NoError(t, err)
 	assert.Equal(t, "alice", parsed.Name())
 	assert.Equal(t, namer.KeyTypeHash, parsed.Type())
@@ -132,9 +132,9 @@ func TestUnnamedLayeredNamer_ParseKey_Errors(t *testing.T) {
 	cases := []string{
 		"",
 		"/",
-		"/hash/",
-		"/hash/sha256/",
-		"/hash/unknown/alice",
+		"/hashes/",
+		"/hashes/sha256/",
+		"/hashes/unknown/alice",
 		"/sig/",
 		"/sig/unknown/alice",
 		"/alice/",
@@ -199,7 +199,7 @@ func TestUnnamedLayeredNamer_Compact(t *testing.T) {
 	require.Len(t, keys, 3)
 
 	assert.Equal(t, "/alice", keys[0].Build())
-	assert.Equal(t, "/hash/alice", keys[1].Build())
+	assert.Equal(t, "/hashes/alice", keys[1].Build())
 	assert.Equal(t, "/sig/alice", keys[2].Build())
 
 	for _, key := range keys {
@@ -221,7 +221,7 @@ func TestUnnamedLayeredNamer_Compact_ParseErrors(t *testing.T) {
 	)
 
 	// Compact + unnamed: hash/<name> must not be empty or end with '/'.
-	cases := []string{"/hash/", "/hash/alice/", "/sig/", "/sig/alice/"}
+	cases := []string{"/hashes/", "/hashes/alice/", "/sig/", "/sig/alice/"}
 
 	for _, raw := range cases {
 		t.Run(raw, func(t *testing.T) {
@@ -241,15 +241,15 @@ func TestUnnamedLayeredNamer_Prefixes(t *testing.T) {
 		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
 	)
 
-	// Unnamed-mode roots: value at "/", hash at "/hash/<loc>/", sig at "/sig/<loc>/".
+	// Unnamed-mode roots: value at "/", hash at "/hashes/<loc>/", sig at "/sig/<loc>/".
 	prefixes := nmr.Prefixes("", true)
-	assert.Equal(t, []string{"/", "/hash/sha256/", "/sig/ed25519/"}, prefixes)
+	assert.Equal(t, []string{"/", "/hashes/sha256/", "/sig/ed25519/"}, prefixes)
 
 	prefixes = nmr.Prefixes("alice", false)
-	assert.Equal(t, []string{"/alice", "/hash/sha256/alice", "/sig/ed25519/alice"}, prefixes)
+	assert.Equal(t, []string{"/alice", "/hashes/sha256/alice", "/sig/ed25519/alice"}, prefixes)
 
 	prefixes = nmr.Prefixes("alice", true)
-	assert.Equal(t, []string{"/alice/", "/hash/sha256/alice/", "/sig/ed25519/alice/"}, prefixes)
+	assert.Equal(t, []string{"/alice/", "/hashes/sha256/alice/", "/sig/ed25519/alice/"}, prefixes)
 }
 
 func TestUnnamedLayeredNamer_Compact_Prefixes(t *testing.T) {
@@ -264,5 +264,5 @@ func TestUnnamedLayeredNamer_Compact_Prefixes(t *testing.T) {
 
 	// Compact + unnamed: hashLocation / sigLocation segments are also dropped.
 	prefixes := nmr.Prefixes("", true)
-	assert.Equal(t, []string{"/", "/hash/", "/sig/"}, prefixes)
+	assert.Equal(t, []string{"/", "/hashes/", "/sig/"}, prefixes)
 }


### PR DESCRIPTION
The hash key path marker changes from `/hash/` to `/hashes/` across both DefaultNamer and LayeredNamer (including unnamed and compact variants). The reserved-marker check on `objectLocation` and the unnamed-mode reserved-first-segment guard now reject `hashes` instead of `hash`.

Breaking change: keys written by prior versions under `/hash/...` will not parse with the new namer; operators upgrading must migrate stored keys to the new prefix.