### PR TITLE
connect: strip http scheme from endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- connect: fix TCS connection failure when endpoint URL contains `http://` or
+  `https://` scheme. Endpoints are now normalized by stripping the scheme
+  prefix; etcd endpoints use `http://` or `https://` based on `SSL.Enable`.
+
 ## [v1.4.0] - 2026-05-12
 
 This release adds an unnamed codec layout and a `SingletonStore[T]` for

--- a/connect/etcd.go
+++ b/connect/etcd.go
@@ -24,8 +24,25 @@ func createEtcdClient(ctx context.Context, cfg Config) (*etcdclient.Client, Clea
 		return nil, nil, err
 	}
 
+	endpoints := make([]string, len(cfg.Endpoints))
+
+	scheme := "http"
+	if cfg.SSL.Enable {
+		scheme = "https"
+	}
+
+	for idx, endpoint := range cfg.Endpoints {
+		if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+			endpoint = strings.TrimPrefix(endpoint, "http://")
+			endpoint = strings.TrimPrefix(endpoint, "https://")
+			endpoint = scheme + "://" + endpoint
+		}
+
+		endpoints[idx] = endpoint
+	}
+
 	etcdConfig := etcdclient.Config{ //nolint:exhaustruct
-		Endpoints:   cfg.Endpoints,
+		Endpoints:   endpoints,
 		DialTimeout: cfg.dialTimeout(),
 		Username:    cfg.Username,
 		Password:    cfg.Password,
@@ -49,7 +66,7 @@ func createEtcdClient(ctx context.Context, cfg Config) (*etcdclient.Client, Clea
 	statusCtx, statusCancel := context.WithTimeout(ctx, cfg.dialTimeout())
 	defer statusCancel()
 
-	_, statusErr := client.Status(statusCtx, cfg.Endpoints[0])
+	_, statusErr := client.Status(statusCtx, endpoints[0])
 	if statusErr != nil {
 		_ = client.Close()
 

--- a/connect/integration_test.go
+++ b/connect/integration_test.go
@@ -528,3 +528,70 @@ func TestNewEtcdStorage_WithTLSEncryptedKeyAndPasswordFile(t *testing.T) {
 	require.NotEmpty(t, kvs)
 	assert.Equal(t, []byte("password-file-test"), kvs[0].Value)
 }
+
+func TestNewTCSStorage_HTTPEndpointScheme(t *testing.T) {
+	if !haveTCS {
+		t.Skip("TCS is unsupported or Tarantool isn't found")
+	}
+
+	if testing.Short() {
+		t.Skip("skipping integration tests in short mode")
+	}
+
+	endpoints := make([]string, len(tcsEndpoints))
+	for i, ep := range tcsEndpoints {
+		endpoints[i] = "http://" + ep
+	}
+
+	ctx := context.Background()
+	stor, cancel, err := connect.NewTCSStorage(ctx, connect.Config{ //nolint:exhaustruct
+		Endpoints: endpoints,
+		Username:  "client",
+		Password:  "secret",
+	})
+	require.NoError(t, err)
+
+	defer cancel()
+
+	prefix := "/" + t.Name() + "/test"
+	key := []byte(prefix + "/value")
+
+	_, _ = stor.Tx(ctx).Then(operation.Delete(key)).Commit()
+	defer func() { _, _ = stor.Tx(ctx).Then(operation.Delete(key)).Commit() }()
+
+	_, err = stor.Tx(ctx).Then(operation.Put(key, []byte("http-scheme-test"))).Commit()
+	require.NoError(t, err)
+
+	kvs, err := stor.Range(ctx, storage.WithPrefix(prefix))
+	require.NoError(t, err)
+	require.NotEmpty(t, kvs)
+	assert.Equal(t, []byte("http-scheme-test"), kvs[0].Value)
+}
+
+func TestNewEtcdStorage_HTTPSEndpointScheme(t *testing.T) {
+	cluster := createEtcdTLSCluster(t)
+	tlsDir := tlsDir(t)
+
+	ctx := context.Background()
+	stor, cleanup, err := connect.NewEtcdStorage(ctx, connect.Config{ //nolint:exhaustruct
+		Endpoints: cluster.EndpointsGRPC(),
+		SSL: connect.SSLConfig{ //nolint:exhaustruct
+			Enable: true,
+			CaFile: filepath.Join(tlsDir, "ca.crt"),
+		},
+	})
+	require.NoError(t, err)
+
+	defer cleanup()
+
+	prefix := "/" + t.Name() + "/test"
+	key := []byte(prefix + "/value")
+
+	_, err = stor.Tx(ctx).Then(operation.Put(key, []byte("https-scheme-test"))).Commit()
+	require.NoError(t, err)
+
+	kvs, err := stor.Range(ctx, storage.WithPrefix(prefix))
+	require.NoError(t, err)
+	require.NotEmpty(t, kvs)
+	assert.Equal(t, []byte("https-scheme-test"), kvs[0].Value)
+}

--- a/connect/tcs.go
+++ b/connect/tcs.go
@@ -3,6 +3,7 @@ package connect
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/tarantool/go-tarantool/v2"
 	"github.com/tarantool/go-tarantool/v2/pool"
@@ -23,6 +24,9 @@ func createTCSConnection(ctx context.Context, cfg Config) (tcsdriver.DoerWatcher
 	instances := make([]pool.Instance, 0, len(cfg.Endpoints))
 
 	for idx, addr := range cfg.Endpoints {
+		addr = strings.TrimPrefix(addr, "http://")
+		addr = strings.TrimPrefix(addr, "https://")
+
 		instDialer, dialerErr := newDialerForAddress(cfg, addr)
 		if dialerErr != nil {
 			return nil, nil, dialerErr


### PR DESCRIPTION
TCS connections failed with "too many colons in address" error when endpoints contained http:// or https:// scheme. The go-tarantool dialer expects host:port format, not full URLs.

Now endpoints are normalized: TCS strips the scheme prefix, etcd constructs the URL based on SSL.Enable config. This allows users to pass endpoint URLs with scheme without knowing which backend will be used.
