### PR TITLE
namer: add LegacyHashSigLayout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `/`, returning the new `storage.ErrPrefixNoLeadingSlash`. Interior `/`
   separators remain allowed; a trailing `/` is still rejected with
   `storage.ErrPrefixTrailingSlash`.
+- namer.LayeredNamer: `LegacyHashSigLayout()` option emits hash and signature
+  keys without the per-codec `objectLocation` segment (value keys keep it) to
+  match the layout produced by the legacy product:
+
+      /<objectLocation>/<name>
+      /hashes/<hashLocation>/<name>
+      /sig/<sigLocation>/<name>
+
+  Composes with `CompactSingleHash` / `CompactSingleSig` and is a no-op in
+  unnamed mode.
 
 ### Changed
 

--- a/namer/layered.go
+++ b/namer/layered.go
@@ -75,6 +75,7 @@ type LayeredOption func(*layeredOpts)
 type layeredOpts struct {
 	compactHash bool
 	compactSig  bool
+	legacy      bool
 }
 
 // CompactSingleHash drops the per-hasher location segment in generated and
@@ -93,6 +94,23 @@ func CompactSingleSig() LayeredOption {
 	return func(o *layeredOpts) { o.compactSig = true }
 }
 
+// LegacyHashSigLayout drops the per-codec objectLocation segment from hash
+// and signature keys (but keeps it for value keys), matching the layout
+// emitted by the legacy product. The resulting layout is:
+//
+//	/<objectLocation>/<name>            (value)
+//	/hashes/<hashLocation>/<name>       (hash)
+//	/sig/<sigLocation>/<name>           (sig)
+//
+// Composes with CompactSingleHash / CompactSingleSig as expected — the
+// <hashLocation> / <sigLocation> segments are dropped independently of
+// this option. Has no effect in unnamed mode (objectLocation ==
+// ObjectLocationMissing) since the unnamed layout already omits the
+// objectLocation segment.
+func LegacyHashSigLayout() LayeredOption {
+	return func(o *layeredOpts) { o.legacy = true }
+}
+
 type layeredNamer struct {
 	objectLocation string
 	hashLocations  []LayeredHashLocation
@@ -103,6 +121,10 @@ type layeredNamer struct {
 	// mode the objectLocation segment is omitted from every emitted key
 	// and from the parser's expected layout.
 	unnamed bool
+	// legacy is set by LegacyHashSigLayout(). It drops the objectLocation
+	// segment from hash and signature keys (but keeps it for value keys)
+	// to match the layout emitted by the legacy product.
+	legacy bool
 	// Reverse maps populated once at construction so ParseKey is O(1)
 	// regardless of hash/sig list size.
 	hashIndex map[string]string // hashLocation -> hasherName.
@@ -127,6 +149,10 @@ type layeredNamer struct {
 //
 // Pass ObjectLocationMissing as objectLocation to drop the per-codec
 // segment entirely; see ObjectLocationMissing for the resulting layout.
+//
+// With LegacyHashSigLayout, the per-codec <objectLocation> segment is
+// dropped from hash and sig keys (but kept for value keys) to match the
+// legacy product layout.
 //
 // Validation rules:
 //   - hashLocation / sigLocation must be a single non-empty segment with no '/'.
@@ -215,6 +241,7 @@ func NewLayeredNamer(
 		compactHash:    resolved.compactHash,
 		compactSig:     resolved.compactSig,
 		unnamed:        unnamed,
+		legacy:         resolved.legacy,
 		hashIndex:      hashIndex,
 		sigIndex:       sigIndex,
 	}, nil
@@ -449,6 +476,15 @@ func (n *layeredNamer) Prefixes(val string, isPrefix bool) []string {
 	return out
 }
 
+// omitObjLocFromHashSig reports whether hash and signature keys must be
+// emitted/parsed without the per-codec objectLocation segment. This is the
+// case in unnamed mode (objectLocation == ObjectLocationMissing) — there
+// is no objectLocation to insert — and also when LegacyHashSigLayout() is
+// set, which deliberately drops the segment.
+func (n *layeredNamer) omitObjLocFromHashSig() bool {
+	return n.unnamed || n.legacy
+}
+
 func (n *layeredNamer) valueRoot() string {
 	if n.unnamed {
 		return "/"
@@ -463,7 +499,7 @@ func (n *layeredNamer) hashRoot(hashLocation string) string {
 		root += hashLocation + "/"
 	}
 
-	if !n.unnamed {
+	if !n.omitObjLocFromHashSig() {
 		root += n.objectLocation + "/"
 	}
 
@@ -476,7 +512,7 @@ func (n *layeredNamer) sigRoot(sigLocation string) string {
 		root += sigLocation + "/"
 	}
 
-	if !n.unnamed {
+	if !n.omitObjLocFromHashSig() {
 		root += n.objectLocation + "/"
 	}
 
@@ -508,12 +544,14 @@ func (n *layeredNamer) buildValueKey(name string) string {
 }
 
 func (n *layeredNamer) buildHashKey(hashLocation, name string) string {
+	omitObj := n.omitObjLocFromHashSig()
+
 	switch {
-	case n.compactHash && n.unnamed:
+	case n.compactHash && omitObj:
 		return "/" + layeredHashMarker + "/" + name
 	case n.compactHash:
 		return "/" + layeredHashMarker + "/" + n.objectLocation + "/" + name
-	case n.unnamed:
+	case omitObj:
 		return "/" + layeredHashMarker + "/" + hashLocation + "/" + name
 	}
 
@@ -521,12 +559,14 @@ func (n *layeredNamer) buildHashKey(hashLocation, name string) string {
 }
 
 func (n *layeredNamer) buildSigKey(sigLocation, name string) string {
+	omitObj := n.omitObjLocFromHashSig()
+
 	switch {
-	case n.compactSig && n.unnamed:
+	case n.compactSig && omitObj:
 		return "/" + layeredSigMarker + "/" + name
 	case n.compactSig:
 		return "/" + layeredSigMarker + "/" + n.objectLocation + "/" + name
-	case n.unnamed:
+	case omitObj:
 		return "/" + layeredSigMarker + "/" + sigLocation + "/" + name
 	}
 
@@ -575,7 +615,7 @@ func (n *layeredNamer) parseHashKey(raw, rest string) (DefaultKey, error) {
 }
 
 func (n *layeredNamer) parseCompactHashKey(raw, rest string) (DefaultKey, error) {
-	if n.unnamed {
+	if n.omitObjLocFromHashSig() {
 		err := validateNamePart(raw, rest, "hash")
 		if err != nil {
 			return DefaultKey{}, err
@@ -609,7 +649,7 @@ func (n *layeredNamer) parseFullHashKey(raw, rest string) (DefaultKey, error) {
 		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown hash location %q", hashLoc))
 	}
 
-	if n.unnamed {
+	if n.omitObjLocFromHashSig() {
 		err := validateNamePart(raw, afterLoc, "hash")
 		if err != nil {
 			return DefaultKey{}, err
@@ -641,7 +681,7 @@ func (n *layeredNamer) parseSigKey(raw, rest string) (DefaultKey, error) {
 }
 
 func (n *layeredNamer) parseCompactSigKey(raw, rest string) (DefaultKey, error) {
-	if n.unnamed {
+	if n.omitObjLocFromHashSig() {
 		err := validateNamePart(raw, rest, "sig")
 		if err != nil {
 			return DefaultKey{}, err
@@ -675,7 +715,7 @@ func (n *layeredNamer) parseFullSigKey(raw, rest string) (DefaultKey, error) {
 		return DefaultKey{}, errInvalidKey(raw, fmt.Sprintf("unknown sig location %q", sigLoc))
 	}
 
-	if n.unnamed {
+	if n.omitObjLocFromHashSig() {
 		err := validateNamePart(raw, afterLoc, "sig")
 		if err != nil {
 			return DefaultKey{}, err

--- a/namer/layered_example_test.go
+++ b/namer/layered_example_test.go
@@ -91,6 +91,34 @@ func ExampleCompactSingleSig() {
 	// KeyTypeSignature -> /sig/objects/alice
 }
 
+// ExampleLegacyHashSigLayout shows the legacy product layout: hash and sig
+// keys drop the objectLocation segment while value keys keep it.
+func ExampleLegacyHashSigLayout() {
+	layered, err := namer.NewLayeredNamer(
+		"config",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		namer.LegacyHashSigLayout(),
+	)
+	if err != nil {
+		log.Fatalf("new namer: %v", err)
+	}
+
+	keys, err := layered.GenerateNames("all")
+	if err != nil {
+		log.Fatalf("generate: %v", err)
+	}
+
+	for _, k := range keys {
+		fmt.Printf("%s -> %s\n", k.Type(), k.Build())
+	}
+
+	// Output:
+	// KeyTypeValue -> /config/all
+	// KeyTypeHash -> /hashes/sha256/all
+	// KeyTypeSignature -> /sig/ed25519/all
+}
+
 // ExampleNewLayeredNamer_parse shows how ParseKey resolves a raw key path
 // back into its category and object name.
 func ExampleNewLayeredNamer_parse() {

--- a/namer/legacy_layered_test.go
+++ b/namer/legacy_layered_test.go
@@ -1,0 +1,222 @@
+package namer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/namer"
+)
+
+func newLegacyNamer(
+	t *testing.T,
+	objectLocation string,
+	hashLocs []namer.LayeredHashLocation,
+	sigLocs []namer.LayeredSigLocation,
+	extra ...namer.LayeredOption,
+) namer.Namer {
+	t.Helper()
+
+	opts := append([]namer.LayeredOption{namer.LegacyHashSigLayout()}, extra...)
+
+	n, err := namer.NewLayeredNamer(objectLocation, hashLocs, sigLocs, opts...)
+	require.NoError(t, err)
+
+	return n
+}
+
+func TestLegacyLayout_GenerateNames(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "config",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	keys, err := nmr.GenerateNames("all")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	assert.Equal(t, "/config/all", keys[0].Build())
+	assert.Equal(t, namer.KeyTypeValue, keys[0].Type())
+	assert.Equal(t, "all", keys[0].Name())
+
+	assert.Equal(t, "/hashes/sha256/all", keys[1].Build())
+	assert.Equal(t, namer.KeyTypeHash, keys[1].Type())
+	assert.Equal(t, "sha256", keys[1].Property())
+
+	assert.Equal(t, "/sig/ed25519/all", keys[2].Build())
+	assert.Equal(t, namer.KeyTypeSignature, keys[2].Type())
+	assert.Equal(t, "ed25519", keys[2].Property())
+}
+
+func TestLegacyLayout_MultiSegmentObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "settings/ldap",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+	)
+
+	keys, err := nmr.GenerateNames("alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	assert.Equal(t, "/settings/ldap/alice", keys[0].Build())
+	assert.Equal(t, "/hashes/sha256/alice", keys[1].Build())
+}
+
+func TestLegacyLayout_CompactSingleHash(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "config",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+		namer.CompactSingleHash(),
+	)
+
+	keys, err := nmr.GenerateNames("all")
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	assert.Equal(t, "/config/all", keys[0].Build())
+	assert.Equal(t, "/hashes/all", keys[1].Build())
+}
+
+func TestLegacyLayout_CompactSingleSig(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "config", nil,
+		[]namer.LayeredSigLocation{{SignerName: "rsa", Location: "rsa"}},
+		namer.CompactSingleSig(),
+	)
+
+	keys, err := nmr.GenerateNames("all")
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	assert.Equal(t, "/config/all", keys[0].Build())
+	assert.Equal(t, "/sig/all", keys[1].Build())
+}
+
+func TestLegacyLayout_ParseKey(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "config",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	cases := []struct {
+		raw      string
+		typ      namer.KeyType
+		name     string
+		property string
+	}{
+		{"/config/all", namer.KeyTypeValue, "all", ""},
+		{"/hashes/sha256/all", namer.KeyTypeHash, "all", "sha256"},
+		{"/sig/ed25519/all", namer.KeyTypeSignature, "all", "ed25519"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.raw, func(t *testing.T) {
+			t.Parallel()
+
+			k, err := nmr.ParseKey(tt.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tt.typ, k.Type())
+			assert.Equal(t, tt.name, k.Name())
+			assert.Equal(t, tt.property, k.Property())
+		})
+	}
+}
+
+func TestLegacyLayout_ParseKey_NamesMayContainSlashes(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "config",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+	)
+
+	// Legacy hash keys have shape /hashes/<hashLoc>/<name>; the parser treats
+	// every segment after <hashLoc> as the (possibly slash-containing) name.
+	k, err := nmr.ParseKey("/hashes/sha256/sub/all")
+	require.NoError(t, err)
+	assert.Equal(t, namer.KeyTypeHash, k.Type())
+	assert.Equal(t, "sub/all", k.Name())
+	assert.Equal(t, "sha256", k.Property())
+}
+
+func TestLegacyLayout_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "config",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	keys, err := nmr.GenerateNames("alice")
+	require.NoError(t, err)
+
+	for _, k := range keys {
+		parsed, err := nmr.ParseKey(k.Build())
+		require.NoError(t, err, "round-trip parse %q", k.Build())
+		assert.Equal(t, k.Type(), parsed.Type())
+		assert.Equal(t, k.Name(), parsed.Name())
+		assert.Equal(t, k.Property(), parsed.Property())
+	}
+}
+
+func TestLegacyLayout_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	nmr := newLegacyNamer(t, "config",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	got := nmr.Prefixes("", false)
+	assert.Equal(t, []string{
+		"/config/",
+		"/hashes/sha256/",
+		"/sig/ed25519/",
+	}, got)
+
+	got = nmr.Prefixes("alice", true)
+	assert.Equal(t, []string{
+		"/config/alice/",
+		"/hashes/sha256/alice/",
+		"/sig/ed25519/alice/",
+	}, got)
+}
+
+func TestLegacyLayout_UnnamedIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// In unnamed mode the layout already omits objectLocation; the legacy
+	// option has no effect.
+	legacy := newLegacyNamer(t, namer.ObjectLocationMissing,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+
+	plain, err := namer.NewLayeredNamer(namer.ObjectLocationMissing,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+	)
+	require.NoError(t, err)
+
+	legacyKeys, err := legacy.GenerateNames("alice")
+	require.NoError(t, err)
+
+	plainKeys, err := plain.GenerateNames("alice")
+	require.NoError(t, err)
+
+	require.Len(t, legacyKeys, len(plainKeys))
+
+	for i := range legacyKeys {
+		assert.Equal(t, plainKeys[i].Build(), legacyKeys[i].Build())
+	}
+}


### PR DESCRIPTION
- Adds `LegacyHashSigLayout()` option to `LayeredNamer` that emits hash/sig keys without the per-codec `objectLocation` segment (value keys keep it), matching the layout produced by the legacy product:
    ```
    /<objectLocation>/<name>
    /hash/<hashLocation>/<name>
    /sig/<sigLocation>/<name>
    ```
- Composes with `CompactSingleHash` / `CompactSingleSig`; no-op in unnamed mode (segment is already absent).