### PR TITLE
connect: probe all endpoints before failing

### DIFF
--- a/connect/etcd.go
+++ b/connect/etcd.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -63,17 +64,26 @@ func createEtcdClient(ctx context.Context, cfg Config) (*etcdclient.Client, Clea
 		return nil, nil, fmt.Errorf("%w: %w", errFailedEtcdClient, clientErr)
 	}
 
-	statusCtx, statusCancel := context.WithTimeout(ctx, cfg.dialTimeout())
-	defer statusCancel()
+	probeErrs := make([]error, 0, len(endpoints))
 
-	_, statusErr := client.Status(statusCtx, endpoints[0])
-	if statusErr != nil {
-		_ = client.Close()
+	for _, endpoint := range endpoints {
+		statusCtx, statusCancel := context.WithTimeout(ctx, cfg.dialTimeout())
 
-		return nil, nil, fmt.Errorf("%w: %w", errFailedEtcdClient, statusErr)
+		_, statusErr := client.Status(statusCtx, endpoint)
+
+		statusCancel()
+
+		if statusErr == nil {
+			return client, func() { _ = client.Close() }, nil
+		}
+
+		probeErrs = append(probeErrs, fmt.Errorf("%s: %w", endpoint, statusErr))
 	}
 
-	return client, func() { _ = client.Close() }, nil
+	_ = client.Close()
+
+	return nil, nil, fmt.Errorf("%w: failed to connect to %v: %w",
+		errFailedEtcdClient, endpoints, errors.Join(probeErrs...))
 }
 
 func validateSSLConfig(cfg SSLConfig) error {

--- a/connect/tcs.go
+++ b/connect/tcs.go
@@ -2,6 +2,7 @@ package connect
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -44,18 +45,10 @@ func createTCSConnection(ctx context.Context, cfg Config) (tcsdriver.DoerWatcher
 	// Go-tarantool pool doesn't return connection failures, just logs it.
 	// Check go-tarantool/v2@v2.4.1/pool/connection_pool.go:200,
 	// So we need to check it ourselves.
-	probeCtx, cancel := context.WithTimeout(ctx, cfg.dialTimeout())
-	probeConn, err := tarantool.Connect(probeCtx, instances[0].Dialer, tarantool.Opts{ //nolint:exhaustruct
-		Timeout: cfg.dialTimeout(),
-	})
-
-	cancel()
-
+	err = probeTCSEndpoints(ctx, cfg, instances)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w: %w", errFailedTarantool, err)
+		return nil, nil, err
 	}
-
-	_ = probeConn.Close()
 
 	conn, connErr := pool.Connect(ctx, instances)
 	if connErr != nil {
@@ -65,4 +58,28 @@ func createTCSConnection(ctx context.Context, cfg Config) (tcsdriver.DoerWatcher
 	wrapper := pool.NewConnectorAdapter(conn, pool.RW)
 
 	return wrapper, func() { _ = wrapper.Close() }, nil
+}
+
+func probeTCSEndpoints(ctx context.Context, cfg Config, instances []pool.Instance) error {
+	probeErrs := make([]error, 0, len(instances))
+
+	for idx, inst := range instances {
+		probeCtx, cancel := context.WithTimeout(ctx, cfg.dialTimeout())
+		probeConn, err := tarantool.Connect(probeCtx, inst.Dialer, tarantool.Opts{ //nolint:exhaustruct
+			Timeout: cfg.dialTimeout(),
+		})
+
+		cancel()
+
+		if err == nil {
+			_ = probeConn.Close()
+
+			return nil
+		}
+
+		probeErrs = append(probeErrs, fmt.Errorf("%s: %w", cfg.Endpoints[idx], err))
+	}
+
+	return fmt.Errorf("%w: failed to connect to %v: %w",
+		errFailedTarantool, cfg.Endpoints, errors.Join(probeErrs...))
 }


### PR DESCRIPTION
- Previously both etcd and TCS connectors only probed `Endpoints[0]`; if the first endpoint was down the whole connection failed even when later endpoints were healthy.
- Each endpoint is now probed in order. The first success wins (etcd client / TCS pool is returned), and only when every endpoint fails do we return a single error wrapping `errors.Join` of the per-endpoint failures, with each error prefixed by its endpoint address.
