### PR TITLE
driver/dummy: add in-memory Locker

### DIFF
--- a/driver/dummy/examples_test.go
+++ b/driver/dummy/examples_test.go
@@ -3,10 +3,12 @@ package dummy_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
 	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/locker"
 	"github.com/tarantool/go-storage/operation"
 	"github.com/tarantool/go-storage/predicate"
 )
@@ -313,4 +315,65 @@ func ExampleDriver_Watch() {
 	// Received watch event for prefix: /config/database
 	// Started watch with manual control
 	// Stopping watch gracefully...
+}
+
+// ExampleDriver_NewLocker demonstrates acquiring a named lock with the dummy
+// driver, observing contention from a second Locker on the same name, and
+// releasing the lock so the contender can proceed.
+func ExampleDriver_NewLocker() {
+	ctx := context.Background()
+	driver := dummy.New()
+
+	holder, err := driver.NewLocker(ctx, "/locks/leader")
+	if err != nil {
+		log.Printf("NewLocker (holder) failed: %v", err)
+		return
+	}
+
+	err = holder.Lock(ctx)
+	if err != nil {
+		log.Printf("Lock failed: %v", err)
+		return
+	}
+
+	fmt.Println("holder acquired:", holder.Key())
+
+	contender, err := driver.NewLocker(ctx, "/locks/leader")
+	if err != nil {
+		log.Printf("NewLocker (contender) failed: %v", err)
+		return
+	}
+
+	err = contender.TryLock(ctx)
+	if errors.Is(err, locker.ErrLocked) {
+		fmt.Println("contender saw the lock as held")
+	}
+
+	err = holder.Unlock(ctx)
+	if err != nil {
+		log.Printf("Unlock failed: %v", err)
+		return
+	}
+
+	fmt.Println("holder released")
+
+	err = contender.TryLock(ctx)
+	if err != nil {
+		log.Printf("contender TryLock after release failed: %v", err)
+		return
+	}
+
+	fmt.Println("contender acquired:", contender.Key())
+
+	err = contender.Unlock(ctx)
+	if err != nil {
+		log.Printf("Unlock failed: %v", err)
+		return
+	}
+
+	// Output:
+	// holder acquired: /locks/leader
+	// contender saw the lock as held
+	// holder released
+	// contender acquired: /locks/leader
 }

--- a/driver/dummy/locker.go
+++ b/driver/dummy/locker.go
@@ -1,0 +1,134 @@
+package dummy
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/tarantool/go-storage/locker"
+)
+
+type dummyLockEntry struct {
+	mu sync.Mutex
+}
+
+//nolint:gochecknoglobals // package-wide registry maps lock names to shared entries.
+var dummyLockRegistry sync.Map // name -> *dummyLockEntry.
+
+func lockEntryFor(name string) *dummyLockEntry {
+	v, _ := dummyLockRegistry.LoadOrStore(name, &dummyLockEntry{}) //nolint:exhaustruct
+	entry, _ := v.(*dummyLockEntry)
+
+	return entry
+}
+
+type dummyLocker struct {
+	entry *dummyLockEntry
+	//nolint:containedctx // lifeCtx scopes the locker; cancellation aborts a blocking Lock.
+	lifeCtx context.Context
+	name    string
+
+	mu   sync.Mutex
+	held bool
+	key  string
+}
+
+var _ locker.Locker = (*dummyLocker)(nil)
+
+func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
+	_ = locker.ApplyOptions(opts)
+
+	return &dummyLocker{ //nolint:exhaustruct // mu/held/key are zero-initialized by design.
+		entry:   lockEntryFor(name),
+		lifeCtx: ctx,
+		name:    name,
+	}, nil
+}
+
+func (dl *dummyLocker) Lock(ctx context.Context) error {
+	dl.mu.Lock()
+	if dl.held {
+		dl.mu.Unlock()
+		return nil
+	}
+
+	dl.mu.Unlock()
+
+	// sync.Mutex.Lock is not cancellable; run it in a goroutine and select on
+	// whichever context fires first.
+	acquired := make(chan struct{})
+
+	go func() {
+		dl.entry.mu.Lock()
+		close(acquired)
+	}()
+
+	select {
+	case <-acquired:
+		dl.mu.Lock()
+		dl.held = true
+		dl.key = dl.name
+		dl.mu.Unlock()
+
+		return nil
+
+	case <-ctx.Done():
+		go func() {
+			<-acquired
+			dl.entry.mu.Unlock()
+		}()
+
+		return fmt.Errorf("dummy locker: lock: %w", ctx.Err())
+
+	case <-dl.lifeCtx.Done():
+		go func() {
+			<-acquired
+			dl.entry.mu.Unlock()
+		}()
+
+		return fmt.Errorf("dummy locker: lock: %w", dl.lifeCtx.Err())
+	}
+}
+
+func (dl *dummyLocker) TryLock(ctx context.Context) error {
+	dl.mu.Lock()
+	if dl.held {
+		dl.mu.Unlock()
+		return nil
+	}
+
+	dl.mu.Unlock()
+
+	if !dl.entry.mu.TryLock() {
+		return locker.ErrLocked
+	}
+
+	dl.mu.Lock()
+	dl.held = true
+	dl.key = dl.name
+	dl.mu.Unlock()
+
+	return nil
+}
+
+func (dl *dummyLocker) Unlock(_ context.Context) error {
+	dl.mu.Lock()
+	defer dl.mu.Unlock()
+
+	if !dl.held {
+		return locker.ErrLockReleased
+	}
+
+	dl.held = false
+	dl.key = ""
+	dl.entry.mu.Unlock()
+
+	return nil
+}
+
+func (dl *dummyLocker) Key() string {
+	dl.mu.Lock()
+	defer dl.mu.Unlock()
+
+	return dl.key
+}

--- a/driver/dummy/locker_test.go
+++ b/driver/dummy/locker_test.go
@@ -1,0 +1,255 @@
+package dummy_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/driver/dummy"
+	"github.com/tarantool/go-storage/locker"
+)
+
+func newLocker(t *testing.T, name string) locker.Locker {
+	t.Helper()
+
+	ctx := context.Background()
+	d := dummy.New()
+	lk, err := d.NewLocker(ctx, name)
+	require.NoError(t, err)
+	require.NotNil(t, lk)
+
+	return lk
+}
+
+func TestDummyLocker_LockUnlock_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	lock := newLocker(t, "test-lock")
+
+	assert.Empty(t, lock.Key())
+
+	err := lock.Lock(context.Background())
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-lock", lock.Key())
+
+	err = lock.Unlock(context.Background())
+	require.NoError(t, err)
+
+	assert.Empty(t, lock.Key())
+}
+
+func TestDummyLocker_ReLock_IsNoOp(t *testing.T) {
+	t.Parallel()
+
+	lock := newLocker(t, "relock-test")
+
+	err := lock.Lock(context.Background())
+	require.NoError(t, err)
+
+	err = lock.Lock(context.Background())
+	require.NoError(t, err)
+
+	err = lock.Unlock(context.Background())
+	require.NoError(t, err)
+}
+
+func TestDummyLocker_TryLock_Contended(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := dummy.New()
+
+	lockA, err := d.NewLocker(ctx, "trylock-contend")
+	require.NoError(t, err)
+
+	lockB, err := d.NewLocker(ctx, "trylock-contend")
+	require.NoError(t, err)
+
+	require.NoError(t, lockA.Lock(ctx))
+
+	err = lockB.TryLock(ctx)
+	require.ErrorIs(t, err, locker.ErrLocked)
+
+	require.NoError(t, lockA.Unlock(ctx))
+}
+
+func TestDummyLocker_TryLock_Free(t *testing.T) {
+	t.Parallel()
+
+	lock := newLocker(t, "trylock-free")
+
+	err := lock.TryLock(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "trylock-free", lock.Key())
+
+	require.NoError(t, lock.Unlock(context.Background()))
+}
+
+func TestDummyLocker_TryLock_AlreadyHeld(t *testing.T) {
+	t.Parallel()
+
+	lock := newLocker(t, "trylock-held")
+
+	require.NoError(t, lock.Lock(context.Background()))
+	require.NoError(t, lock.TryLock(context.Background()))
+	require.NoError(t, lock.Unlock(context.Background()))
+}
+
+func TestDummyLocker_DoubleUnlock(t *testing.T) {
+	t.Parallel()
+
+	lock := newLocker(t, "double-unlock")
+
+	require.NoError(t, lock.Lock(context.Background()))
+	require.NoError(t, lock.Unlock(context.Background()))
+
+	err := lock.Unlock(context.Background())
+	require.ErrorIs(t, err, locker.ErrLockReleased)
+}
+
+func TestDummyLocker_Unlock_NeverLocked(t *testing.T) {
+	t.Parallel()
+
+	lock := newLocker(t, "never-locked")
+
+	err := lock.Unlock(context.Background())
+	require.ErrorIs(t, err, locker.ErrLockReleased)
+}
+
+func TestDummyLocker_Lock_CtxCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	driver := dummy.New()
+
+	lockA, err := driver.NewLocker(ctx, "ctx-cancel")
+	require.NoError(t, err)
+	require.NoError(t, lockA.Lock(ctx))
+
+	lockB, err := driver.NewLocker(ctx, "ctx-cancel")
+	require.NoError(t, err)
+
+	callCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+
+	err = lockB.Lock(callCtx)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, callCtx.Err())
+	assert.Less(t, elapsed, 1*time.Second)
+
+	err = lockB.Unlock(ctx)
+	require.ErrorIs(t, err, locker.ErrLockReleased)
+
+	require.NoError(t, lockA.Unlock(ctx))
+}
+
+func TestDummyLocker_TwoLockers_SameName_Contend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	driver := dummy.New()
+
+	lockA, err := driver.NewLocker(ctx, "shared-name")
+	require.NoError(t, err)
+
+	lockB, err := driver.NewLocker(ctx, "shared-name")
+	require.NoError(t, err)
+
+	require.NoError(t, lockA.Lock(ctx))
+
+	err = lockB.TryLock(ctx)
+	require.ErrorIs(t, err, locker.ErrLocked)
+
+	require.NoError(t, lockA.Unlock(ctx))
+
+	require.NoError(t, lockB.Lock(ctx))
+	require.NoError(t, lockB.Unlock(ctx))
+}
+
+func TestDummyLocker_TwoLockers_DifferentNames_DoNotContend(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	driver := dummy.New()
+
+	lockA, err := driver.NewLocker(ctx, "name-a")
+	require.NoError(t, err)
+
+	lockB, err := driver.NewLocker(ctx, "name-b")
+	require.NoError(t, err)
+
+	require.NoError(t, lockA.Lock(ctx))
+
+	lockDone := make(chan error, 1)
+
+	go func() {
+		lockDone <- lockB.Lock(ctx)
+	}()
+
+	select {
+	case err := <-lockDone:
+		require.NoError(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("lockB.Lock timed out even though it uses a different lock name")
+	}
+
+	require.NoError(t, lockA.Unlock(ctx))
+	require.NoError(t, lockB.Unlock(ctx))
+}
+
+func TestDummyLocker_LifeCtxCancellation_AbortsBlockingLock(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	driver := dummy.New()
+
+	holderCtx := context.Background()
+	lockA, err := driver.NewLocker(holderCtx, "life-ctx-test")
+	require.NoError(t, err)
+	require.NoError(t, lockA.Lock(holderCtx))
+
+	lifeCtx, cancelLife := context.WithCancel(ctx)
+	lockB, err := driver.NewLocker(lifeCtx, "life-ctx-test")
+	require.NoError(t, err)
+
+	var (
+		waiters sync.WaitGroup
+		lockErr error
+	)
+	waiters.Add(1)
+
+	go func() {
+		defer waiters.Done()
+
+		lockErr = lockB.Lock(context.Background())
+	}()
+
+	time.Sleep(30 * time.Millisecond)
+
+	cancelLife()
+
+	done := make(chan struct{})
+
+	go func() {
+		waiters.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Lock did not abort after lifetime context cancellation")
+	}
+
+	require.Error(t, lockErr)
+
+	require.NoError(t, lockA.Unlock(holderCtx))
+}


### PR DESCRIPTION
Add the locker.Locker interface package and an in-process Locker implementation in driver/dummy backed by a sync.Mutex map keyed by name. Honors per-call and lifetime ctx cancellation. Intended for tests and single-process setups. Example covers acquire / TryLock contention / release.

Part of #29