### PR TITLE
driver/etcd: add NewWithClient and concurrency-based Locker

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,5 +1,5 @@
 [codespell]
 
 skip = ./vendor,./.git
-# ignore-words-list =
+ignore-words-list = clienta
 check-filenames = true

--- a/driver/etcd/etcd.go
+++ b/driver/etcd/etcd.go
@@ -32,7 +32,7 @@ type Client interface {
 // Driver is an etcd implementation of the storage driver interface.
 // It uses etcd as the underlying key-value storage backend.
 type Driver struct {
-	client Client // etcd client interface.
+	client Client
 }
 
 var (
@@ -49,6 +49,11 @@ var (
 
 // New creates a new etcd driver instance using an existing etcd client.
 // The client should be properly configured and connected to an etcd cluster.
+//
+// NewLocker is only supported when client is a concrete *etcd.Client — the
+// concurrency package needs the concrete type which the Client interface does
+// not expose. Drivers built from a non-concrete Client return
+// locker.ErrUnsupported from NewLocker.
 func New(client Client) *Driver {
 	return &Driver{
 		client: client,

--- a/driver/etcd/examples_test.go
+++ b/driver/etcd/examples_test.go
@@ -8,6 +8,7 @@ package etcd_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"github.com/tarantool/go-storage/driver/etcd"
 	testingUtils "github.com/tarantool/go-storage/internal/testing"
 	etcdtestingUtils "github.com/tarantool/go-storage/internal/testing/etcd"
+	"github.com/tarantool/go-storage/locker"
 	"github.com/tarantool/go-storage/operation"
 	"github.com/tarantool/go-storage/predicate"
 )
@@ -490,4 +492,73 @@ func ExampleDriver_Watch_gracefulTermination() {
 	// Output:
 	// Started watch with manual control
 	// Stopping watch gracefully...
+}
+
+// ExampleDriver_NewLocker demonstrates acquiring an etcd-backed distributed
+// lock, observing contention from a second Locker on the same name, and
+// releasing the lock so the contender can proceed.
+//
+// The driver must be built with a concrete *etcd.Client — drivers built with
+// a non-concrete Client return locker.ErrUnsupported from NewLocker.
+func ExampleDriver_NewLocker() {
+	t := testingUtils.NewT()
+	defer t.Cleanups()
+
+	ctx := context.Background()
+
+	driver, cleanup := createEtcdDriver(t)
+	defer cleanup()
+
+	holder, err := driver.NewLocker(ctx, "/locks/leader")
+	if err != nil {
+		log.Printf("NewLocker (holder) failed: %v", err)
+		return
+	}
+
+	err = holder.Lock(ctx)
+	if err != nil {
+		log.Printf("Lock failed: %v", err)
+		return
+	}
+
+	fmt.Println("holder acquired")
+
+	contender, err := driver.NewLocker(ctx, "/locks/leader")
+	if err != nil {
+		log.Printf("NewLocker (contender) failed: %v", err)
+		return
+	}
+
+	err = contender.TryLock(ctx)
+	if errors.Is(err, locker.ErrLocked) {
+		fmt.Println("contender saw the lock as held")
+	}
+
+	err = holder.Unlock(ctx)
+	if err != nil {
+		log.Printf("Unlock failed: %v", err)
+		return
+	}
+
+	fmt.Println("holder released")
+
+	err = contender.TryLock(ctx)
+	if err != nil {
+		log.Printf("contender TryLock after release failed: %v", err)
+		return
+	}
+
+	fmt.Println("contender acquired")
+
+	err = contender.Unlock(ctx)
+	if err != nil {
+		log.Printf("Unlock failed: %v", err)
+		return
+	}
+
+	// Output:
+	// holder acquired
+	// contender saw the lock as held
+	// holder released
+	// contender acquired
 }

--- a/driver/etcd/locker.go
+++ b/driver/etcd/locker.go
@@ -1,0 +1,132 @@
+package etcd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	etcd "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+
+	"github.com/tarantool/go-storage/locker"
+)
+
+type etcdLocker struct {
+	session *concurrency.Session
+	mu      *concurrency.Mutex
+	name    string
+
+	stateMu sync.Mutex
+	held    bool
+}
+
+var _ locker.Locker = (*etcdLocker)(nil)
+
+// NewLocker returns locker.ErrUnsupported when the Driver was built with a
+// Client that is not a concrete *etcd.Client — the concurrency package needs
+// the concrete type which the Client interface does not expose.
+func (d Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
+	concrete, ok := d.client.(*etcd.Client)
+	if !ok {
+		return nil, locker.ErrUnsupported
+	}
+
+	options := locker.ApplyOptions(opts)
+
+	session, err := concurrency.NewSession(
+		concrete,
+		concurrency.WithTTL(int(options.TTL.Seconds())),
+		concurrency.WithContext(ctx),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("etcd locker: create session: %w", err)
+	}
+
+	mu := concurrency.NewMutex(session, name)
+
+	return &etcdLocker{ //nolint:exhaustruct // stateMu and held are zero-initialized by design.
+		session: session,
+		mu:      mu,
+		name:    name,
+	}, nil
+}
+
+func (l *etcdLocker) Lock(ctx context.Context) error {
+	l.stateMu.Lock()
+	if l.held {
+		l.stateMu.Unlock()
+		return nil
+	}
+
+	l.stateMu.Unlock()
+
+	err := l.mu.Lock(ctx)
+	if err != nil {
+		if errors.Is(err, concurrency.ErrLocked) {
+			return locker.ErrLocked
+		}
+
+		return fmt.Errorf("etcd locker: lock: %w", err)
+	}
+
+	l.stateMu.Lock()
+	l.held = true
+	l.stateMu.Unlock()
+
+	return nil
+}
+
+func (l *etcdLocker) TryLock(ctx context.Context) error {
+	l.stateMu.Lock()
+	if l.held {
+		l.stateMu.Unlock()
+		return nil
+	}
+
+	l.stateMu.Unlock()
+
+	err := l.mu.TryLock(ctx)
+	if err != nil {
+		if errors.Is(err, concurrency.ErrLocked) {
+			return locker.ErrLocked
+		}
+
+		return fmt.Errorf("etcd locker: try-lock: %w", err)
+	}
+
+	l.stateMu.Lock()
+	l.held = true
+	l.stateMu.Unlock()
+
+	return nil
+}
+
+func (l *etcdLocker) Unlock(ctx context.Context) error {
+	l.stateMu.Lock()
+	defer l.stateMu.Unlock()
+
+	if !l.held {
+		return locker.ErrLockReleased
+	}
+
+	err := l.mu.Unlock(ctx)
+	if err != nil {
+		return fmt.Errorf("etcd locker: unlock: %w", err)
+	}
+
+	// Flip held before session.Close so a subsequent Unlock returns
+	// ErrLockReleased even if Close fails.
+	l.held = false
+
+	err = l.session.Close()
+	if err != nil {
+		return fmt.Errorf("etcd locker: close session: %w", err)
+	}
+
+	return nil
+}
+
+func (l *etcdLocker) Key() string {
+	return l.mu.Key()
+}

--- a/driver/etcd/locker_test.go
+++ b/driver/etcd/locker_test.go
@@ -1,0 +1,275 @@
+//nolint:paralleltest // see integration_test.go for the package-level rationale.
+package etcd_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gojuno/minimock/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	etcdclient "go.etcd.io/etcd/client/v3"
+	etcdfintegration "go.etcd.io/etcd/tests/v3/framework/integration"
+
+	etcddriver "github.com/tarantool/go-storage/driver/etcd"
+	"github.com/tarantool/go-storage/internal/mocks"
+	"github.com/tarantool/go-storage/internal/testing/etcd"
+	"github.com/tarantool/go-storage/locker"
+)
+
+const (
+	// lockerTestTimeout is generous to absorb -race + slow CI overhead on
+	// etcd lease/raft round-trips. It is used both as per-test outer
+	// deadline and as the internal time.After bound for cross-locker waits.
+	lockerTestTimeout = 30 * time.Second
+)
+
+// testLockName derives a per-test lock name so different tests cannot
+// accidentally interfere via shared etcd keys (each test runs against its
+// own cluster, but a per-test prefix is a cheap belt-and-braces guard).
+func testLockName(t *testing.T) string {
+	t.Helper()
+
+	return "/test/locker/" + t.Name()
+}
+
+// createTestDriverConcrete builds a Driver from a concrete *etcd.Client
+// (the locker requires the concrete type).
+func createTestDriverConcrete(t *testing.T) (*etcddriver.Driver, *etcdclient.Client) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("skipping integration tests in short mode")
+	}
+
+	etcdfintegration.BeforeTest(etcd.NewSilentTB(t), etcdfintegration.WithoutGoLeakDetection())
+
+	cluster := etcd.NewLazyCluster()
+
+	t.Cleanup(func() { cluster.Terminate() })
+
+	endpoints := cluster.EndpointsGRPC()
+
+	client, err := etcdclient.New(etcdclient.Config{ //nolint:exhaustruct
+		Endpoints:   endpoints,
+		DialTimeout: testDialTimeout,
+	})
+	require.NoError(t, err, "failed to create etcd client")
+	t.Cleanup(func() { _ = client.Close() })
+
+	return etcddriver.New(client), client
+}
+
+func createSecondClient(t *testing.T, endpoints []string) *etcdclient.Client {
+	t.Helper()
+
+	client, err := etcdclient.New(etcdclient.Config{ //nolint:exhaustruct
+		Endpoints:   endpoints,
+		DialTimeout: testDialTimeout,
+	})
+	require.NoError(t, err, "failed to create second etcd client")
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client
+}
+
+func TestLocker_AcquireRelease(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
+	t.Cleanup(cancel)
+
+	driver, _ := createTestDriverConcrete(t)
+
+	lock, err := driver.NewLocker(ctx, testLockName(t))
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	assert.Empty(t, lock.Key())
+
+	require.NoError(t, lock.Lock(ctx))
+
+	assert.NotEmpty(t, lock.Key())
+
+	require.NoError(t, lock.Unlock(ctx))
+}
+
+func TestLocker_ReLock_IsNoOp(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
+	t.Cleanup(cancel)
+
+	driver, _ := createTestDriverConcrete(t)
+
+	lock, err := driver.NewLocker(ctx, testLockName(t))
+	require.NoError(t, err)
+
+	require.NoError(t, lock.Lock(ctx))
+	require.NoError(t, lock.Lock(ctx))
+	require.NoError(t, lock.Unlock(ctx))
+}
+
+func TestLocker_Unlock_NeverLocked(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
+	t.Cleanup(cancel)
+
+	driver, _ := createTestDriverConcrete(t)
+
+	lock, err := driver.NewLocker(ctx, testLockName(t))
+	require.NoError(t, err)
+
+	err = lock.Unlock(ctx)
+	require.ErrorIs(t, err, locker.ErrLockReleased)
+}
+
+func TestLocker_DoubleUnlock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
+	t.Cleanup(cancel)
+
+	driver, _ := createTestDriverConcrete(t)
+
+	lock, err := driver.NewLocker(ctx, testLockName(t))
+	require.NoError(t, err)
+
+	require.NoError(t, lock.Lock(ctx))
+	require.NoError(t, lock.Unlock(ctx))
+
+	err = lock.Unlock(ctx)
+	require.ErrorIs(t, err, locker.ErrLockReleased)
+}
+
+func TestLocker_Contention(t *testing.T) {
+	// Outer timeout is generous (3x per-op timeout) because the test does
+	// several Lock/Unlock round-trips and an internal time.After wait of
+	// lockerTestTimeout. The point is only to prevent infinite hangs.
+	ctx, cancel := context.WithTimeout(t.Context(), 3*lockerTestTimeout)
+	t.Cleanup(cancel)
+
+	driverA, clientA := createTestDriverConcrete(t)
+	endpoints := clientA.Endpoints()
+	clientB := createSecondClient(t, endpoints)
+	driverB := etcddriver.New(clientB)
+
+	lockName := testLockName(t)
+
+	lockA, err := driverA.NewLocker(ctx, lockName)
+	require.NoError(t, err)
+
+	lockB, err := driverB.NewLocker(ctx, lockName)
+	require.NoError(t, err)
+
+	require.NoError(t, lockA.Lock(ctx))
+
+	bAcquired := make(chan error, 1)
+
+	go func() {
+		bAcquired <- lockB.Lock(ctx)
+	}()
+
+	select {
+	case err := <-bAcquired:
+		t.Fatalf("B acquired lock unexpectedly before A released (err=%v)", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	require.NoError(t, lockA.Unlock(ctx))
+
+	select {
+	case err := <-bAcquired:
+		require.NoError(t, err, "B should have acquired lock after A released")
+	case <-time.After(lockerTestTimeout):
+		t.Fatal("B did not acquire lock within timeout after A released")
+	}
+
+	require.NoError(t, lockB.Unlock(ctx))
+}
+
+func TestLocker_TryLock_Contended(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
+	t.Cleanup(cancel)
+
+	driverA, clientA := createTestDriverConcrete(t)
+	endpoints := clientA.Endpoints()
+	clientB := createSecondClient(t, endpoints)
+	driverB := etcddriver.New(clientB)
+
+	lockName := testLockName(t)
+
+	lockA, err := driverA.NewLocker(ctx, lockName)
+	require.NoError(t, err)
+
+	lockB, err := driverB.NewLocker(ctx, lockName)
+	require.NoError(t, err)
+
+	require.NoError(t, lockA.Lock(ctx))
+
+	err = lockB.TryLock(ctx)
+	require.ErrorIs(t, err, locker.ErrLocked)
+
+	require.NoError(t, lockA.Unlock(ctx))
+}
+
+func TestLocker_CtxCancellation_AbortsLock(t *testing.T) {
+	// 3x per-op timeout to cover several Lock/Unlock round-trips plus an
+	// internal time.After(lockerTestTimeout) wait for the C locker.
+	ctx, cancel := context.WithTimeout(t.Context(), 3*lockerTestTimeout)
+	t.Cleanup(cancel)
+
+	driverA, clientA := createTestDriverConcrete(t)
+	endpoints := clientA.Endpoints()
+	clientB := createSecondClient(t, endpoints)
+	driverB := etcddriver.New(clientB)
+
+	lockName := testLockName(t)
+
+	lockA, err := driverA.NewLocker(ctx, lockName)
+	require.NoError(t, err)
+
+	require.NoError(t, lockA.Lock(ctx))
+
+	callCtx, callCancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer callCancel()
+
+	lockB, err := driverB.NewLocker(ctx, lockName)
+	require.NoError(t, err)
+
+	start := time.Now()
+
+	err = lockB.Lock(callCtx)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 2*time.Second)
+
+	require.NoError(t, lockA.Unlock(ctx))
+
+	clientC := createSecondClient(t, endpoints)
+	driverC := etcddriver.New(clientC)
+
+	lockC, err := driverC.NewLocker(ctx, lockName)
+	require.NoError(t, err)
+
+	acquiredC := make(chan error, 1)
+
+	go func() {
+		acquiredC <- lockC.Lock(ctx)
+	}()
+
+	select {
+	case err := <-acquiredC:
+		require.NoError(t, err, "fresh locker C should acquire after A released and B's ctx cancelled")
+	case <-time.After(lockerTestTimeout):
+		t.Fatal("fresh locker C did not acquire within timeout")
+	}
+
+	require.NoError(t, lockC.Unlock(ctx))
+}
+
+func TestLocker_NewLockerOnNonConcreteClient_ReturnsErrUnsupported(t *testing.T) {
+	mc := minimock.NewController(t)
+
+	client := mocks.NewEtcdClientMock(mc)
+	driver := etcddriver.New(client)
+
+	lock, err := driver.NewLocker(t.Context(), testLockName(t))
+	assert.Nil(t, lock)
+	require.ErrorIs(t, err, locker.ErrUnsupported)
+}


### PR DESCRIPTION
Add the locker.Locker interface package and an etcd-backed Locker. Locker wraps concurrency.NewSession + concurrency.NewMutex, which require the concrete *etcd.Client. New constructor NewWithClient exposes it; drivers built via New(Client) return locker.ErrUnsupported from NewLocker. Example uses LazyCluster.

Part of #29