### PR TITLE
driver/tcs: add Locker over config.storage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,6 +72,7 @@ linters:
             - "!$test"
           allow:
             - $gostd
+            - "github.com/google/uuid"
             - "github.com/tarantool/go-iproto"
             - "github.com/tarantool/go-option"
             - "github.com/tarantool/go-storage"

--- a/driver/tcs/examples_test.go
+++ b/driver/tcs/examples_test.go
@@ -2,6 +2,7 @@ package tcs_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/tarantool/go-storage/driver/tcs"
 	gsTesting "github.com/tarantool/go-storage/internal/testing"
+	"github.com/tarantool/go-storage/locker"
 	"github.com/tarantool/go-storage/operation"
 	"github.com/tarantool/go-storage/predicate"
 )
@@ -441,4 +443,127 @@ func ExampleDriver_Watch() {
 	// Event 3: change detected on /config/database
 	// Started watch with manual control
 	// Stopping watch gracefully...
+}
+
+// lockerMockResponse builds a raw config.storage.* response (an outer
+// single-element list wrapping body) as the typed locker decoders expect.
+func lockerMockResponse(body any) *gsTesting.MockResponse {
+	return gsTesting.NewMockResponse(gsTesting.NewT(), []any{body})
+}
+
+// createTCSDriverNewLocker scripts a MockDoer that mimics a TCS server
+// advertising features.ttl + features.keepalive, then walks two Lockers
+// through one round of contention plus a clean handover.
+func createTCSDriverNewLocker() *tcs.Driver {
+	infoFeatures := map[string]any{
+		"features": map[string]any{"ttl": true, "keepalive": true},
+	}
+
+	getEntry := func(path string, modRev int64) any {
+		return map[string]any{"path": path, "value": "", "mod_revision": modRev}
+	}
+
+	getResponse := func(entries ...any) any {
+		return map[string]any{"data": entries, "revision": int64(1000)}
+	}
+
+	mock := gsTesting.NewMockDoer(gsTesting.NewT(),
+		// Holder NewLocker probes features.
+		lockerMockResponse(infoFeatures),
+		// Holder TryLock: put → get(only-self) → smallest, held.
+		lockerMockResponse(map[string]any{"revision": int64(10)}),
+		lockerMockResponse(getResponse(getEntry("/locks/leader/h", 10))),
+
+		// Contender NewLocker probes features.
+		lockerMockResponse(infoFeatures),
+		// Contender TryLock: put → get(holder+self) → not smallest → ErrLocked
+		// → cleanup delete of contender's failed key.
+		lockerMockResponse(map[string]any{"revision": int64(20)}),
+		lockerMockResponse(getResponse(
+			getEntry("/locks/leader/h", 10),
+			getEntry("/locks/leader/c", 20),
+		)),
+		lockerMockResponse(map[string]any{}),
+
+		// Holder Unlock deletes its key.
+		lockerMockResponse(map[string]any{}),
+
+		// Contender TryLock again: put → get(only-self) → smallest, held.
+		lockerMockResponse(map[string]any{"revision": int64(30)}),
+		lockerMockResponse(getResponse(getEntry("/locks/leader/c2", 30))),
+
+		// Contender Unlock deletes its key.
+		lockerMockResponse(map[string]any{}),
+	)
+
+	return tcs.New(gsTesting.NewMockDoerWithWatcher(mock, nil))
+}
+
+// ExampleDriver_NewLocker demonstrates acquiring a TCS-backed distributed
+// lock, observing contention from a second Locker on the same name, and
+// releasing the lock so the contender can proceed.
+//
+// The TCS server must advertise features.ttl and features.keepalive — on
+// older schemas NewLocker returns tcs.ErrUnsupportedFeatures.
+func ExampleDriver_NewLocker() {
+	ctx := context.Background()
+
+	driver := createTCSDriverNewLocker()
+
+	// A long TTL keeps the keepalive ticker (ttl/3) from firing during the
+	// example, so the scripted MockDoer only sees the calls illustrated below.
+	const ttl = 120 * time.Second
+
+	holder, err := driver.NewLocker(ctx, "/locks/leader", locker.WithTTL(ttl))
+	if err != nil {
+		log.Printf("NewLocker (holder) failed: %v", err)
+		return
+	}
+
+	err = holder.TryLock(ctx)
+	if err != nil {
+		log.Printf("holder TryLock failed: %v", err)
+		return
+	}
+
+	fmt.Println("holder acquired:", holder.Key() != "")
+
+	contender, err := driver.NewLocker(ctx, "/locks/leader", locker.WithTTL(ttl))
+	if err != nil {
+		log.Printf("NewLocker (contender) failed: %v", err)
+		return
+	}
+
+	err = contender.TryLock(ctx)
+	if errors.Is(err, locker.ErrLocked) {
+		fmt.Println("contender saw the lock as held")
+	}
+
+	err = holder.Unlock(ctx)
+	if err != nil {
+		log.Printf("Unlock failed: %v", err)
+		return
+	}
+
+	fmt.Println("holder released")
+
+	err = contender.TryLock(ctx)
+	if err != nil {
+		log.Printf("contender TryLock after release failed: %v", err)
+		return
+	}
+
+	fmt.Println("contender acquired:", contender.Key() != "")
+
+	err = contender.Unlock(ctx)
+	if err != nil {
+		log.Printf("Unlock failed: %v", err)
+		return
+	}
+
+	// Output:
+	// holder acquired: true
+	// contender saw the lock as held
+	// holder released
+	// contender acquired: true
 }

--- a/driver/tcs/locker.go
+++ b/driver/tcs/locker.go
@@ -1,0 +1,309 @@
+package tcs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tarantool/go-tarantool/v2"
+
+	"github.com/tarantool/go-storage/locker"
+)
+
+var (
+	errInvalidLockerName = errors.New("tcs locker: name must start with '/' and must not end with '/'")
+
+	// ErrUnsupportedFeatures is returned by NewLocker when the TCS instance does
+	// not advertise both the ttl and keepalive features required by the locker.
+	ErrUnsupportedFeatures = errors.New("tcs locker: server does not support ttl+keepalive — schema upgrade required")
+)
+
+// tcsLocker implements "smallest mod_revision wins" locking over the prefix
+// `name + "/"`. Each attempt writes a unique ephemeral key with a TTL renewed
+// at ttl/3 cadence, which assumes replication_synchro_timeout + RTT < ttl/3
+// on a healthy cluster.
+type tcsLocker struct {
+	conn   DoerWatcher
+	name   string
+	ttlSec int
+	//nolint:containedctx // lifeCtx scopes the locker; cancellation aborts a blocking Lock.
+	lifeCtx context.Context
+
+	mu      sync.Mutex
+	held    bool
+	myKey   string
+	myRev   int64
+	stopKA  chan struct{}
+	expired chan struct{}
+}
+
+var _ locker.Locker = (*tcsLocker)(nil)
+
+// NewLocker requires name to start with '/' and not end with '/' (e.g.
+// "/my/lock"). Cancel ctx to stop the keepalive goroutine.
+//
+// Returns ErrUnsupportedFeatures if the TCS server does not advertise
+// features.ttl and features.keepalive.
+func (d Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
+	if !strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") {
+		return nil, errInvalidLockerName
+	}
+
+	hasTTL, hasKeepalive, err := infoFeatures(ctx, d.conn)
+	if err != nil {
+		return nil, fmt.Errorf("tcs locker: NewLocker: %w", err)
+	}
+
+	if !hasTTL || !hasKeepalive {
+		return nil, ErrUnsupportedFeatures
+	}
+
+	options := locker.ApplyOptions(opts)
+
+	ttlSec := max(int(options.TTL.Seconds()), 1)
+
+	return &tcsLocker{ //nolint:exhaustruct // mutable state fields are zero-initialized by design.
+		conn:    d.conn,
+		name:    name,
+		ttlSec:  ttlSec,
+		lifeCtx: ctx,
+	}, nil
+}
+
+func (l *tcsLocker) Lock(ctx context.Context) error {
+	l.mu.Lock()
+	if l.held {
+		l.mu.Unlock()
+		return nil
+	}
+
+	l.mu.Unlock()
+
+	myKey := l.name + "/" + uuid.NewString()
+
+	myRev, err := putWithTTL(ctx, l.conn, myKey, "", l.ttlSec)
+	if err != nil {
+		return fmt.Errorf("tcs locker: lock %s: %w", l.name, err)
+	}
+
+	stopKA := make(chan struct{})
+	expired := make(chan struct{})
+
+	go l.keepaliveLoop(myKey, stopKA, expired)
+
+	cleanupOnFail := func() { //nolint:contextcheck // cleanup must run even when ctx is already canceled.
+		close(stopKA)
+
+		_ = deletePath(context.Background(), l.conn, myKey)
+	}
+
+	for {
+		entries, err := getPrefix(ctx, l.conn, l.name+"/")
+		if err != nil {
+			cleanupOnFail()
+			return fmt.Errorf("tcs locker: lock %s: list: %w", l.name, err)
+		}
+
+		if isSmallestRev(entries, myRev) {
+			l.mu.Lock()
+			l.held = true
+			l.myKey = myKey
+			l.myRev = myRev
+			l.stopKA = stopKA
+			l.expired = expired
+			l.mu.Unlock()
+
+			return nil
+		}
+
+		watchKey := predecessorKey(entries, myRev, l.name+"/")
+
+		notified := make(chan struct{}, 1)
+
+		watcher, werr := l.conn.NewWatcher("config.storage:"+watchKey, func(_ tarantool.WatchEvent) {
+			select {
+			case notified <- struct{}{}:
+			default:
+			}
+		})
+		if werr != nil {
+			cleanupOnFail()
+			return fmt.Errorf("tcs locker: lock %s: watch: %w", l.name, werr)
+		}
+
+		select {
+		case <-notified:
+		case <-ctx.Done():
+			watcher.Unregister()
+			cleanupOnFail()
+
+			return fmt.Errorf("tcs locker: lock %s: %w", l.name, ctx.Err())
+		case <-l.lifeCtx.Done():
+			watcher.Unregister()
+			cleanupOnFail()
+
+			return fmt.Errorf("tcs locker: lock %s: lifetime context: %w", l.name, l.lifeCtx.Err())
+		case <-expired:
+			watcher.Unregister()
+			// TTL expiry already removed our key — no cleanup needed.
+			return fmt.Errorf("tcs locker: lock %s: %w", l.name, locker.ErrSessionExpired)
+		}
+
+		watcher.Unregister()
+	}
+}
+
+func (l *tcsLocker) TryLock(ctx context.Context) error {
+	l.mu.Lock()
+	if l.held {
+		l.mu.Unlock()
+		return nil
+	}
+
+	l.mu.Unlock()
+
+	myKey := l.name + "/" + uuid.NewString()
+
+	myRev, err := putWithTTL(ctx, l.conn, myKey, "", l.ttlSec)
+	if err != nil {
+		return fmt.Errorf("tcs locker: try-lock %s: %w", l.name, err)
+	}
+
+	entries, err := getPrefix(ctx, l.conn, l.name+"/")
+	if err != nil {
+		//nolint:contextcheck // cleanup must run even when ctx is already canceled.
+		_ = deletePath(context.Background(), l.conn, myKey)
+		return fmt.Errorf("tcs locker: try-lock %s: list: %w", l.name, err)
+	}
+
+	if !isSmallestRev(entries, myRev) {
+		//nolint:contextcheck // cleanup must run even when ctx is already canceled.
+		_ = deletePath(context.Background(), l.conn, myKey)
+
+		return locker.ErrLocked
+	}
+
+	stopKA := make(chan struct{})
+	expired := make(chan struct{})
+
+	go l.keepaliveLoop(myKey, stopKA, expired)
+
+	l.mu.Lock()
+	l.held = true
+	l.myKey = myKey
+	l.myRev = myRev
+	l.stopKA = stopKA
+	l.expired = expired
+	l.mu.Unlock()
+
+	return nil
+}
+
+func (l *tcsLocker) Unlock(ctx context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if !l.held {
+		return locker.ErrLockReleased
+	}
+
+	close(l.stopKA)
+
+	myKey := l.myKey
+
+	l.held = false
+	l.myKey = ""
+	l.myRev = 0
+	l.stopKA = nil
+	l.expired = nil
+
+	err := deletePath(ctx, l.conn, myKey)
+	if err != nil {
+		return fmt.Errorf("tcs locker: unlock %s: %w", l.name, err)
+	}
+
+	return nil
+}
+
+func (l *tcsLocker) Key() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.myKey
+}
+
+// keepaliveDivisor sets keepalive cadence to ttl/keepaliveDivisor; the divisor
+// must satisfy replication_synchro_timeout + RTT < ttl/keepaliveDivisor.
+const keepaliveDivisor = 3
+
+func (l *tcsLocker) keepaliveLoop(myKey string, stop <-chan struct{}, expired chan<- struct{}) {
+	interval := max(time.Duration(l.ttlSec)*time.Second/keepaliveDivisor, time.Second)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stop:
+			return
+		case <-l.lifeCtx.Done():
+			return
+		case <-ticker.C:
+			err := keepalivePath(l.lifeCtx, l.conn, myKey, l.ttlSec)
+			if err != nil {
+				close(expired)
+				return
+			}
+		}
+	}
+}
+
+func isSmallestRev(entries []lockEntry, myRev int64) bool {
+	if len(entries) == 0 {
+		return true
+	}
+
+	for _, e := range entries {
+		if e.ModRevision < myRev {
+			return false
+		}
+	}
+
+	return true
+}
+
+// predecessorKey returns the entry with the largest mod_revision strictly less
+// than myRev, or prefix when none exists (so the watcher fires on any change).
+func predecessorKey(entries []lockEntry, myRev int64, prefix string) string {
+	sorted := make([]lockEntry, len(entries))
+	copy(sorted, entries)
+	slices.SortFunc(sorted, func(a, b lockEntry) int {
+		switch {
+		case a.ModRevision < b.ModRevision:
+			return -1
+		case a.ModRevision > b.ModRevision:
+			return 1
+		default:
+			return 0
+		}
+	})
+
+	predecessor := ""
+
+	for _, e := range sorted {
+		if e.ModRevision < myRev {
+			predecessor = e.Path
+		}
+	}
+
+	if predecessor == "" {
+		return prefix
+	}
+
+	return predecessor
+}

--- a/driver/tcs/locker_calls.go
+++ b/driver/tcs/locker_calls.go
@@ -1,0 +1,149 @@
+package tcs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tarantool/go-tarantool/v2"
+)
+
+type lockEntry struct {
+	Path        string
+	Value       string
+	ModRevision int64
+}
+
+// putWithTTL writes path with the given TTL and returns the cluster revision
+// assigned to the write — the same value reappears as mod_revision in
+// config.storage.get results, providing the ordering for "smallest revision
+// wins".
+func putWithTTL(ctx context.Context, conn DoerWatcher, path, value string, ttlSec int) (int64, error) {
+	req := tarantool.NewCallRequest("config.storage.put").
+		Args([]any{path, value, map[string]any{"ttl": ttlSec}}).
+		Context(ctx)
+
+	// Response shape: [ { revision: N } ].
+	var result []struct {
+		Revision int64 `msgpack:"revision"`
+	}
+
+	err := conn.Do(req).GetTyped(&result)
+	if err != nil {
+		return 0, fmt.Errorf("tcs locker: putWithTTL %s: %w", path, err)
+	}
+
+	if len(result) != 1 {
+		return 0, fmt.Errorf("tcs locker: putWithTTL %s: %w: expected 1 element, got %d",
+			path, ErrUnexpectedResponse, len(result))
+	}
+
+	return result[0].Revision, nil
+}
+
+func keepalivePath(ctx context.Context, conn DoerWatcher, path string, ttlSec int) error {
+	req := tarantool.NewCallRequest("config.storage.keepalive").
+		Args([]any{path, ttlSec}).
+		Context(ctx)
+
+	var result []any
+
+	err := conn.Do(req).GetTyped(&result)
+	if err != nil {
+		return fmt.Errorf("tcs locker: keepalive %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// getPrefix returns entries under prefix. Response shape:
+//
+//	[ { data: [ {path, value, mod_revision}, ... ], revision: N } ]
+func getPrefix(ctx context.Context, conn DoerWatcher, prefix string) ([]lockEntry, error) {
+	req := tarantool.NewCallRequest("config.storage.get").
+		Args([]any{prefix}).
+		Context(ctx)
+
+	var raw []struct {
+		Data []struct {
+			Path        string `msgpack:"path"`
+			Value       string `msgpack:"value"`
+			ModRevision int64  `msgpack:"mod_revision"`
+		} `msgpack:"data"`
+		Revision int64 `msgpack:"revision"`
+	}
+
+	err := conn.Do(req).GetTyped(&raw)
+	if err != nil {
+		return nil, fmt.Errorf("tcs locker: getPrefix %s: %w", prefix, err)
+	}
+
+	if len(raw) == 0 {
+		return nil, nil
+	}
+
+	entries := make([]lockEntry, 0, len(raw[0].Data))
+	for _, r := range raw[0].Data {
+		entries = append(entries, lockEntry{
+			Path:        r.Path,
+			Value:       r.Value,
+			ModRevision: r.ModRevision,
+		})
+	}
+
+	return entries, nil
+}
+
+func deletePath(ctx context.Context, conn DoerWatcher, path string) error {
+	req := tarantool.NewCallRequest("config.storage.delete").
+		Args([]any{path}).
+		Context(ctx)
+
+	var result []any
+
+	err := conn.Do(req).GetTyped(&result)
+	if err != nil {
+		return fmt.Errorf("tcs locker: delete %s: %w", path, err)
+	}
+
+	return nil
+}
+
+// infoFeatures reports whether the server exposes the ttl and keepalive
+// features required by the locker.
+func infoFeatures(ctx context.Context, conn DoerWatcher) (bool, bool, error) {
+	req := tarantool.NewCallRequest("config.storage.info").
+		Args([]any{}).
+		Context(ctx)
+
+	// Response shape: [ { features = { ttl, keepalive, ... } } ].
+	var result []struct {
+		Features map[string]any `msgpack:"features"`
+	}
+
+	err := conn.Do(req).GetTyped(&result)
+	if err != nil {
+		return false, false, fmt.Errorf("tcs locker: info: %w", err)
+	}
+
+	if len(result) == 0 {
+		return false, false, fmt.Errorf("tcs locker: info: %w: empty response", ErrUnexpectedResponse)
+	}
+
+	features := result[0].Features
+
+	var ttl, keepalive bool
+
+	if v, ok := features["ttl"]; ok {
+		if b, ok2 := v.(bool); ok2 {
+			ttl = b
+		}
+	}
+
+	if v, ok := features["keepalive"]; ok {
+		if b, ok2 := v.(bool); ok2 {
+			keepalive = b
+		}
+	}
+
+	return ttl, keepalive, nil
+}

--- a/driver/tcs/locker_test.go
+++ b/driver/tcs/locker_test.go
@@ -1,0 +1,288 @@
+package tcs_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/driver/tcs"
+	"github.com/tarantool/go-storage/locker"
+)
+
+const lockerTestTTL = 3 * time.Second
+
+// lockerTestSlack is extra time beyond lockerTestTTL for a key to expire.
+const lockerTestSlack = 4 * time.Second
+
+func testLockerKey(t *testing.T, suffix string) string {
+	t.Helper()
+	return fmt.Sprintf("/locker-test/%s/%s", t.Name(), suffix)
+}
+
+// createTestLockerDriver builds a TCS driver and skips the test when the
+// server does not advertise ttl+keepalive.
+func createTestLockerDriver(ctx context.Context, t *testing.T) (*tcs.Driver, func()) {
+	t.Helper()
+
+	driver, done := createTestDriver(ctx, t)
+
+	// Probing features requires going through NewLocker — infoFeatures is
+	// package-private.
+	_, err := driver.NewLocker(ctx, "/probe", locker.WithTTL(lockerTestTTL))
+	if errors.Is(err, tcs.ErrUnsupportedFeatures) {
+		done()
+		t.Skip("TCS instance does not support ttl+keepalive — skipping locker integration tests")
+	}
+
+	require.NoError(t, err)
+
+	return driver, done
+}
+
+func TestLocker_NewLocker_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	t.Cleanup(done)
+
+	cases := []struct {
+		name string
+		desc string
+	}{
+		{"no-leading-slash", "no leading slash"},
+		{"/trailing/slash/", "trailing slash"},
+		{"", "empty string"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := driver.NewLocker(ctx, tc.name, locker.WithTTL(lockerTestTTL))
+			require.Error(t, err, "expected error for name %q", tc.name)
+		})
+	}
+}
+
+func TestLocker_AcquireRelease(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "basic")
+
+	lock, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lock.Lock(ctx))
+	assert.NotEmpty(t, lock.Key(), "Key() must be non-empty after Lock")
+
+	require.NoError(t, lock.Unlock(ctx))
+	assert.Empty(t, lock.Key(), "Key() must be empty after Unlock")
+}
+
+func TestLocker_Unlock_NotHeld(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "not-held")
+
+	lock, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	err = lock.Unlock(ctx)
+	require.ErrorIs(t, err, locker.ErrLockReleased)
+}
+
+func TestLocker_Lock_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "idempotent")
+
+	lock, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lock.Lock(ctx))
+	require.NoError(t, lock.Lock(ctx), "re-Lock on held locker must be a no-op")
+	require.NoError(t, lock.Unlock(ctx))
+}
+
+func TestLocker_Contention(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "contention")
+
+	lockerA, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lockerA.Lock(ctx))
+
+	lockerB, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	bDone := make(chan error, 1)
+
+	go func() {
+		bDone <- lockerB.Lock(ctx)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	select {
+	case err := <-bDone:
+		t.Fatalf("B acquired lock before A released it (err=%v)", err)
+	default:
+	}
+
+	require.NoError(t, lockerA.Unlock(ctx))
+
+	select {
+	case err := <-bDone:
+		require.NoError(t, err, "B should acquire lock after A unlocks")
+	case <-time.After(10 * time.Second):
+		t.Fatal("B did not acquire lock within timeout after A released")
+	}
+
+	require.NoError(t, lockerB.Unlock(ctx))
+}
+
+func TestLocker_TryLock_Contended(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "try-lock")
+
+	lockerA, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lockerA.Lock(ctx))
+
+	lockerB, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	err = lockerB.TryLock(ctx)
+	require.ErrorIs(t, err, locker.ErrLocked, "TryLock must return ErrLocked when another holder is present")
+
+	require.NoError(t, lockerA.Unlock(ctx))
+}
+
+func TestLocker_TryLock_Free(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "try-lock-free")
+
+	lock, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lock.TryLock(ctx))
+	assert.NotEmpty(t, lock.Key())
+	require.NoError(t, lock.Unlock(ctx))
+}
+
+func TestLocker_CtxCancel_CleansUp(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "ctx-cancel")
+
+	lockerA, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lockerA.Lock(ctx))
+
+	cancelCtx, cancel := context.WithCancel(ctx)
+
+	lockerB, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	bDone := make(chan error, 1)
+
+	go func() {
+		bDone <- lockerB.Lock(cancelCtx)
+	}()
+
+	time.Sleep(500 * time.Millisecond)
+
+	cancel()
+
+	select {
+	case err := <-bDone:
+		require.Error(t, err, "B.Lock should return an error after ctx cancel")
+	case <-time.After(5 * time.Second):
+		t.Fatal("B did not unblock within timeout after ctx cancel")
+	}
+
+	require.NoError(t, lockerA.Unlock(ctx))
+
+	lockerC, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lockerC.TryLock(ctx), "C should acquire lock after A and B are gone")
+	require.NoError(t, lockerC.Unlock(ctx))
+}
+
+//nolint:paralleltest // uses a short TTL + real time.Sleep; running in parallel races on shared TTL state.
+func TestLocker_LifetimeCtxCancel_KeyExpires(t *testing.T) {
+	ctx := context.Background()
+
+	driver, done := createTestLockerDriver(ctx, t)
+	defer done()
+
+	name := testLockerKey(t, "lifetime-expire")
+
+	lifeCtx, lifeCancel := context.WithCancel(ctx)
+
+	lockerA, err := driver.NewLocker(lifeCtx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lockerA.Lock(ctx))
+
+	// Cancel the lifetime context: keepalive stops, TTL is no longer renewed,
+	// and the key expires within lockerTestTTL.
+	lifeCancel()
+
+	time.Sleep(lockerTestTTL + lockerTestSlack)
+
+	lockerB, err := driver.NewLocker(ctx, name, locker.WithTTL(lockerTestTTL))
+	require.NoError(t, err)
+
+	require.NoError(t, lockerB.TryLock(ctx), "B should acquire lock after A's TTL expired")
+	require.NoError(t, lockerB.Unlock(ctx))
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.0
 
 require (
 	github.com/gojuno/minimock/v3 v3.4.7
+	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
 	github.com/tarantool/go-iproto v1.1.0
 	github.com/tarantool/go-option v1.0.0
@@ -38,7 +39,6 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 // indirect


### PR DESCRIPTION
Add the locker.Locker interface package and a tcs-backed Locker. "Smallest mod_revision wins" admission over config.storage.put / get / keepalive / delete, with a UUID fence and a ttl/3 keepalive ticker; on transport or session loss the locker fires ErrSessionExpired. Probes config.storage.info for features.ttl and features.keepalive — returns ErrUnsupportedFeatures if either is absent. Promotes google/uuid to a direct dependency.

Part of #29