### PR TITLE
integrity: add WithKeyPrefix option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- namer.LayeredNamer: `WithKeyPrefix(prefix)` option prepends a fixed path
+  prefix to every emitted/parsed key. Lets two codecs sit in disjoint
+  sub-trees of a single `storage.Storage` so they can be committed atomically
+  in one `integrity.Tx` (which cannot span multiple storage handles, the way
+  `storage.Prefixed` wrappers can). Validation matches `storage.Prefixed`:
+  must start with `/`, must not end with `/`; an empty prefix is a no-op.
+  Returns `namer.ErrKeyPrefixNoLeadingSlash` / `namer.ErrKeyPrefixTrailingSlash`
+  on malformed input; `ParseKey` returns `namer.ErrKeyPrefixMissing` for
+  keys that do not start with the configured prefix.
+- integrity.CodecBuilder: `WithKeyPrefix(prefix)` threads the namer option
+  through to the underlying `namer.NewLayeredNamer`, so codecs can be
+  built directly with a prefix without writing a custom
+  `CodecNamerConstructor`.
+
 ### Changed
 
 ### Fixed

--- a/integrity/codec.go
+++ b/integrity/codec.go
@@ -115,6 +115,7 @@ type CodecBuilder[T any] struct {
 	namerFunc      CodecNamerConstructor
 	compactHash    bool
 	compactSig     bool
+	keyPrefix      string
 }
 
 // NewCodecBuilder returns a new CodecBuilder with sensible defaults.
@@ -135,6 +136,7 @@ func NewCodecBuilder[T any]() CodecBuilder[T] {
 		namerFunc:      nil,
 		compactHash:    false,
 		compactSig:     false,
+		keyPrefix:      "",
 	}
 }
 
@@ -153,6 +155,7 @@ func (b CodecBuilder[T]) copy() CodecBuilder[T] {
 		namerFunc:      b.namerFunc,
 		compactHash:    b.compactHash,
 		compactSig:     b.compactSig,
+		keyPrefix:      b.keyPrefix,
 	}
 }
 
@@ -264,6 +267,27 @@ func (b CodecBuilder[T]) WithSingleSigCompact() CodecBuilder[T] {
 	out := b.copy()
 
 	out.compactSig = true
+
+	return out
+}
+
+// WithKeyPrefix prepends the given path prefix to every key the codec emits
+// and parses. This lets multiple codecs share a single storage.Storage while
+// keeping their keys in disjoint sub-trees — and therefore stay atomic in a
+// single integrity.Tx, which cannot span multiple storage handles.
+//
+// The prefix must start with '/' and must not end with '/'; empty is a no-op.
+// The validation runs in Build via the underlying namer, which returns
+// namer.ErrKeyPrefixNoLeadingSlash or namer.ErrKeyPrefixTrailingSlash on
+// malformed input.
+//
+// Custom namers passed through WithNamer receive the prefix as an extra
+// namer.LayeredOption. Namers that ignore LayeredOptions silently drop the
+// prefix; the default namer.NewLayeredNamer honours it.
+func (b CodecBuilder[T]) WithKeyPrefix(prefix string) CodecBuilder[T] {
+	out := b.copy()
+
+	out.keyPrefix = prefix
 
 	return out
 }
@@ -394,6 +418,10 @@ func (b CodecBuilder[T]) Build() (*Codec[T], error) {
 		}
 
 		opts = append(opts, namer.CompactSingleSig())
+	}
+
+	if b.keyPrefix != "" {
+		opts = append(opts, namer.WithKeyPrefix(b.keyPrefix))
 	}
 
 	genNamer, err := namerFn(objLoc, genHashLocs, genSigLocs, opts...)

--- a/integrity/tx_keyprefix_test.go
+++ b/integrity/tx_keyprefix_test.go
@@ -1,0 +1,225 @@
+package integrity_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	storage "github.com/tarantool/go-storage"
+	"github.com/tarantool/go-storage/hasher"
+	"github.com/tarantool/go-storage/integrity"
+	"github.com/tarantool/go-storage/operation"
+)
+
+func newPrefixedCodec(t *testing.T, prefix string) *integrity.Codec[txTestValue] {
+	t.Helper()
+
+	codec, err := integrity.NewCodecBuilder[txTestValue]().
+		WithObjectLocation("objects").
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithKeyPrefix(prefix).
+		Build()
+	require.NoError(t, err)
+
+	return codec
+}
+
+// TestTx_TwoCodecsDifferentPrefixes_Atomic verifies the motivating use case:
+// two codecs with different WithKeyPrefix values share one storage handle and
+// are committed in the same atomic Tx.
+func TestTx_TwoCodecsDifferentPrefixes_Atomic(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStorage()
+
+	codecA := newPrefixedCodec(t, "/a")
+	codecB := newPrefixedCodec(t, "/b")
+
+	txn := integrity.NewTx(store)
+
+	err := codecA.TxPut(txn, "alice", txTestValue{Field: "from-A"})
+	require.NoError(t, err)
+
+	err = codecB.TxPut(txn, "alice", txTestValue{Field: "from-B"})
+	require.NoError(t, err)
+
+	rsp, err := txn.Commit(context.Background())
+	require.NoError(t, err)
+	require.True(t, rsp.Succeeded)
+
+	readTx := integrity.NewTx(store)
+	futureA := codecA.TxGet(readTx, "alice")
+	futureB := codecB.TxGet(readTx, "alice")
+
+	_, err = readTx.Commit(context.Background())
+	require.NoError(t, err)
+
+	resultA, err := futureA.Result()
+	require.NoError(t, err)
+
+	gotA, ok := resultA.Value.Get()
+	require.True(t, ok)
+	assert.Equal(t, "from-A", gotA.Field)
+
+	resultB, err := futureB.Result()
+	require.NoError(t, err)
+
+	gotB, ok := resultB.Value.Get()
+	require.True(t, ok)
+	assert.Equal(t, "from-B", gotB.Field)
+}
+
+// TestTx_TwoCodecsDifferentPrefixes_RolledBackTogether verifies that when a
+// predicate fails, neither prefix sees a partial write.
+func TestTx_TwoCodecsDifferentPrefixes_RolledBackTogether(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStorage()
+
+	codecA := newPrefixedCodec(t, "/a")
+	codecB := newPrefixedCodec(t, "/b")
+
+	txn := integrity.NewTx(store)
+
+	pred, err := codecA.BindPredicate("alice", codecA.VersionGreater(999))
+	require.NoError(t, err)
+
+	txn.If(pred)
+	require.NoError(t, codecA.TxPut(txn, "alice", txTestValue{Field: "from-A"}))
+	require.NoError(t, codecB.TxPut(txn, "alice", txTestValue{Field: "from-B"}))
+
+	rsp, err := txn.Commit(context.Background())
+	require.NoError(t, err)
+	assert.False(t, rsp.Succeeded, "predicate must have failed")
+
+	readTx := integrity.NewTx(store)
+	futureA := codecA.TxGet(readTx, "alice")
+	futureB := codecB.TxGet(readTx, "alice")
+
+	_, err = readTx.Commit(context.Background())
+	require.NoError(t, err)
+
+	_, errA := futureA.Result()
+	_, errB := futureB.Result()
+
+	require.ErrorIs(t, errA, integrity.ErrNotFound, "A side must not be written")
+	require.ErrorIs(t, errB, integrity.ErrNotFound, "B side must not be written")
+}
+
+// TestTx_TwoCodecsDifferentPrefixes_RangeIsolated verifies that TxRange on
+// codec A only returns entries written under its own prefix — codec B's
+// entries in the same storage must not leak into A's range result.
+func TestTx_TwoCodecsDifferentPrefixes_RangeIsolated(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStorage()
+
+	codecA := newPrefixedCodec(t, "/a")
+	codecB := newPrefixedCodec(t, "/b")
+
+	seedTx := integrity.NewTx(store)
+	require.NoError(t, codecA.TxPut(seedTx, "alice", txTestValue{Field: "A-alice"}))
+	require.NoError(t, codecA.TxPut(seedTx, "bob", txTestValue{Field: "A-bob"}))
+	require.NoError(t, codecB.TxPut(seedTx, "carol", txTestValue{Field: "B-carol"}))
+
+	rsp, err := seedTx.Commit(context.Background())
+	require.NoError(t, err)
+	require.True(t, rsp.Succeeded)
+
+	rangeTx := integrity.NewTx(store)
+	futA := codecA.TxRange(rangeTx, "")
+	futB := codecB.TxRange(rangeTx, "")
+
+	_, err = rangeTx.Commit(context.Background())
+	require.NoError(t, err)
+
+	resultsA, err := futA.Result()
+	require.NoError(t, err)
+	assert.Len(t, resultsA, 2, "codec A range must see only its own two entries")
+
+	resultsB, err := futB.Result()
+	require.NoError(t, err)
+	assert.Len(t, resultsB, 1, "codec B range must see only its own one entry")
+}
+
+// TestTx_KeyPrefix_OnTopOfStoragePrefixed_DoublePrefixes guards the docstring
+// warning: stacking WithKeyPrefix on top of storage.Prefixed for the same
+// logical prefix doubles it. A value written via storage.Prefixed("/p") +
+// codec.WithKeyPrefix("/p") lands at "/p/p/objects/alice" in the underlying
+// driver, not "/p/objects/alice". This test pins that behaviour so a future
+// refactor that silently "helps" by deduping prefixes shows up as a failure.
+func TestTx_KeyPrefix_OnTopOfStoragePrefixed_DoublePrefixes(t *testing.T) {
+	t.Parallel()
+
+	inner := newTestStorage()
+
+	scoped, err := storage.Prefixed("/p", inner)
+	require.NoError(t, err)
+
+	codec, err := integrity.NewCodecBuilder[txTestValue]().
+		WithObjectLocation("objects").
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithKeyPrefix("/p").
+		Build()
+	require.NoError(t, err)
+
+	txn := integrity.NewTx(scoped)
+	require.NoError(t, codec.TxPut(txn, "alice", txTestValue{Field: "v"}))
+
+	rsp, err := txn.Commit(context.Background())
+	require.NoError(t, err)
+	require.True(t, rsp.Succeeded)
+
+	// The codec sees its own "/p/objects/alice" key through the Prefixed
+	// scope, which prepends another "/p" — final physical key is "/p/p/...".
+	// Scan the inner (un-prefixed) storage to observe the doubled prefix.
+	innerTx := inner.Tx(context.Background()).
+		Then(operation.Get([]byte("/")))
+
+	results, err := innerTx.Commit()
+	require.NoError(t, err)
+	require.True(t, results.Succeeded)
+	require.NotEmpty(t, results.Results)
+
+	keys := make([]string, 0, len(results.Results[0].Values))
+	for _, kv := range results.Results[0].Values {
+		keys = append(keys, string(kv.Key))
+	}
+
+	require.NotEmpty(t, keys, "expected at least one physical key in inner storage")
+
+	for _, k := range keys {
+		assert.True(t, strings.HasPrefix(k, "/p/p/"),
+			"stacked prefix should double to /p/p/...; got %q", k)
+	}
+}
+
+// TestTx_TwoCodecsDifferentPrefixes_KeySpacesAreDisjoint verifies that
+// /a/objects/alice and /b/objects/alice live in different sub-trees.
+func TestTx_TwoCodecsDifferentPrefixes_KeySpacesAreDisjoint(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStorage()
+
+	codecA := newPrefixedCodec(t, "/a")
+	codecB := newPrefixedCodec(t, "/b")
+
+	txn := integrity.NewTx(store)
+	require.NoError(t, codecA.TxPut(txn, "alice", txTestValue{Field: "A"}))
+
+	rsp, err := txn.Commit(context.Background())
+	require.NoError(t, err)
+	require.True(t, rsp.Succeeded)
+
+	readTx := integrity.NewTx(store)
+	futureB := codecB.TxGet(readTx, "alice")
+
+	_, err = readTx.Commit(context.Background())
+	require.NoError(t, err)
+
+	_, errB := futureB.Result()
+	require.ErrorIs(t, errB, integrity.ErrNotFound)
+}

--- a/namer/layered.go
+++ b/namer/layered.go
@@ -55,6 +55,16 @@ var (
 	// ErrCompactSingleSigCardinality is returned when CompactSingleSig is set
 	// but the configured sig list does not have exactly one entry.
 	ErrCompactSingleSigCardinality = errors.New("namer: CompactSingleSig requires exactly one sig entry")
+	// ErrKeyPrefixNoLeadingSlash is returned when WithKeyPrefix is given a
+	// non-empty value that does not start with '/'.
+	ErrKeyPrefixNoLeadingSlash = errors.New("namer: WithKeyPrefix must start with '/'")
+	// ErrKeyPrefixTrailingSlash is returned when WithKeyPrefix is given a value
+	// that ends with '/'. Layered keys begin with '/', so a trailing slash here
+	// would produce keys like "/p//objectLocation/name".
+	ErrKeyPrefixTrailingSlash = errors.New("namer: WithKeyPrefix must not end with '/'")
+	// ErrKeyPrefixMissing is returned by ParseKey when the raw key does not
+	// start with the configured WithKeyPrefix.
+	ErrKeyPrefixMissing = errors.New("namer: key does not start with configured WithKeyPrefix")
 )
 
 // LayeredHashLocation associates a hasher name with its key location segment.
@@ -76,6 +86,7 @@ type layeredOpts struct {
 	compactHash bool
 	compactSig  bool
 	legacy      bool
+	keyPrefix   string
 }
 
 // CompactSingleHash drops the per-hasher location segment in generated and
@@ -111,6 +122,30 @@ func LegacyHashSigLayout() LayeredOption {
 	return func(o *layeredOpts) { o.legacy = true }
 }
 
+// WithKeyPrefix prepends a fixed path prefix to every key the namer emits
+// and expects on parse. The resulting layout is:
+//
+//	<keyPrefix>/<objectLocation>/<name>                            (value)
+//	<keyPrefix>/hashes/<hashLocation>/<objectLocation>/<name>      (hash)
+//	<keyPrefix>/sig/<sigLocation>/<objectLocation>/<name>          (sig)
+//
+// The prefix must start with '/' and must not end with '/' (it is prepended
+// verbatim to keys that themselves start with '/', so a trailing slash would
+// produce empty segments). Interior '/' separators are allowed
+// (e.g. "/a/b"). An empty prefix is a no-op.
+//
+// Compared with storage.Prefixed, WithKeyPrefix lives in the namer, so two
+// codecs with different prefixes can share a single storage.Storage and be
+// committed atomically via a single transaction. Don't stack WithKeyPrefix on
+// top of storage.Prefixed for the same logical prefix — the two would double
+// it.
+//
+// NewLayeredNamer returns ErrKeyPrefixNoLeadingSlash or
+// ErrKeyPrefixTrailingSlash if the prefix is malformed.
+func WithKeyPrefix(prefix string) LayeredOption {
+	return func(o *layeredOpts) { o.keyPrefix = prefix }
+}
+
 type layeredNamer struct {
 	objectLocation string
 	hashLocations  []LayeredHashLocation
@@ -125,6 +160,9 @@ type layeredNamer struct {
 	// segment from hash and signature keys (but keeps it for value keys)
 	// to match the layout emitted by the legacy product.
 	legacy bool
+	// keyPrefix is prepended verbatim to every emitted key and stripped at
+	// the top of ParseKey. Empty string disables the feature.
+	keyPrefix string
 	// Reverse maps populated once at construction so ParseKey is O(1)
 	// regardless of hash/sig list size.
 	hashIndex map[string]string // hashLocation -> hasherName.
@@ -153,6 +191,10 @@ type layeredNamer struct {
 // With LegacyHashSigLayout, the per-codec <objectLocation> segment is
 // dropped from hash and sig keys (but kept for value keys) to match the
 // legacy product layout.
+//
+// With WithKeyPrefix, every emitted/parsed key is prefixed with the given
+// path segment, allowing multiple namers to share a single storage handle
+// in disjoint key spaces.
 //
 // Validation rules:
 //   - hashLocation / sigLocation must be a single non-empty segment with no '/'.
@@ -194,6 +236,16 @@ func NewLayeredNamer(
 
 	if resolved.compactSig && len(sigLocations) != 1 {
 		return nil, fmt.Errorf("%w: got %d", ErrCompactSingleSigCardinality, len(sigLocations))
+	}
+
+	if resolved.keyPrefix != "" {
+		if !strings.HasPrefix(resolved.keyPrefix, "/") {
+			return nil, fmt.Errorf("%w: %q", ErrKeyPrefixNoLeadingSlash, resolved.keyPrefix)
+		}
+
+		if strings.HasSuffix(resolved.keyPrefix, "/") {
+			return nil, fmt.Errorf("%w: %q", ErrKeyPrefixTrailingSlash, resolved.keyPrefix)
+		}
 	}
 
 	hashIndex := make(map[string]string, len(hashLocations))
@@ -242,6 +294,7 @@ func NewLayeredNamer(
 		compactSig:     resolved.compactSig,
 		unnamed:        unnamed,
 		legacy:         resolved.legacy,
+		keyPrefix:      resolved.keyPrefix,
 		hashIndex:      hashIndex,
 		sigIndex:       sigIndex,
 	}, nil
@@ -365,7 +418,12 @@ func (n *layeredNamer) GenerateNames(name string) ([]Key, error) {
 // <objectLocation> segment is dropped from every shape; the value-key
 // branch treats the entire stripped path as <name>.
 func (n *layeredNamer) ParseKey(raw string) (DefaultKey, error) {
-	stripped := strings.TrimPrefix(raw, "/")
+	keyless, err := n.stripKeyPrefix(raw)
+	if err != nil {
+		return DefaultKey{}, err
+	}
+
+	stripped := strings.TrimPrefix(keyless, "/")
 
 	first, _, found := strings.Cut(stripped, "/")
 	if first == "" {
@@ -431,6 +489,7 @@ func (n *layeredNamer) Prefix(val string, isPrefix bool) string {
 
 	var builder strings.Builder
 
+	builder.WriteString(n.keyPrefix)
 	builder.WriteByte('/')
 
 	if !n.unnamed {
@@ -487,14 +546,14 @@ func (n *layeredNamer) omitObjLocFromHashSig() bool {
 
 func (n *layeredNamer) valueRoot() string {
 	if n.unnamed {
-		return "/"
+		return n.keyPrefix + "/"
 	}
 
-	return "/" + n.objectLocation + "/"
+	return n.keyPrefix + "/" + n.objectLocation + "/"
 }
 
 func (n *layeredNamer) hashRoot(hashLocation string) string {
-	root := "/" + layeredHashMarker + "/"
+	root := n.keyPrefix + "/" + layeredHashMarker + "/"
 	if !n.compactHash {
 		root += hashLocation + "/"
 	}
@@ -507,7 +566,7 @@ func (n *layeredNamer) hashRoot(hashLocation string) string {
 }
 
 func (n *layeredNamer) sigRoot(sigLocation string) string {
-	root := "/" + layeredSigMarker + "/"
+	root := n.keyPrefix + "/" + layeredSigMarker + "/"
 	if !n.compactSig {
 		root += sigLocation + "/"
 	}
@@ -537,10 +596,10 @@ func (n *layeredNamer) layerPrefix(root, suffix string, isPrefix bool) string {
 
 func (n *layeredNamer) buildValueKey(name string) string {
 	if n.unnamed {
-		return "/" + name
+		return n.keyPrefix + "/" + name
 	}
 
-	return "/" + n.objectLocation + "/" + name
+	return n.keyPrefix + "/" + n.objectLocation + "/" + name
 }
 
 func (n *layeredNamer) buildHashKey(hashLocation, name string) string {
@@ -548,14 +607,14 @@ func (n *layeredNamer) buildHashKey(hashLocation, name string) string {
 
 	switch {
 	case n.compactHash && omitObj:
-		return "/" + layeredHashMarker + "/" + name
+		return n.keyPrefix + "/" + layeredHashMarker + "/" + name
 	case n.compactHash:
-		return "/" + layeredHashMarker + "/" + n.objectLocation + "/" + name
+		return n.keyPrefix + "/" + layeredHashMarker + "/" + n.objectLocation + "/" + name
 	case omitObj:
-		return "/" + layeredHashMarker + "/" + hashLocation + "/" + name
+		return n.keyPrefix + "/" + layeredHashMarker + "/" + hashLocation + "/" + name
 	}
 
-	return "/" + layeredHashMarker + "/" + hashLocation + "/" + n.objectLocation + "/" + name
+	return n.keyPrefix + "/" + layeredHashMarker + "/" + hashLocation + "/" + n.objectLocation + "/" + name
 }
 
 func (n *layeredNamer) buildSigKey(sigLocation, name string) string {
@@ -563,14 +622,14 @@ func (n *layeredNamer) buildSigKey(sigLocation, name string) string {
 
 	switch {
 	case n.compactSig && omitObj:
-		return "/" + layeredSigMarker + "/" + name
+		return n.keyPrefix + "/" + layeredSigMarker + "/" + name
 	case n.compactSig:
-		return "/" + layeredSigMarker + "/" + n.objectLocation + "/" + name
+		return n.keyPrefix + "/" + layeredSigMarker + "/" + n.objectLocation + "/" + name
 	case omitObj:
-		return "/" + layeredSigMarker + "/" + sigLocation + "/" + name
+		return n.keyPrefix + "/" + layeredSigMarker + "/" + sigLocation + "/" + name
 	}
 
-	return "/" + layeredSigMarker + "/" + sigLocation + "/" + n.objectLocation + "/" + name
+	return n.keyPrefix + "/" + layeredSigMarker + "/" + sigLocation + "/" + n.objectLocation + "/" + name
 }
 
 func (n *layeredNamer) parseValueKey(raw, stripped string) (DefaultKey, error) {
@@ -736,6 +795,28 @@ func (n *layeredNamer) parseFullSigKey(raw, rest string) (DefaultKey, error) {
 	}
 
 	return NewDefaultKey(after, KeyTypeSignature, signerName, raw), nil
+}
+
+// stripKeyPrefix returns raw with the configured keyPrefix removed. When no
+// keyPrefix is set this is a no-op; otherwise raw must start with the prefix
+// followed by '/' (or end exactly at the prefix), else ErrKeyPrefixMissing is
+// returned. The follow-up-slash check prevents a prefix like "/p" from
+// falsely matching keys under a sibling prefix like "/pp/...".
+func (n *layeredNamer) stripKeyPrefix(raw string) (string, error) {
+	if n.keyPrefix == "" {
+		return raw, nil
+	}
+
+	rest, ok := strings.CutPrefix(raw, n.keyPrefix)
+	if !ok {
+		return "", fmt.Errorf("%w: key %q, prefix %q", ErrKeyPrefixMissing, raw, n.keyPrefix)
+	}
+
+	if rest != "" && !strings.HasPrefix(rest, "/") {
+		return "", fmt.Errorf("%w: key %q, prefix %q", ErrKeyPrefixMissing, raw, n.keyPrefix)
+	}
+
+	return rest, nil
 }
 
 func validateNamePart(raw, name, kind string) error {

--- a/namer/layered_keyprefix_test.go
+++ b/namer/layered_keyprefix_test.go
@@ -1,0 +1,375 @@
+package namer_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/namer"
+)
+
+func newPrefixedLayeredNamer(t *testing.T, prefix string, opts ...namer.LayeredOption) namer.Namer {
+	t.Helper()
+
+	allOpts := append([]namer.LayeredOption{namer.WithKeyPrefix(prefix)}, opts...)
+
+	layeredN, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		allOpts...,
+	)
+	require.NoError(t, err)
+
+	return layeredN
+}
+
+func TestLayeredNamer_WithKeyPrefix_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		prefix  string
+		wantErr error
+	}{
+		{"empty prefix is allowed", "", nil},
+		{"missing leading slash", "a", namer.ErrKeyPrefixNoLeadingSlash},
+		{"trailing slash rejected", "/a/", namer.ErrKeyPrefixTrailingSlash},
+		{"single segment ok", "/a", nil},
+		{"multi-segment ok", "/a/b", nil},
+		{"just root slash is trailing slash", "/", namer.ErrKeyPrefixTrailingSlash},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := namer.NewLayeredNamer(
+				"objects",
+				nil,
+				nil,
+				namer.WithKeyPrefix(tt.prefix),
+			)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestLayeredNamer_WithKeyPrefix_GenerateNames(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p")
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+
+	expected := []string{
+		"/p/objects/alice",
+		"/p/hashes/sha256/objects/alice",
+		"/p/sig/ed25519/objects/alice",
+	}
+	for i, want := range expected {
+		assert.Equal(t, want, keys[i].Build(), "key[%d].Build()", i)
+		assert.Equal(t, "alice", keys[i].Name(), "key[%d].Name()", i)
+	}
+}
+
+func TestLayeredNamer_WithKeyPrefix_MultiSegment(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/tenant/acme")
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/tenant/acme/objects/alice", keys[0].Build())
+	assert.Equal(t, "/tenant/acme/hashes/sha256/objects/alice", keys[1].Build())
+	assert.Equal(t, "/tenant/acme/sig/ed25519/objects/alice", keys[2].Build())
+}
+
+func TestLayeredNamer_WithKeyPrefix_ParseRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p")
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	for _, key := range keys {
+		parsed, perr := layeredN.ParseKey(key.Build())
+		require.NoError(t, perr, "ParseKey(%q)", key.Build())
+		assert.Equal(t, key.Name(), parsed.Name())
+		assert.Equal(t, key.Type(), parsed.Type())
+		assert.Equal(t, key.Property(), parsed.Property())
+		assert.Equal(t, key.Build(), parsed.Build())
+	}
+}
+
+func TestLayeredNamer_WithKeyPrefix_ParseKey_MissingPrefix(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p")
+
+	_, err := layeredN.ParseKey("/objects/alice")
+	require.ErrorIs(t, err, namer.ErrKeyPrefixMissing)
+}
+
+func TestLayeredNamer_WithKeyPrefix_Prefixes(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p")
+
+	got := layeredN.Prefixes("", false)
+	expected := []string{
+		"/p/objects/",
+		"/p/hashes/sha256/objects/",
+		"/p/sig/ed25519/objects/",
+	}
+	assert.Equal(t, expected, got)
+
+	gotWithVal := layeredN.Prefixes("alice", true)
+	expectedWithVal := []string{
+		"/p/objects/alice/",
+		"/p/hashes/sha256/objects/alice/",
+		"/p/sig/ed25519/objects/alice/",
+	}
+	assert.Equal(t, expectedWithVal, gotWithVal)
+}
+
+func TestLayeredNamer_WithKeyPrefix_Prefix(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p")
+
+	assert.Equal(t, "/p/objects/", layeredN.Prefix("", false))
+	assert.Equal(t, "/p/objects/alice", layeredN.Prefix("alice", false))
+	assert.Equal(t, "/p/objects/alice/", layeredN.Prefix("alice", true))
+}
+
+func TestLayeredNamer_WithKeyPrefix_UnnamedMode(t *testing.T) {
+	t.Parallel()
+
+	layeredN, err := namer.NewLayeredNamer(
+		namer.ObjectLocationMissing,
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+		namer.WithKeyPrefix("/p"),
+	)
+	require.NoError(t, err)
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/p/alice", keys[0].Build())
+	assert.Equal(t, "/p/hashes/sha256/alice", keys[1].Build())
+
+	for _, key := range keys {
+		parsed, perr := layeredN.ParseKey(key.Build())
+		require.NoError(t, perr, "ParseKey(%q)", key.Build())
+		assert.Equal(t, key.Build(), parsed.Build())
+	}
+}
+
+func TestLayeredNamer_WithKeyPrefix_Legacy(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p", namer.LegacyHashSigLayout())
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/p/objects/alice", keys[0].Build())
+	assert.Equal(t, "/p/hashes/sha256/alice", keys[1].Build())
+	assert.Equal(t, "/p/sig/ed25519/alice", keys[2].Build())
+}
+
+func TestLayeredNamer_WithKeyPrefix_Compact(t *testing.T) {
+	t.Parallel()
+
+	layeredN, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		[]namer.LayeredSigLocation{{SignerName: "ed25519", Location: "ed25519"}},
+		namer.WithKeyPrefix("/p"),
+		namer.CompactSingleHash(),
+		namer.CompactSingleSig(),
+	)
+	require.NoError(t, err)
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/p/objects/alice", keys[0].Build())
+	assert.Equal(t, "/p/hashes/objects/alice", keys[1].Build())
+	assert.Equal(t, "/p/sig/objects/alice", keys[2].Build())
+
+	for _, key := range keys {
+		parsed, perr := layeredN.ParseKey(key.Build())
+		require.NoError(t, perr, "ParseKey(%q)", key.Build())
+		assert.Equal(t, key.Build(), parsed.Build())
+		assert.Equal(t, key.Type(), parsed.Type())
+	}
+}
+
+func TestLayeredNamer_WithKeyPrefix_EmptyIsNoop(t *testing.T) {
+	t.Parallel()
+
+	withEmpty, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+		namer.WithKeyPrefix(""),
+	)
+	require.NoError(t, err)
+
+	without, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{{HasherName: "sha256", Location: "sha256"}},
+		nil,
+	)
+	require.NoError(t, err)
+
+	keysA, err := withEmpty.GenerateNames("alice")
+	require.NoError(t, err)
+
+	keysB, err := without.GenerateNames("alice")
+	require.NoError(t, err)
+
+	require.Len(t, keysA, len(keysB))
+
+	for i := range keysA {
+		assert.Equal(t, keysB[i].Build(), keysA[i].Build())
+	}
+}
+
+// TestLayeredNamer_WithKeyPrefix_ParseKey_SiblingPrefixRejected guards against
+// a subtle confused-prefix bug: prefix "/p" must not falsely match keys under
+// a sibling prefix such as "/pp/..." just because "/p" is a string prefix of
+// "/pp". The check must require the configured prefix to be followed by '/'
+// (or the end of the key).
+func TestLayeredNamer_WithKeyPrefix_ParseKey_SiblingPrefixRejected(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p")
+
+	cases := []string{
+		"/pp/objects/alice",
+		"/p2/objects/alice",
+		"/papa/objects/alice",
+	}
+
+	for _, raw := range cases {
+		_, err := layeredN.ParseKey(raw)
+		require.ErrorIs(t, err, namer.ErrKeyPrefixMissing, "ParseKey(%q)", raw)
+	}
+}
+
+// TestLayeredNamer_WithKeyPrefix_OverlapsObjectLocation checks that a keyPrefix
+// textually overlapping the objectLocation does not corrupt the residual
+// ParseKey validates: the prefix is stripped up to a '/' boundary, so the
+// following objectLocation segment is matched independently and the round-trip
+// stays exact.
+func TestLayeredNamer_WithKeyPrefix_OverlapsObjectLocation(t *testing.T) {
+	t.Parallel()
+
+	prefixes := []string{
+		"/objects",         // prefix equals the objectLocation.
+		"/a/objects/b",     // prefix contains objectLocation as an interior segment.
+		"/objects/objects", // repeated objectLocation segments.
+	}
+
+	for _, prefix := range prefixes {
+		t.Run(prefix, func(t *testing.T) {
+			t.Parallel()
+
+			layeredN := newPrefixedLayeredNamer(t, prefix)
+
+			keys, err := layeredN.GenerateNames("alice")
+			require.NoError(t, err)
+			require.Len(t, keys, 3)
+
+			assert.Equal(t, prefix+"/objects/alice", keys[0].Build())
+
+			for _, key := range keys {
+				parsed, perr := layeredN.ParseKey(key.Build())
+				require.NoError(t, perr, "ParseKey(%q)", key.Build())
+				assert.Equal(t, "alice", parsed.Name(), "name for %q", key.Build())
+				assert.Equal(t, key.Type(), parsed.Type())
+				assert.Equal(t, key.Property(), parsed.Property())
+				assert.Equal(t, key.Build(), parsed.Build())
+			}
+		})
+	}
+}
+
+func TestLayeredNamer_WithKeyPrefix_MultipleHashersAndSigners(t *testing.T) {
+	t.Parallel()
+
+	layeredN, err := namer.NewLayeredNamer(
+		"objects",
+		[]namer.LayeredHashLocation{
+			{HasherName: "sha256", Location: "sha256"},
+			{HasherName: "blake3", Location: "blake3"},
+		},
+		[]namer.LayeredSigLocation{
+			{SignerName: "ed25519", Location: "ed25519"},
+			{SignerName: "rsa", Location: "rsa"},
+		},
+		namer.WithKeyPrefix("/p"),
+	)
+	require.NoError(t, err)
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+	require.Len(t, keys, 5)
+
+	expected := []string{
+		"/p/objects/alice",
+		"/p/hashes/sha256/objects/alice",
+		"/p/hashes/blake3/objects/alice",
+		"/p/sig/ed25519/objects/alice",
+		"/p/sig/rsa/objects/alice",
+	}
+	for i, want := range expected {
+		assert.Equal(t, want, keys[i].Build(), "key[%d].Build()", i)
+	}
+
+	for _, key := range keys {
+		parsed, perr := layeredN.ParseKey(key.Build())
+		require.NoError(t, perr, "ParseKey(%q)", key.Build())
+		assert.Equal(t, key.Build(), parsed.Build())
+		assert.Equal(t, key.Type(), parsed.Type())
+		assert.Equal(t, key.Property(), parsed.Property())
+	}
+}
+
+func TestLayeredNamer_WithKeyPrefix_ParseKeys_GroupsByName(t *testing.T) {
+	t.Parallel()
+
+	layeredN := newPrefixedLayeredNamer(t, "/p")
+
+	keys, err := layeredN.GenerateNames("alice")
+	require.NoError(t, err)
+
+	raws := make([]string, len(keys))
+	for i, key := range keys {
+		raws[i] = key.Build()
+	}
+
+	results, err := layeredN.ParseKeys(raws, false)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, results.Len())
+
+	got, ok := results.Select("alice")
+	require.True(t, ok)
+	assert.Len(t, got, 3)
+}


### PR DESCRIPTION
Add WithKeyPrefix option to namer.LayeredNamer and thread it through integrity.CodecBuilder so codecs can be built with a fixed path prefix prepended to every emitted/parsed key.

- Let two codecs sit in disjoint sub-trees of one storage.Storage so they can be committed atomically in a single integrity.Tx, which cannot span multiple storage handles the way storage.Prefixed wrappers can.
- Validate the prefix the same way storage.Prefixed does: must start with '/', must not end with '/'; empty is a no-op.
- Return namer.ErrKeyPrefixNoLeadingSlash / ErrKeyPrefixTrailingSlash on malformed input, and namer.ErrKeyPrefixMissing from ParseKey when the raw key does not start with the configured prefix.
- Add namer and integrity tests covering the new layout.