### PR TITLE
integrity: add ValueKey/FullKeys with prefix-aware Store accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `CodecNamerConstructor`.
 - `locker.Do(ctx, f, name, fn, opts...)`: helper that creates a Locker via the supplied `Factory`, acquires it, runs `fn` while the lock is held, and releases the lock on return. `fn`'s error leads any joined Unlock error so `errors.Is` against domain errors works without peeling off lock-machinery wrappers; Unlock always runs after `fn` regardless of `fn`'s result.
 - `locker.Prefixed(prefix, inner)`: Factory-level name-scoping helper that concatenates `prefix` to every caller-supplied lock name before delegating to `inner`, mirroring `storage.Prefixed`'s rewrite convention. Lets a component receive a name-scoped `locker.Factory` without seeing the full `Storage`; an empty prefix is a transparent passthrough, and a non-empty prefix must start with `/` (`ErrPrefixNoLeadingSlash`) and not end with `/` (`ErrPrefixTrailingSlash`).
+- integrity.Codec: `ValueKey(name)` returns the namer-relative value-layer
+  key; `FullKeys(name)` returns every key the codec's namer would emit
+  (value + hashes + signatures), in namer-emitted order. Both reject
+  empty, leading-slash, and trailing-slash names with `ErrInvalidName`,
+  matching the rule applied by `Put`/`Delete`/`Get`/`Watch`.
+- integrity.Store: `ValueKey(name)` and `FullKeys(name)` mirror the codec
+  methods but return on-disk keys — when the storage is wrapped with
+  `storage.Prefixed`, the wrapper's prefix is prepended.
+- integrity.SingletonStore: no-arg `ValueKey()` and `FullKeys()` delegate
+  to the inner `Store` with the bound name.
+- storage.Prefixer: optional interface implemented by `Prefixed` storages
+  to expose their key prefix. `storage.StoragePrefix(s)` returns the
+  prefix or `nil` for storages that are not wrapped.
 
 ### Changed
 
@@ -31,6 +44,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `locker.Factory` and `Storage.LockerFactory()`: a lightweight "create a lock" surface for components that do not need the full `Storage` interface. `Prefixed` implements it so factory-issued lockers keep the prefix-rewrite path that scopes lock names under the wrapper's namespace. **Breaking change:** `locker.Factory` is now an interface with a `NewLocker(ctx, name, opts...) (Locker, error)` method instead of a function type. `Storage` and the `Prefixed` wrapper already satisfy it via their `NewLocker` method; adapt a bare function with the new `locker.FactoryFunc` (mirrors `http.HandlerFunc`). `locker.Prefixed` composition is now flattened at construction and is outer-first — `locker.Prefixed("/a", locker.Prefixed("/b", inner))` is equivalent to `locker.Prefixed("/a/b", inner)`, matching `storage.Prefixed`.
 
 ### Fixed
+
+- integrity.Codec.BindPredicate now rejects empty, leading-slash, and
+  trailing-slash names with `ErrInvalidName`, matching `Put`/`Delete`/
+  `Get`/`Watch`. Without it, a leading slash was silently stripped by
+  the namer and aliased `"/foo"` to `"foo"`, letting a predicate match
+  a row no sibling call could see.
 
 ## [v1.5.0] - 2026-05-15
 

--- a/integrity/codec.go
+++ b/integrity/codec.go
@@ -452,6 +452,63 @@ func (b CodecBuilder[T]) Build() (*Codec[T], error) {
 	}, nil
 }
 
+// ValueKey returns the value-layer key for name as produced by the codec's
+// namer — e.g. "/objects/<name>" for a codec built with
+// WithObjectLocation("objects"), or "/<name>" for an unnamed codec.
+//
+// The returned key is namer-relative: it does NOT include any prefix added
+// by a [storage.Prefixed] wrapper — for the on-disk key, use
+// [Store.ValueKey]. Hash and signature keys are not included; use
+// [Codec.FullKeys] for those.
+//
+// Returns ErrInvalidName for empty, leading-slash, or trailing-slash names,
+// and ErrNoValueKey if the namer emits no value-layer key.
+func (c *Codec[T]) ValueKey(name string) (string, error) {
+	if !checkName(name) {
+		return "", ErrInvalidName
+	}
+
+	keys, err := c.namer.GenerateNames(name)
+	if err != nil {
+		return "", fmt.Errorf("generate names: %w", err)
+	}
+
+	for _, key := range keys {
+		if key.Type() == namer.KeyTypeValue {
+			return key.Build(), nil
+		}
+	}
+
+	return "", ErrNoValueKey
+}
+
+// FullKeys returns every key the codec's namer would emit for name — the
+// value-layer key plus one key per configured hash and signature layer.
+// The order matches [namer.Namer.GenerateNames]: value first, then hashes,
+// then signatures.
+//
+// Returned keys are namer-relative — use [Store.FullKeys] for keys that
+// include any [storage.Prefixed] wrapper's prefix.
+//
+// Returns ErrInvalidName for empty, leading-slash, or trailing-slash names.
+func (c *Codec[T]) FullKeys(name string) ([]string, error) {
+	if !checkName(name) {
+		return nil, ErrInvalidName
+	}
+
+	keys, err := c.namer.GenerateNames(name)
+	if err != nil {
+		return nil, fmt.Errorf("generate names: %w", err)
+	}
+
+	out := make([]string, len(keys))
+	for i, key := range keys {
+		out[i] = key.Build()
+	}
+
+	return out, nil
+}
+
 // Bind creates a new Store[T] by binding c to the given storage. Bind is a
 // cheap struct literal — no caching, no validation.
 func (c *Codec[T]) Bind(s storage.Storage) *Store[T] {

--- a/integrity/codec_test.go
+++ b/integrity/codec_test.go
@@ -3,6 +3,7 @@ package integrity_test
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
 	"strings"
 	"testing"
 
@@ -540,4 +541,288 @@ func TestCodecBuilder_MultipleBuildCalls(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.NotSame(t, codec1, codec2, "each Build call should return a distinct *Codec[T]")
+}
+
+func TestCodec_ValueKey_NamedLocation(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("foo")
+	require.NoError(t, err)
+	assert.Equal(t, "/objects/foo", key)
+}
+
+func TestCodec_ValueKey_UnnamedDefault(t *testing.T) {
+	t.Parallel()
+
+	// No WithObjectLocation — codec is in unnamed mode (no per-codec segment).
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("foo")
+	require.NoError(t, err)
+	assert.Equal(t, "/foo", key)
+}
+
+func TestCodec_ValueKey_MultiSegmentLocation(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("settings/ldap").
+		Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("entry-1")
+	require.NoError(t, err)
+	assert.Equal(t, "/settings/ldap/entry-1", key)
+}
+
+func TestCodec_ValueKey_IgnoresHashAndSigLayers(t *testing.T) {
+	t.Parallel()
+
+	// Adding hashers/signers must not change the value-layer key: ValueKey
+	// is documented to return only the value layer, even when other layers
+	// are present.
+	signerVerifier := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithSignerVerifier(signerVerifier).
+		Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("foo")
+	require.NoError(t, err)
+	assert.Equal(t, "/objects/foo", key, "ValueKey must return only the value-layer key")
+	assert.NotContains(t, key, "/hash/")
+	assert.NotContains(t, key, "/sig/")
+}
+
+func TestCodec_ValueKey_RespectsLocationOverrides(t *testing.T) {
+	t.Parallel()
+
+	// Hash/sig location overrides affect the hash/sig layers only — the
+	// value-layer key must remain /<objectLocation>/<name>.
+	signerVerifier := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithHashLocation("sha256", "checksums").
+		WithSignerVerifier(signerVerifier).
+		WithSignatureLocation(signerVerifier.Name(), "sigs").
+		Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("foo")
+	require.NoError(t, err)
+	assert.Equal(t, "/objects/foo", key)
+}
+
+func TestCodec_ValueKey_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
+	require.NoError(t, err)
+
+	cases := []struct {
+		label string
+		name  string
+	}{
+		{"empty", ""},
+		{"leading slash", "/foo"},
+		{"trailing slash", "foo/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := codec.ValueKey(tc.name)
+			require.Error(t, err)
+			require.ErrorIs(t, err, integrity.ErrInvalidName)
+			assert.Empty(t, key)
+		})
+	}
+}
+
+func TestCodec_ValueKey_RoundTripsThroughNamer(t *testing.T) {
+	t.Parallel()
+
+	// ValueKey must produce a key that the codec's own (reproducible) namer
+	// can parse back to the original name with type=value.
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("alpha-beta")
+	require.NoError(t, err)
+
+	reproNamer, err := namer.NewLayeredNamer("objects", nil, nil)
+	require.NoError(t, err)
+
+	parsed, err := reproNamer.ParseKey(key)
+	require.NoError(t, err)
+	assert.Equal(t, namer.KeyTypeValue, parsed.Type())
+	assert.Equal(t, "alpha-beta", parsed.Name())
+}
+
+// fullKeyNoValueNamer always emits a hash-only key set, so ValueKey has no
+// value layer to return and must surface ErrNoValueKey. Reuses the
+// sentinelNamer plumbing but overrides GenerateNames to drop the value key.
+type fullKeyNoValueNamer struct{ sentinelNamer }
+
+func (n *fullKeyNoValueNamer) GenerateNames(name string) ([]namer.Key, error) {
+	return []namer.Key{
+		namer.NewDefaultKey(name, namer.KeyTypeHash, "sha256", "/hash/sha256/"+name),
+	}, nil
+}
+
+func TestCodec_ValueKey_NoValueKey(t *testing.T) {
+	t.Parallel()
+
+	customConstructor := integrity.CodecNamerConstructor(func(
+		_ string,
+		_ []namer.LayeredHashLocation,
+		_ []namer.LayeredSigLocation,
+		_ ...namer.LayeredOption,
+	) (namer.Namer, error) {
+		return &fullKeyNoValueNamer{sentinelNamer: sentinelNamer{called: false}}, nil
+	})
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		WithNamer(customConstructor).
+		Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("foo")
+	require.Error(t, err)
+	require.ErrorIs(t, err, integrity.ErrNoValueKey)
+	assert.Empty(t, key)
+}
+
+// fullKeyErrNamer fails GenerateNames so ValueKey can surface the wrapped
+// namer error path.
+type fullKeyErrNamer struct{ sentinelNamer }
+
+func (n *fullKeyErrNamer) GenerateNames(_ string) ([]namer.Key, error) {
+	return nil, errSentinelNamerFailure
+}
+
+var errSentinelNamerFailure = errors.New("sentinel namer failure")
+
+func TestCodec_ValueKey_NamerError(t *testing.T) {
+	t.Parallel()
+
+	customConstructor := integrity.CodecNamerConstructor(func(
+		_ string,
+		_ []namer.LayeredHashLocation,
+		_ []namer.LayeredSigLocation,
+		_ ...namer.LayeredOption,
+	) (namer.Namer, error) {
+		return &fullKeyErrNamer{sentinelNamer: sentinelNamer{called: false}}, nil
+	})
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		WithNamer(customConstructor).
+		Build()
+	require.NoError(t, err)
+
+	key, err := codec.ValueKey("foo")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSentinelNamerFailure)
+	assert.Empty(t, key)
+}
+
+func TestCodec_FullKeys_ValueOnly(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		Build()
+	require.NoError(t, err)
+
+	keys, err := codec.FullKeys("foo")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/objects/foo"}, keys)
+}
+
+func TestCodec_FullKeys_ValueHashSig(t *testing.T) {
+	t.Parallel()
+
+	// Adding a hasher and a signer expands the key set to three layers,
+	// in namer-emitted order: value, hash, signature.
+	signerVerifier := newTestRSAPSS(t)
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		WithHasher(hasher.NewSHA256Hasher()).
+		WithSignerVerifier(signerVerifier).
+		Build()
+	require.NoError(t, err)
+
+	keys, err := codec.FullKeys("foo")
+	require.NoError(t, err)
+	require.Len(t, keys, 3)
+	assert.Equal(t, "/objects/foo", keys[0], "value layer first")
+	assert.Contains(t, keys[1], "/foo", "hash layer carries the object name")
+	assert.Contains(t, keys[2], "/foo", "signature layer carries the object name")
+	assert.NotEqual(t, keys[0], keys[1])
+	assert.NotEqual(t, keys[0], keys[2])
+	assert.NotEqual(t, keys[1], keys[2])
+}
+
+func TestCodec_FullKeys_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().WithObjectLocation("objects").Build()
+	require.NoError(t, err)
+
+	for _, testCase := range []struct {
+		label string
+		name  string
+	}{
+		{"empty", ""},
+		{"leading slash", "/foo"},
+		{"trailing slash", "foo/"},
+	} {
+		t.Run(testCase.label, func(t *testing.T) {
+			t.Parallel()
+
+			keys, err := codec.FullKeys(testCase.name)
+			require.ErrorIs(t, err, integrity.ErrInvalidName)
+			assert.Nil(t, keys)
+		})
+	}
+}
+
+func TestCodec_FullKeys_NamerError(t *testing.T) {
+	t.Parallel()
+
+	customConstructor := integrity.CodecNamerConstructor(func(
+		_ string,
+		_ []namer.LayeredHashLocation,
+		_ []namer.LayeredSigLocation,
+		_ ...namer.LayeredOption,
+	) (namer.Namer, error) {
+		return &fullKeyErrNamer{sentinelNamer: sentinelNamer{called: false}}, nil
+	})
+
+	codec, err := integrity.NewCodecBuilder[codecTestStruct]().
+		WithObjectLocation("objects").
+		WithNamer(customConstructor).
+		Build()
+	require.NoError(t, err)
+
+	keys, err := codec.FullKeys("foo")
+	require.ErrorIs(t, err, errSentinelNamerFailure)
+	assert.Nil(t, keys)
 }

--- a/integrity/store.go
+++ b/integrity/store.go
@@ -149,6 +149,45 @@ func (s *Store[T]) Watch(ctx context.Context, name string) (<-chan watch.Event, 
 	return s.storage.Watch(ctx, []byte(key)), nil
 }
 
+// ValueKey returns the on-disk value-layer key for name — the namer's
+// value key prefixed with the bound storage's prefix (if it is wrapped
+// with [storage.Prefixed]). See [Codec.ValueKey] for the namer-relative
+// form.
+func (s *Store[T]) ValueKey(name string) (string, error) {
+	key, err := s.codec.ValueKey(name)
+	if err != nil {
+		return "", err
+	}
+
+	if prefix := storage.StoragePrefix(s.storage); len(prefix) > 0 {
+		return string(prefix) + key, nil
+	}
+
+	return key, nil
+}
+
+// FullKeys returns every on-disk key the bound codec would produce for
+// name (value + hashes + signatures), each prefixed with the bound
+// storage's prefix if it is wrapped with [storage.Prefixed]. See
+// [Codec.FullKeys] for the namer-relative form.
+func (s *Store[T]) FullKeys(name string) ([]string, error) {
+	keys, err := s.codec.FullKeys(name)
+	if err != nil {
+		return nil, err
+	}
+
+	prefix := storage.StoragePrefix(s.storage)
+	if len(prefix) == 0 {
+		return keys, nil
+	}
+
+	for i, key := range keys {
+		keys[i] = string(prefix) + key
+	}
+
+	return keys, nil
+}
+
 func (s *Store[T]) bindPredicates(name string, preds []Predicate) ([]predicate.Predicate, error) {
 	boundPreds := make([]predicate.Predicate, 0, len(preds))
 

--- a/integrity/store_singleton.go
+++ b/integrity/store_singleton.go
@@ -88,3 +88,15 @@ func (s *SingletonStore[T]) TxDelete(
 func (s *SingletonStore[T]) BindPredicate(pred Predicate) (predicate.Predicate, error) {
 	return s.store.codec.BindPredicate(s.name, pred)
 }
+
+// ValueKey returns the on-disk value-layer key for the singleton's bound
+// name. See [Store.ValueKey].
+func (s *SingletonStore[T]) ValueKey() (string, error) {
+	return s.store.ValueKey(s.name)
+}
+
+// FullKeys returns every on-disk key the bound codec would produce for the
+// singleton (value + hashes + signatures). See [Store.FullKeys].
+func (s *SingletonStore[T]) FullKeys() ([]string, error) {
+	return s.store.FullKeys(s.name)
+}

--- a/integrity/store_singleton_test.go
+++ b/integrity/store_singleton_test.go
@@ -259,3 +259,51 @@ func TestSingletonStore_Watch(t *testing.T) {
 		t.Fatal("timed out waiting for watch event")
 	}
 }
+
+func TestSingletonStore_ValueKey(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	auth, err := codec.BindSingleton(storage.NewStorage(dummy.New()), "auth")
+	require.NoError(t, err)
+
+	key, err := auth.ValueKey()
+	require.NoError(t, err)
+	assert.Equal(t, "/settings/auth", key)
+}
+
+func TestSingletonStore_ValueKey_IncludesStoragePrefix(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	wrapped, err := storage.Prefixed("/scope", storage.NewStorage(dummy.New()))
+	require.NoError(t, err)
+
+	auth, err := codec.BindSingleton(wrapped, "auth")
+	require.NoError(t, err)
+
+	key, err := auth.ValueKey()
+	require.NoError(t, err)
+	assert.Equal(t, "/scope/settings/auth", key,
+		"SingletonStore.ValueKey must include the bound storage's prefix")
+}
+
+func TestSingletonStore_FullKeys(t *testing.T) {
+	t.Parallel()
+
+	codec, _ := newSingletonCodec(t)
+	wrapped, err := storage.Prefixed("/scope", storage.NewStorage(dummy.New()))
+	require.NoError(t, err)
+
+	auth, err := codec.BindSingleton(wrapped, "auth")
+	require.NoError(t, err)
+
+	keys, err := auth.FullKeys()
+	require.NoError(t, err)
+	require.Len(t, keys, 3, "value + sha256 hash + rsa-pss signature")
+
+	for _, k := range keys {
+		assert.True(t, len(k) > len("/scope") && k[:len("/scope")] == "/scope",
+			"every SingletonStore.FullKeys entry must start with /scope, got %q", k)
+	}
+}

--- a/integrity/store_test.go
+++ b/integrity/store_test.go
@@ -1879,3 +1879,151 @@ func TestStore_CrossCodec_AtomicCommit(t *testing.T) {
 
 // Compile-time check: dummy.New() used in newTestStorage (tx_test.go) is available.
 var _ = dummy.New
+
+func TestStore_ValueKey_IncludesPrefix(t *testing.T) {
+	t.Parallel()
+
+	// Store.ValueKey must include the storage's own prefix — it returns the
+	// on-disk key, in contrast to Codec.ValueKey which is namer-relative.
+	driverMock := mocks.NewDriverMock(t)
+	codec := newStoreCodec(t)
+	store := newMockedStore(t, codec, driverMock)
+
+	storeKey, err := store.ValueKey("foo")
+	require.NoError(t, err)
+
+	codecKey, err := codec.ValueKey("foo")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/objects/foo", codecKey,
+		"Codec.ValueKey stays namer-relative")
+	assert.Equal(t, storeTestPrefix+"/objects/foo", storeKey,
+		"Store.ValueKey must prepend the bound storage's prefix")
+}
+
+func TestStore_ValueKey_NoPrefix(t *testing.T) {
+	t.Parallel()
+
+	// Without a Prefixed wrapper, Store.ValueKey returns the namer-relative
+	// key — same shape as Codec.ValueKey.
+	driverMock := mocks.NewDriverMock(t)
+	codec := newStoreCodec(t)
+	store := codec.Bind(storage.NewStorage(driverMock))
+
+	key, err := store.ValueKey("foo")
+	require.NoError(t, err)
+	assert.Equal(t, "/objects/foo", key)
+}
+
+func TestStore_ValueKey_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	driverMock := mocks.NewDriverMock(t)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
+
+	cases := []struct {
+		label string
+		name  string
+	}{
+		{"empty", ""},
+		{"leading slash", "/foo"},
+		{"trailing slash", "foo/"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+
+			key, err := store.ValueKey(tc.name)
+			require.Error(t, err)
+			require.ErrorIs(t, err, integrity.ErrInvalidName)
+			assert.Empty(t, key)
+		})
+	}
+}
+
+// TestStore_ValueKey_MatchesWrittenKey is the integration-style check: the
+// key returned by ValueKey is byte-equal to the value-layer key the store
+// actually writes during Put — including the storage prefix.
+func TestStore_ValueKey_MatchesWrittenKey(t *testing.T) {
+	t.Parallel()
+
+	driverMock := mocks.NewDriverMock(t)
+	codec := newStoreCodec(t)
+	store := newMockedStore(t, codec, driverMock)
+
+	const name = "alpha"
+
+	valueKey, err := store.ValueKey(name)
+	require.NoError(t, err)
+
+	driverMock.ExecuteMock.Set(func(
+		_ context.Context,
+		_ []predicate.Predicate,
+		thenOps []operation.Operation,
+		_ []operation.Operation,
+	) (tx.Response, error) {
+		require.NotEmpty(t, thenOps)
+
+		var sawValueKey bool
+
+		for _, op := range thenOps {
+			// The driver mock sees absolute keys with the storage prefix
+			// prepended. Store.ValueKey now also returns the absolute key,
+			// so compare directly.
+			if op.Type() == operation.TypePut && string(op.Key()) == valueKey {
+				sawValueKey = true
+			}
+		}
+
+		assert.True(t, sawValueKey, "Put must write a value-layer key matching Store.ValueKey(name)")
+
+		return tx.Response{
+			Succeeded: true,
+			Results:   make([]tx.RequestResponse, len(thenOps)),
+		}, nil
+	})
+
+	err = store.Put(context.Background(), name, SimpleStruct{Name: "x", Value: 1})
+	require.NoError(t, err)
+}
+
+func TestStore_FullKeys_IncludesPrefix(t *testing.T) {
+	t.Parallel()
+
+	driverMock := mocks.NewDriverMock(t)
+	codec := newStoreCodecWithHasher(t, hasher.NewSHA256Hasher())
+	store := newMockedStore(t, codec, driverMock)
+
+	keys, err := store.FullKeys("foo")
+	require.NoError(t, err)
+	require.Len(t, keys, 2, "value + one hash layer")
+
+	for _, k := range keys {
+		assert.True(t, strings.HasPrefix(k, storeTestPrefix+"/"),
+			"every Store.FullKeys entry must start with the bound storage prefix, got %q", k)
+	}
+}
+
+func TestStore_FullKeys_NoPrefix(t *testing.T) {
+	t.Parallel()
+
+	driverMock := mocks.NewDriverMock(t)
+	codec := newStoreCodec(t)
+	store := codec.Bind(storage.NewStorage(driverMock))
+
+	keys, err := store.FullKeys("foo")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/objects/foo"}, keys)
+}
+
+func TestStore_FullKeys_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	driverMock := mocks.NewDriverMock(t)
+	store := newMockedStore(t, newStoreCodec(t), driverMock)
+
+	keys, err := store.FullKeys("")
+	require.ErrorIs(t, err, integrity.ErrInvalidName)
+	assert.Nil(t, keys)
+}

--- a/integrity/tx.go
+++ b/integrity/tx.go
@@ -475,7 +475,15 @@ func (c *Codec[T]) TxRange(
 
 // BindPredicate resolves the value-layer key for name and calls p with it,
 // returning the concrete predicate.Predicate ready for use in Tx.If.
+//
+// Returns ErrInvalidName for empty, leading-slash, or trailing-slash names
+// — the same rule applied by Put/Delete/Get/Watch — and ErrNoValueKey if
+// the namer emits no value-layer key.
 func (c *Codec[T]) BindPredicate(name string, pred Predicate) (predicate.Predicate, error) {
+	if !checkName(name) {
+		return nil, ErrInvalidName
+	}
+
 	keys, err := c.namer.GenerateNames(name)
 	if err != nil {
 		return nil, fmt.Errorf("generate names: %w", err)

--- a/integrity/tx_test.go
+++ b/integrity/tx_test.go
@@ -585,6 +585,33 @@ func TestBindPredicate_NoValueKey(t *testing.T) {
 	require.ErrorIs(t, err, integrity.ErrNoValueKey)
 }
 
+// TestBindPredicate_InvalidName guards parity with Put/Delete/Get/Watch —
+// a leading or trailing slash silently aliasing to the un-slashed key would
+// let a predicate match a row a sibling call never sees.
+func TestBindPredicate_InvalidName(t *testing.T) {
+	t.Parallel()
+
+	codec := newTestCodec(t)
+
+	for _, testCase := range []struct {
+		label string
+		name  string
+	}{
+		{"empty", ""},
+		{"leading slash", "/foo"},
+		{"trailing slash", "foo/"},
+	} {
+		t.Run(testCase.label, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := codec.BindPredicate(testCase.name, func(key []byte) predicate.Predicate {
+				return predicate.VersionEqual(key, 1)
+			})
+			require.ErrorIs(t, err, integrity.ErrInvalidName)
+		})
+	}
+}
+
 type hashOnlyNamer struct{}
 
 func (n *hashOnlyNamer) GenerateNames(name string) ([]namer.Key, error) {

--- a/prefix.go
+++ b/prefix.go
@@ -75,6 +75,33 @@ type prefixed struct {
 
 var _ Storage = (*prefixed)(nil)
 
+// Prefixer is implemented by storages that carry a key prefix applied by
+// [Prefixed]. The base storage does not implement it. Callers that want to
+// discover the prefix without depending on the unexported wrapper type
+// should use [StoragePrefix].
+type Prefixer interface {
+	Prefix() []byte
+}
+
+// Prefix returns a copy of the prefix this wrapper prepends to every key.
+func (p *prefixed) Prefix() []byte {
+	out := make([]byte, len(p.prefix))
+	copy(out, p.prefix)
+
+	return out
+}
+
+// StoragePrefix returns the prefix applied to s by [Prefixed], or nil if s
+// is not a [Prefixer]. Use it to reconstruct on-disk keys for storages that
+// may or may not be wrapped — e.g. printing a key for logs or external refs.
+func StoragePrefix(s Storage) []byte {
+	if p, ok := s.(Prefixer); ok {
+		return p.Prefix()
+	}
+
+	return nil
+}
+
 func (p *prefixed) Watch(ctx context.Context, key []byte, opts ...watch.Option) <-chan watch.Event {
 	absKey := concatKey(p.prefix, key)
 	innerCh := p.inner.Watch(ctx, absKey, opts...)


### PR DESCRIPTION
Codec.ValueKey returns the namer-relative value-layer key (renamed from the originally-proposed FullKey). Codec.FullKeys returns every key the namer would emit for the name — value plus one per hash and signature layer. Both validate name with the same rule as Put/Delete/Get/Watch (rejecting empty, leading-slash, trailing-slash names) and surface ErrInvalidName / ErrNoValueKey.

Store.ValueKey and Store.FullKeys mirror the codec methods but return on-disk keys: when the storage is wrapped with storage.Prefixed, the wrapper's prefix is prepended. Discovery uses a new storage.Prefixer interface implemented on *prefixed; storage.StoragePrefix walks the wrapper for callers that may or may not be in a Prefixed scope.

SingletonStore gains no-arg ValueKey and FullKeys delegating to the inner Store with the bound name.

Also tightens Codec.BindPredicate to reject the same invalid names — without it, a stray leading slash would silently equate "/foo" and "foo", letting a predicate match a row that no sibling call could see.