### PR TITLE
connect: fix etcd connection for non admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `Get`/`Watch`. Without it, a leading slash was silently stripped by
   the namer and aliased `"/foo"` to `"foo"`, letting a predicate match
   a row no sibling call could see.
+- connect.NewEtcdStorage failed if user has no admin permission.
 
 ## [v1.5.0] - 2026-05-15
 

--- a/connect/etcd.go
+++ b/connect/etcd.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -64,26 +63,24 @@ func createEtcdClient(ctx context.Context, cfg Config) (*etcdclient.Client, Clea
 		return nil, nil, fmt.Errorf("%w: %w", errFailedEtcdClient, clientErr)
 	}
 
-	probeErrs := make([]error, 0, len(endpoints))
+	statusCtx, statusCancel := context.WithTimeout(ctx, cfg.dialTimeout())
 
-	for _, endpoint := range endpoints {
-		statusCtx, statusCancel := context.WithTimeout(ctx, cfg.dialTimeout())
+	// MemberList is used as a connection probe: it validates reachability and
+	// (when auth is enabled) credentials, but does not require admin permission
+	// the way Maintenance.Status or Auth.AuthStatus do. WithSerializable avoids
+	// a raft round-trip since we only need to confirm the request reached a server.
+	_, statusErr := client.MemberList(statusCtx, etcdclient.WithSerializable())
 
-		_, statusErr := client.Status(statusCtx, endpoint)
+	statusCancel()
 
-		statusCancel()
-
-		if statusErr == nil {
-			return client, func() { _ = client.Close() }, nil
-		}
-
-		probeErrs = append(probeErrs, fmt.Errorf("%s: %w", endpoint, statusErr))
+	if statusErr == nil {
+		return client, func() { _ = client.Close() }, nil
 	}
 
 	_ = client.Close()
 
 	return nil, nil, fmt.Errorf("%w: failed to connect to %v: %w",
-		errFailedEtcdClient, endpoints, errors.Join(probeErrs...))
+		errFailedEtcdClient, endpoints, statusErr)
 }
 
 func validateSSLConfig(cfg SSLConfig) error {

--- a/connect/integration_test.go
+++ b/connect/integration_test.go
@@ -117,7 +117,13 @@ func createEtcdAuthTestConfig(t *testing.T) connect.Config {
 	_, err = client.UserAdd(ctx, "client", "secret")
 	require.NoError(t, err)
 
-	_, err = client.UserGrantRole(ctx, "client", "root")
+	_, err = client.Auth.RoleAdd(ctx, "client")
+	require.NoError(t, err)
+
+	_, err = client.Auth.RoleGrantPermission(ctx, "client", "/prefix/", etcdclient.GetPrefixRangeEnd("/prefix/"), etcdclient.PermissionType(etcdclient.PermReadWrite))
+	require.NoError(t, err)
+
+	_, err = client.Auth.UserGrantRole(ctx, "client", "client")
 	require.NoError(t, err)
 
 	_, err = client.AuthEnable(ctx)
@@ -443,6 +449,15 @@ func TestNewEtcdStorage_InvalidCredentials(t *testing.T) {
 	_, _, err := connect.NewEtcdStorage(ctx, cfg)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "authentication failed, invalid user ID or password")
+}
+
+func TestNewEtcdStorage_ValidCredentials(t *testing.T) {
+	cfg := createEtcdAuthTestConfig(t)
+
+	ctx := context.Background()
+
+	_, _, err := connect.NewEtcdStorage(ctx, cfg)
+	require.NoError(t, err)
 }
 
 func TestNewTCSStorage_CanceledContext(t *testing.T) {


### PR DESCRIPTION
NewEtcdStorage checked the cluster status through the Status function, which requires root permissions, see
https://github.com/etcd-io/etcd/pull/21666. Therefore, an additional check was added to ensure that the connection does not crash in the absence of root permissions.

Part of TNTP-7780