### PR TITLE
hasher: accept nil and empty input as the empty-string digest

### DIFF
--- a/crypto/rsapss_test.go
+++ b/crypto/rsapss_test.go
@@ -98,6 +98,94 @@ func TestRsaSignVerify(t *testing.T) {
 	require.NoError(t, err, "Verify must be successful")
 }
 
+// TestRsaSign_EmptyData_NoExplosion pins that Sign tolerates empty/nil input —
+// before the hasher fix it surfaced "failed to get hash: data is nil" because
+// Sign calls Hash internally over the payload bytes.
+func TestRsaSign_EmptyData_NoExplosion(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signer := crypto.NewRSAPSSSignerVerifier(*privateKey)
+
+	for _, data := range [][]byte{nil, {}} {
+		sig, err := signer.Sign(data)
+		require.NoError(t, err)
+		require.NotEmpty(t, sig)
+	}
+}
+
+// TestRsaVerify_EmptyData_NoExplosion mirrors the Sign-side check: Verify must
+// be able to recompute the digest over an empty/nil payload without erroring
+// out at the hash step.
+func TestRsaVerify_EmptyData_NoExplosion(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+
+	sig, err := signerVerifier.Sign(nil)
+	require.NoError(t, err)
+
+	for _, data := range [][]byte{nil, {}} {
+		require.NoError(t, signerVerifier.Verify(data, sig))
+	}
+}
+
+// TestRsaVerify_EmptySignature pins that Verify rejects an empty or nil
+// signature with a clean error rather than panicking. RSA-PSS signatures over
+// 2048-bit keys are 256 bytes wide; an empty/nil blob is structurally invalid
+// and must surface as a verification failure, not a crash.
+func TestRsaVerify_EmptySignature(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+
+	for _, sig := range [][]byte{nil, {}} {
+		err := signerVerifier.Verify([]byte("payload"), sig)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to verify")
+	}
+}
+
+// TestRsaSignVerify_EmptyData pins that Sign/Verify accept empty/nil payloads.
+// Storage backends commonly round-trip empty values as nil, so a verifier that
+// rejected nil input would fail to validate a legitimately-empty stored value.
+func TestRsaSignVerify_EmptyData(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+
+	for _, data := range [][]byte{nil, {}} {
+		sig, err := signerVerifier.Sign(data)
+		require.NoError(t, err, "Sign must accept empty/nil input")
+		require.NotNil(t, sig, "signature must be returned")
+
+		// Verifying against the matching empty/nil input must succeed.
+		require.NoError(t, signerVerifier.Verify(data, sig))
+
+		// Verifying against the other empty representation must also succeed:
+		// nil and []byte{} hash to the same digest, so signatures are
+		// interchangeable across the two.
+		other := []byte{}
+		if data != nil {
+			other = nil
+		}
+
+		require.NoError(t, signerVerifier.Verify(other, sig),
+			"nil and []byte{} must produce interchangeable signatures")
+	}
+}
+
 func TestRSAPSS_Name(t *testing.T) {
 	t.Parallel()
 

--- a/driver/etcd/locker_test.go
+++ b/driver/etcd/locker_test.go
@@ -22,6 +22,12 @@ const (
 	// lockerTestTimeout is generous to absorb -race + slow CI overhead on
 	// etcd lease/raft round-trips. It is used both as per-test outer
 	// deadline and as the internal time.After bound for cross-locker waits.
+	//
+	// The outer ctx is started AFTER createTestDriverConcrete so the budget
+	// covers only the actual locker operations, not the embedded etcd
+	// cluster bootstrap — which can take >20s on slow CI runners and would
+	// otherwise eat the whole budget, leaving Unlock to fail at
+	// session.Close→Revoke with "context deadline exceeded".
 	lockerTestTimeout = 30 * time.Second
 )
 
@@ -75,10 +81,10 @@ func createSecondClient(t *testing.T, endpoints []string) *etcdclient.Client {
 }
 
 func TestLocker_AcquireRelease(t *testing.T) {
+	driver, _ := createTestDriverConcrete(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driver, _ := createTestDriverConcrete(t)
 
 	lock, err := driver.NewLocker(ctx, testLockName(t))
 	require.NoError(t, err)
@@ -94,10 +100,10 @@ func TestLocker_AcquireRelease(t *testing.T) {
 }
 
 func TestLocker_ReLock_IsNoOp(t *testing.T) {
+	driver, _ := createTestDriverConcrete(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driver, _ := createTestDriverConcrete(t)
 
 	lock, err := driver.NewLocker(ctx, testLockName(t))
 	require.NoError(t, err)
@@ -108,10 +114,10 @@ func TestLocker_ReLock_IsNoOp(t *testing.T) {
 }
 
 func TestLocker_Unlock_NeverLocked(t *testing.T) {
+	driver, _ := createTestDriverConcrete(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driver, _ := createTestDriverConcrete(t)
 
 	lock, err := driver.NewLocker(ctx, testLockName(t))
 	require.NoError(t, err)
@@ -121,10 +127,10 @@ func TestLocker_Unlock_NeverLocked(t *testing.T) {
 }
 
 func TestLocker_DoubleUnlock(t *testing.T) {
+	driver, _ := createTestDriverConcrete(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driver, _ := createTestDriverConcrete(t)
 
 	lock, err := driver.NewLocker(ctx, testLockName(t))
 	require.NoError(t, err)
@@ -137,16 +143,16 @@ func TestLocker_DoubleUnlock(t *testing.T) {
 }
 
 func TestLocker_Contention(t *testing.T) {
+	driverA, clientA := createTestDriverConcrete(t)
+	endpoints := clientA.Endpoints()
+	clientB := createSecondClient(t, endpoints)
+	driverB := etcddriver.New(clientB)
+
 	// Outer timeout is generous (3x per-op timeout) because the test does
 	// several Lock/Unlock round-trips and an internal time.After wait of
 	// lockerTestTimeout. The point is only to prevent infinite hangs.
 	ctx, cancel := context.WithTimeout(t.Context(), 3*lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driverA, clientA := createTestDriverConcrete(t)
-	endpoints := clientA.Endpoints()
-	clientB := createSecondClient(t, endpoints)
-	driverB := etcddriver.New(clientB)
 
 	lockName := testLockName(t)
 
@@ -183,13 +189,13 @@ func TestLocker_Contention(t *testing.T) {
 }
 
 func TestLocker_TryLock_Contended(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
-	t.Cleanup(cancel)
-
 	driverA, clientA := createTestDriverConcrete(t)
 	endpoints := clientA.Endpoints()
 	clientB := createSecondClient(t, endpoints)
 	driverB := etcddriver.New(clientB)
+
+	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
+	t.Cleanup(cancel)
 
 	lockName := testLockName(t)
 
@@ -208,15 +214,15 @@ func TestLocker_TryLock_Contended(t *testing.T) {
 }
 
 func TestLocker_CtxCancellation_AbortsLock(t *testing.T) {
-	// 3x per-op timeout to cover several Lock/Unlock round-trips plus an
-	// internal time.After(lockerTestTimeout) wait for the C locker.
-	ctx, cancel := context.WithTimeout(t.Context(), 3*lockerTestTimeout)
-	t.Cleanup(cancel)
-
 	driverA, clientA := createTestDriverConcrete(t)
 	endpoints := clientA.Endpoints()
 	clientB := createSecondClient(t, endpoints)
 	driverB := etcddriver.New(clientB)
+
+	// 3x per-op timeout to cover several Lock/Unlock round-trips plus an
+	// internal time.After(lockerTestTimeout) wait for the C locker.
+	ctx, cancel := context.WithTimeout(t.Context(), 3*lockerTestTimeout)
+	t.Cleanup(cancel)
 
 	lockName := testLockName(t)
 
@@ -264,10 +270,10 @@ func TestLocker_CtxCancellation_AbortsLock(t *testing.T) {
 }
 
 func TestLocker_Done_NeverLocked_IsClosed(t *testing.T) {
+	driver, _ := createTestDriverConcrete(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driver, _ := createTestDriverConcrete(t)
 
 	lock, err := driver.NewLocker(ctx, testLockName(t))
 	require.NoError(t, err)
@@ -280,10 +286,10 @@ func TestLocker_Done_NeverLocked_IsClosed(t *testing.T) {
 }
 
 func TestLocker_Done_WhileHeld_IsOpen(t *testing.T) {
+	driver, _ := createTestDriverConcrete(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driver, _ := createTestDriverConcrete(t)
 
 	lock, err := driver.NewLocker(ctx, testLockName(t))
 	require.NoError(t, err)
@@ -299,10 +305,10 @@ func TestLocker_Done_WhileHeld_IsOpen(t *testing.T) {
 }
 
 func TestLocker_Done_ClosedAfterUnlock(t *testing.T) {
+	driver, _ := createTestDriverConcrete(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
-
-	driver, _ := createTestDriverConcrete(t)
 
 	lock, err := driver.NewLocker(ctx, testLockName(t))
 	require.NoError(t, err)

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -4,16 +4,17 @@ package hasher
 import (
 	"crypto/sha1" //nolint:gosec
 	"crypto/sha256"
-	"errors"
 	"fmt"
 	"hash"
 )
 
-// ErrDataIsNil is returned if the passed data is nil.
-var ErrDataIsNil = errors.New("data is nil")
-
 // Hasher is the interface that storage hashers must implement.
 // It provides low-level operations for hash calculating.
+//
+// Implementations must accept nil and zero-length input and return the
+// well-defined hash of the empty bit string for both. This matters because
+// storage backends round-trip empty values as nil, so a read of a
+// legitimately-empty value must hash without error.
 type Hasher interface {
 	Name() string
 	Hash(data []byte) ([]byte, error)
@@ -37,10 +38,6 @@ func (h *sha256Hasher) Name() string {
 
 // Hash implements Hasher interface.
 func (h *sha256Hasher) Hash(data []byte) ([]byte, error) {
-	if data == nil {
-		return nil, ErrDataIsNil
-	}
-
 	h.hash.Reset()
 
 	n, err := h.hash.Write(data)
@@ -69,10 +66,6 @@ func (h *sha1Hasher) Name() string {
 
 // Hash implements Hasher interface.
 func (h *sha1Hasher) Hash(data []byte) ([]byte, error) {
-	if data == nil {
-		return nil, ErrDataIsNil
-	}
-
 	h.hash.Reset()
 
 	n, err := h.hash.Write(data)

--- a/hasher/hasher_test.go
+++ b/hasher/hasher_test.go
@@ -5,9 +5,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/tarantool/go-storage/hasher"
 )
+
+// sha1EmptyHex is the hex-encoded SHA-1 of the empty bit string.
+const sha1EmptyHex = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+// sha256EmptyHex is the hex-encoded SHA-256 of the empty bit string.
+const sha256EmptyHex = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 func TestSHA1Hasher(t *testing.T) {
 	t.Parallel()
@@ -17,7 +24,8 @@ func TestSHA1Hasher(t *testing.T) {
 		in   []byte
 		out  string
 	}{
-		{"empty", []byte(""), "da39a3ee5e6b4b0d3255bfef95601890afd80709"},
+		{"nil", nil, sha1EmptyHex},
+		{"empty", []byte(""), sha1EmptyHex},
 		{"abc", []byte("abc"), "a9993e364706816aba3e25717850c26c9cd0d89d"},
 	}
 
@@ -27,35 +35,28 @@ func TestSHA1Hasher(t *testing.T) {
 
 			h := hasher.NewSHA1Hasher()
 
-			result, _ := h.Hash(test.in)
-
+			result, err := h.Hash(test.in)
+			require.NoError(t, err)
 			assert.Equal(t, test.out, hex.EncodeToString(result))
 		})
 	}
 }
 
-func TestSHA1Hasher_negative(t *testing.T) {
+// TestSHA1Hasher_NilEqualsEmpty pins the contract that nil and []byte{} are
+// indistinguishable inputs — storage backends round-trip empty values as nil,
+// so a divergence here would surface as spurious validation failures.
+func TestSHA1Hasher_NilEqualsEmpty(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name              string
-		in                []byte
-		expectedErrorText string
-	}{
-		{"nil", nil, "data is nil"},
-	}
+	h := hasher.NewSHA1Hasher()
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	hashNil, err := h.Hash(nil)
+	require.NoError(t, err)
 
-			h := hasher.NewSHA1Hasher()
+	hashEmpty, err := h.Hash([]byte{})
+	require.NoError(t, err)
 
-			_, err := h.Hash(test.in)
-
-			assert.Contains(t, err.Error(), test.expectedErrorText)
-		})
-	}
+	assert.Equal(t, hashEmpty, hashNil)
 }
 
 func TestSHA256Hasher(t *testing.T) {
@@ -66,7 +67,8 @@ func TestSHA256Hasher(t *testing.T) {
 		in       []byte
 		expected string
 	}{
-		{"empty", []byte(""), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		{"nil", nil, sha256EmptyHex},
+		{"empty", []byte(""), sha256EmptyHex},
 		{"abc", []byte("abc"), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
 	}
 
@@ -76,33 +78,26 @@ func TestSHA256Hasher(t *testing.T) {
 
 			h := hasher.NewSHA256Hasher()
 
-			result, _ := h.Hash(test.in)
-
+			result, err := h.Hash(test.in)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, hex.EncodeToString(result))
 		})
 	}
 }
 
-func TestSHA256Hasher_negative(t *testing.T) {
+// TestSHA256Hasher_NilEqualsEmpty pins the contract that nil and []byte{} are
+// indistinguishable inputs — storage backends round-trip empty values as nil,
+// so a divergence here would surface as spurious validation failures.
+func TestSHA256Hasher_NilEqualsEmpty(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name              string
-		in                []byte
-		expectedErrorText string
-	}{
-		{"nil", nil, "data is nil"},
-	}
+	h := hasher.NewSHA256Hasher()
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	hashNil, err := h.Hash(nil)
+	require.NoError(t, err)
 
-			h := hasher.NewSHA256Hasher()
+	hashEmpty, err := h.Hash([]byte{})
+	require.NoError(t, err)
 
-			_, err := h.Hash(test.in)
-
-			assert.Contains(t, err.Error(), test.expectedErrorText)
-		})
-	}
+	assert.Equal(t, hashEmpty, hashNil)
 }

--- a/integrity/integration_codec_tx_test.go
+++ b/integrity/integration_codec_tx_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tarantool/go-storage/driver"
 	"github.com/tarantool/go-storage/hasher"
 	"github.com/tarantool/go-storage/integrity"
+	"github.com/tarantool/go-storage/marshaller"
 )
 
 // integrationPrefix returns a per-test storage namespace so concurrent driver
@@ -580,5 +581,90 @@ func TestTxIntegration_AlreadyCommitted(t *testing.T) {
 
 		store := codec.Bind(base)
 		defer cleanupStore(t, store, "once")
+	})
+}
+
+// TestTxIntegration_EmptyValue_RoundTrip pins that an empty stored value is a
+// valid first-class value: writing []byte{} and reading it back must succeed
+// even with a hasher and signer/verifier configured, and without
+// IgnoreVerificationError.
+//
+// Storage backends round-trip empty values as nil, so prior to the hasher fix
+// validation panicked with "data is nil" when computing SHA-256 over the
+// read-back body, and the RSA-PSS verifier failed the same way.
+func TestTxIntegration_EmptyValue_RoundTrip(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		shaHash := hasher.NewSHA256Hasher()
+		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+
+		codec, err := integrity.NewCodecBuilder[[]byte]().
+			WithObjectLocation("objects").
+			WithMarshaller(marshaller.NewTypedBytesMarshaller()).
+			WithHasher(shaHash).
+			WithSignerVerifier(rsaSV).
+			Build()
+		require.NoError(t, err)
+
+		store := codec.Bind(base)
+		defer cleanupStore(t, store, "all1")
+
+		// Mirror of the reproducer: TxPut with []byte{}, TxGet without
+		// IgnoreVerificationError, then commit. The future must surface a
+		// successful result, not the hash/signature "data is nil" aggregate.
+		txn := integrity.NewTx(base)
+		require.NoError(t, codec.TxPut(txn.Then(), "all1", []byte{}))
+
+		fut := codec.TxGet(txn.Then(), "all1")
+
+		resp, err := txn.Commit(ctx)
+		require.NoError(t, err)
+		require.True(t, resp.Succeeded)
+
+		got, err := fut.Result()
+		require.NoError(t, err, "round-trip of empty value must succeed")
+		require.True(t, got.Value.IsSome())
+
+		val, _ := got.Value.Get()
+		assert.Empty(t, val)
+	})
+}
+
+// TestStoreIntegration_EmptyValue_GetPut covers the same empty-value
+// round-trip via the higher-level Store API (Put then Get), guarding both
+// entry points against future regressions.
+func TestStoreIntegration_EmptyValue_GetPut(t *testing.T) {
+	executeOnStorage(t, func(t *testing.T, driverInstance driver.Driver) {
+		t.Helper()
+
+		ctx := t.Context()
+		base := scopedStorage(t, driverInstance)
+
+		shaHash := hasher.NewSHA256Hasher()
+		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+
+		codec, err := integrity.NewCodecBuilder[[]byte]().
+			WithObjectLocation("objects").
+			WithMarshaller(marshaller.NewTypedBytesMarshaller()).
+			WithHasher(shaHash).
+			WithSignerVerifier(rsaSV).
+			Build()
+		require.NoError(t, err)
+
+		store := codec.Bind(base)
+		defer cleanupStore(t, store, "empty")
+
+		require.NoError(t, store.Put(ctx, "empty", []byte{}))
+
+		got, err := store.Get(ctx, "empty")
+		require.NoError(t, err)
+		require.True(t, got.Value.IsSome())
+
+		val, _ := got.Value.Get()
+		assert.Empty(t, val)
 	})
 }

--- a/integrity/validator_test.go
+++ b/integrity/validator_test.go
@@ -1,6 +1,8 @@
 package integrity_test
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"testing"
 
@@ -641,8 +643,11 @@ func TestValidatorValidate_MissingValueKey(t *testing.T) {
 	assert.Equal(t, "my-object", result.Name)
 	assert.True(t, result.Value.IsZero())
 	require.ErrorAs(t, result.Error, &integrity.ValidationError{})
-	// When there's no value key, the validator still tries to compute hashes on nil data.
-	require.ErrorContains(t, result.Error, "failed to calculate hash")
+	// With a missing value key the body is nil, which now hashes to the
+	// well-defined SHA-256 of the empty input — that does not match the
+	// "some-hash" placeholder, so the validator reports a hash mismatch
+	// rather than the prior "failed to calculate hash" / "data is nil".
+	require.ErrorContains(t, result.Error, "hash mismatch for \"sha256\"")
 }
 
 func TestValidatorValidate_UnmarshalError(t *testing.T) {
@@ -789,4 +794,138 @@ func TestValidatorValidate_SignatureKeyNotFound(t *testing.T) {
 	assert.Equal(t, SimpleStruct{Name: "test", Value: 42}, val)
 	require.ErrorAs(t, result.Error, &integrity.ValidationError{})
 	require.ErrorContains(t, result.Error, "signature \"ecdsa\" not verified (missing)")
+}
+
+// sha256OfEmpty is the SHA-256 digest of the empty bit string. Storage
+// backends round-trip empty values as nil; the hasher must produce this digest
+// for both nil and []byte{} so validation of an empty stored value succeeds.
+var sha256OfEmpty = []byte{ //nolint:gochecknoglobals
+	0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14,
+	0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f, 0xb9, 0x24,
+	0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c,
+	0xa4, 0x95, 0x99, 0x1b, 0x78, 0x52, 0xb8, 0x55,
+}
+
+// TestValidatorValidate_EmptyValue_NilBody pins that the validator computes
+// the hash over a nil body without erroring. Storage backends return nil for
+// stored empty values, and prior to the hasher fix this aggregated to "failed
+// to calculate hash 'sha256': data is nil".
+func TestValidatorValidate_EmptyValue_NilBody(t *testing.T) {
+	t.Parallel()
+
+	namerInstance := namer.NewDefaultNamer("test", []string{"sha256"}, nil)
+	marshallerInstance := marshaller.NewTypedBytesMarshaller()
+	hashers := []hasher.Hasher{hasher.NewSHA256Hasher()}
+
+	validator := integrity.NewValidator[[]byte](
+		namerInstance,
+		marshallerInstance,
+		hashers,
+		nil,
+	)
+
+	kvs := []kv.KeyValue{
+		{
+			Key:         []byte("/test/my-object"),
+			Value:       nil, // The shape a real driver returns for an empty stored value.
+			ModRevision: 0,
+		},
+		{
+			Key:         []byte("/test/hashes/sha256/my-object"),
+			Value:       sha256OfEmpty,
+			ModRevision: 0,
+		},
+	}
+
+	results, err := validator.Validate(kvs)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	result := results[0]
+	assert.Equal(t, "my-object", result.Name)
+	require.NoError(t, result.Error, "validator must not surface hash errors on empty body")
+	require.True(t, result.Value.IsSome())
+
+	val, _ := result.Value.Get()
+	assert.Empty(t, val)
+}
+
+// TestValidatorValidate_EmptyValue_EmptyBody is the []byte{} sibling of
+// TestValidatorValidate_EmptyValue_NilBody — some drivers return an empty
+// slice instead of nil, and both must validate cleanly against the same hash.
+func TestValidatorValidate_EmptyValue_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	namerInstance := namer.NewDefaultNamer("test", []string{"sha256"}, nil)
+	marshallerInstance := marshaller.NewTypedBytesMarshaller()
+	hashers := []hasher.Hasher{hasher.NewSHA256Hasher()}
+
+	validator := integrity.NewValidator[[]byte](
+		namerInstance,
+		marshallerInstance,
+		hashers,
+		nil,
+	)
+
+	kvs := []kv.KeyValue{
+		{
+			Key:         []byte("/test/my-object"),
+			Value:       []byte{},
+			ModRevision: 0,
+		},
+		{
+			Key:         []byte("/test/hashes/sha256/my-object"),
+			Value:       sha256OfEmpty,
+			ModRevision: 0,
+		},
+	}
+
+	results, err := validator.Validate(kvs)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	result := results[0]
+	require.NoError(t, result.Error)
+}
+
+// TestValidatorValidate_EmptyValue_WithVerifier covers the signature branch:
+// an empty stored body must verify cleanly against an RSA-PSS signature
+// computed over the same empty input. Mirrors the user-reported reproducer
+// where rsapss aggregated "failed to get hash: data is nil" alongside the
+// sha256 failure.
+func TestValidatorValidate_EmptyValue_WithVerifier(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+
+	sig, err := signerVerifier.Sign(nil)
+	require.NoError(t, err)
+
+	namerInstance := namer.NewDefaultNamer("test", []string{"sha256"}, []string{"rsapss"})
+	marshallerInstance := marshaller.NewTypedBytesMarshaller()
+	hashers := []hasher.Hasher{hasher.NewSHA256Hasher()}
+	verifiers := []crypto.Verifier{signerVerifier}
+
+	validator := integrity.NewValidator[[]byte](
+		namerInstance,
+		marshallerInstance,
+		hashers,
+		verifiers,
+	)
+
+	kvs := []kv.KeyValue{
+		{Key: []byte("/test/my-object"), Value: nil, ModRevision: 0},
+		{Key: []byte("/test/hashes/sha256/my-object"), Value: sha256OfEmpty, ModRevision: 0},
+		{Key: []byte("/test/sig/rsapss/my-object"), Value: sig, ModRevision: 0},
+	}
+
+	results, err := validator.Validate(kvs)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	require.NoError(t, results[0].Error,
+		"signature verification over an empty stored body must succeed")
 }


### PR DESCRIPTION
Storage backends round-trip empty stored values as nil, so a read of a legitimately-empty value reached the validator with body=nil and exploded at the SHA-256 hash check ("data is nil") and the RSA-PSS verifier check ("failed to get hash: data is nil"). The only workaround was `IgnoreVerificationError()`, which defeats the integrity layer.

Drop the `data == nil` guard from sha1/sha256 — `hash.Hash.Write(nil)` is well-defined, both `nil` and `[]byte{}` now produce the empty-input digest. `ErrDataIsNil` was internal-only; remove it.

Pin the contract at every layer: nil/empty parity in the hasher units, sign+verify acceptance plus empty-signature rejection in rsapss, direct empty-body validator coverage (value-only, value+hash, value+hash+sig), and a `TxPut([]byte{})` / `TxGet` round-trip mirroring the reproducer against every backend.