### PR TITLE
hasher,crypto: add hex-encoding decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- hasher, crypto: hex-encoding decorators that wrap an existing `Hasher` or
+  `SignerVerifier` so the stored payload is lower-case hex while `Name()` is
+  passed through unchanged, preserving the on-disk key layout. New
+  constructors: `hasher.NewHexHasher`, `hasher.NewHexSHA256Hasher`,
+  `hasher.NewHexSHA1Hasher`, `crypto.NewHexSignerVerifier`,
+  `crypto.NewHexVerifier`, `crypto.NewHexRSAPSSSignerVerifier`, and
+  `crypto.NewHexRSAPSSVerifier`. The raw constructors are unchanged (#114).
+
 ### Changed
 
 ### Fixed

--- a/crypto/hex.go
+++ b/crypto/hex.go
@@ -1,0 +1,92 @@
+package crypto
+
+import (
+	"crypto/rsa"
+	"encoding/hex"
+	"fmt"
+)
+
+// hexSignerVerifier decorates a SignerVerifier so that Sign emits a hex-encoded
+// signature and Verify accepts a hex-encoded one. Name is passed through
+// unchanged, so the on-disk key layout is preserved; only the stored signature
+// payload becomes hex.
+type hexSignerVerifier struct {
+	inner SignerVerifier
+}
+
+// hexVerifier decorates a Verifier so that Verify accepts a hex-encoded signature.
+type hexVerifier struct {
+	inner Verifier
+}
+
+// NewHexSignerVerifier wraps sv so that Sign emits a hex-encoded signature and
+// Verify accepts a hex-encoded one.
+func NewHexSignerVerifier(sv SignerVerifier) SignerVerifier {
+	return hexSignerVerifier{inner: sv}
+}
+
+// NewHexVerifier wraps v so that Verify accepts a hex-encoded signature.
+func NewHexVerifier(v Verifier) Verifier {
+	return hexVerifier{inner: v}
+}
+
+// NewHexRSAPSSSignerVerifier creates an RSA-PSS signer/verifier whose
+// signatures are hex-encoded.
+func NewHexRSAPSSSignerVerifier(privKey rsa.PrivateKey) SignerVerifier {
+	return NewHexSignerVerifier(NewRSAPSSSignerVerifier(privKey))
+}
+
+// NewHexRSAPSSVerifier creates an RSA-PSS verifier that accepts hex-encoded
+// signatures.
+func NewHexRSAPSSVerifier(pubKey rsa.PublicKey) Verifier {
+	return NewHexVerifier(NewRSAPSSVerifier(pubKey))
+}
+
+// Name implements Signer/Verifier interface.
+func (h hexSignerVerifier) Name() string {
+	return h.inner.Name()
+}
+
+// Sign implements Signer interface, returning the inner signature hex-encoded.
+func (h hexSignerVerifier) Sign(data []byte) ([]byte, error) {
+	sig, err := h.inner.Sign(data)
+	if err != nil {
+		return nil, fmt.Errorf("hex signer: %w", err)
+	}
+
+	dst := make([]byte, hex.EncodedLen(len(sig)))
+	hex.Encode(dst, sig)
+
+	return dst, nil
+}
+
+// Verify implements Verifier interface, decoding a hex signature before verifying.
+func (h hexSignerVerifier) Verify(data []byte, signature []byte) error {
+	return verifyHex(h.inner, data, signature)
+}
+
+// Name implements Verifier interface.
+func (h hexVerifier) Name() string {
+	return h.inner.Name()
+}
+
+// Verify implements Verifier interface, decoding a hex signature before verifying.
+func (h hexVerifier) Verify(data []byte, signature []byte) error {
+	return verifyHex(h.inner, data, signature)
+}
+
+func verifyHex(verifier Verifier, data []byte, signature []byte) error {
+	raw := make([]byte, hex.DecodedLen(len(signature)))
+
+	n, err := hex.Decode(raw, signature)
+	if err != nil {
+		return fmt.Errorf("failed to decode hex signature: %w", err)
+	}
+
+	err = verifier.Verify(data, raw[:n])
+	if err != nil {
+		return fmt.Errorf("hex verifier: %w", err)
+	}
+
+	return nil
+}

--- a/crypto/hex_test.go
+++ b/crypto/hex_test.go
@@ -1,0 +1,73 @@
+package crypto_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/crypto"
+)
+
+func TestHexSignerVerifierRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signerVerifier := crypto.NewHexRSAPSSSignerVerifier(*privateKey)
+	require.NotNil(t, signerVerifier)
+
+	data := []byte("abc")
+
+	sig, err := signerVerifier.Sign(data)
+	require.NoError(t, err)
+
+	// Signature is a valid hex string.
+	_, err = hex.DecodeString(string(sig))
+	require.NoError(t, err, "signature must be hex-encoded")
+
+	require.NoError(t, signerVerifier.Verify(data, sig))
+}
+
+func TestHexVerifierAcceptsHexSignature(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signer := crypto.NewHexRSAPSSSignerVerifier(*privateKey)
+	verifier := crypto.NewHexRSAPSSVerifier(privateKey.PublicKey)
+
+	data := []byte("payload")
+
+	sig, err := signer.Sign(data)
+	require.NoError(t, err)
+
+	require.NoError(t, verifier.Verify(data, sig))
+}
+
+func TestHexVerifierRejectsNonHex(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	verifier := crypto.NewHexRSAPSSVerifier(privateKey.PublicKey)
+
+	err = verifier.Verify([]byte("payload"), []byte("zz-not-hex"))
+	require.ErrorContains(t, err, "failed to decode hex signature")
+}
+
+func TestHexSignerVerifierName(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	// Name is passed through unchanged so the on-disk key layout is preserved.
+	require.Equal(t, "rsapss", crypto.NewHexRSAPSSSignerVerifier(*privateKey).Name())
+	require.Equal(t, "rsapss", crypto.NewHexRSAPSSVerifier(privateKey.PublicKey).Name())
+}

--- a/hasher/hex.go
+++ b/hasher/hex.go
@@ -1,0 +1,46 @@
+package hasher
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// hexHasher decorates a Hasher so that Hash returns a hex-encoded digest.
+// Name is passed through unchanged, so the on-disk key layout is preserved;
+// only the stored payload becomes hex.
+type hexHasher struct {
+	inner Hasher
+}
+
+// NewHexHasher wraps h so that Hash returns a lower-case hex-encoded digest.
+func NewHexHasher(h Hasher) Hasher {
+	return hexHasher{inner: h}
+}
+
+// NewHexSHA256Hasher creates a SHA-256 hasher whose Hash output is hex-encoded.
+func NewHexSHA256Hasher() Hasher {
+	return NewHexHasher(NewSHA256Hasher())
+}
+
+// NewHexSHA1Hasher creates a SHA-1 hasher whose Hash output is hex-encoded.
+func NewHexSHA1Hasher() Hasher {
+	return NewHexHasher(NewSHA1Hasher())
+}
+
+// Name implements Hasher interface.
+func (h hexHasher) Name() string {
+	return h.inner.Name()
+}
+
+// Hash implements Hasher interface, returning the inner digest hex-encoded.
+func (h hexHasher) Hash(data []byte) ([]byte, error) {
+	sum, err := h.inner.Hash(data)
+	if err != nil {
+		return nil, fmt.Errorf("hex hasher: %w", err)
+	}
+
+	dst := make([]byte, hex.EncodedLen(len(sum)))
+	hex.Encode(dst, sum)
+
+	return dst, nil
+}

--- a/hasher/hex_test.go
+++ b/hasher/hex_test.go
@@ -1,0 +1,55 @@
+package hasher_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/hasher"
+)
+
+func TestHexHasher(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []byte
+		out  string
+	}{
+		{"nil-input", nil, sha256EmptyHex},
+		{"empty-input", []byte(""), sha256EmptyHex},
+		{"abc-input", []byte("abc"), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := hasher.NewHexSHA256Hasher()
+
+			result, err := h.Hash(test.in)
+			require.NoError(t, err)
+
+			// Output is already the ASCII hex string of the digest.
+			assert.Equal(t, test.out, string(result))
+
+			// And it round-trips back to the raw digest of the inner hasher.
+			raw, err := hex.DecodeString(string(result))
+			require.NoError(t, err)
+
+			inner, err := hasher.NewSHA256Hasher().Hash(test.in)
+			require.NoError(t, err)
+			assert.Equal(t, inner, raw)
+		})
+	}
+}
+
+func TestHexHasherName(t *testing.T) {
+	t.Parallel()
+
+	// Name is passed through unchanged so the on-disk key layout is preserved.
+	assert.Equal(t, "sha256", hasher.NewHexSHA256Hasher().Name())
+	assert.Equal(t, "sha1", hasher.NewHexSHA1Hasher().Name())
+}


### PR DESCRIPTION
Add hex variants that wrap the existing Hasher and SignerVerifier so the stored payload is lower-case hex while Name() is passed through unchanged, preserving the on-disk key layout.

- hasher: NewHexHasher, NewHexSHA256Hasher, NewHexSHA1Hasher
- crypto: NewHexSignerVerifier, NewHexVerifier, NewHexRSAPSSSignerVerifier, NewHexRSAPSSVerifier

The raw constructors are kept. No production call site is switched: the only default use of NewSHA256Hasher is the digest computation inside RSAPSS, which must stay raw because rsa.SignPSS expects the bare digest.