### PR TITLE
hasher,crypto: hex output by default with opt-out (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- hasher, crypto: three encoding modes selected via `WithMode()` —
+  `ModeAuto` (default), `ModeHex` and `ModeBin`. All hasher/crypto constructors
+  (`NewSHA256Hasher`, `NewSHA1Hasher`, `NewRSAPSS`, `NewRSAPSSVerifier`) take
+  variadic options. `ModeAuto` produces raw bytes and, on verification, accepts
+  a stored digest/signature in either raw or lower-case hex form — the
+  migration-friendly read path. `ModeHex` produces and accepts only hex;
+  `ModeBin` produces and accepts only raw bytes.
+- hasher: `Hasher` interface gains `Verify(data, stored []byte) error`, which
+  reports whether a stored digest matches under the hasher's mode. The integrity
+  validator uses it so hash verification is encoding-aware.
+
 ### Changed
 
 - **BREAKING:** dropped the redundant `Layered` qualifier from the `namer`
@@ -36,6 +47,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **BREAKING:** dropped the unused `opts ...watch.Option` parameter from
   `storage.Storage.Watch` and `driver.Driver.Watch`. Prefix watches are still
   selected by ending the key with `/`.
+- **BREAKING:** the `hasher.Hasher` interface now requires a
+  `Verify(data, stored []byte) error` method; custom implementations must add
+  it. The built-in SHA-1/SHA-256 hashers implement it.
+- **BREAKING:** `crypto.NewRSAPSSSignerVerifier` is renamed to
+  `crypto.NewRSAPSS`.
 
 ### Removed
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -107,6 +107,10 @@ for the full list.
 * [watch.Event field rename](#watch-event)
 * [connect.NewStorage renamed](#connect-rename)
 * [Error handling](#error-handling)
+* [hasher/crypto: encoding modes](#encoding-modes)
+* [hasher.Hasher gains a Verify method](#hasher-verify)
+* [crypto.NewRSAPSSSignerVerifier renamed](#rsapss-rename)
+* [On-disk encoding of hashes and signatures](#on-disk-encoding)
 
 ### <a id="integrity-typed">integrity: Typed storage removed</a>
 
@@ -217,5 +221,80 @@ are unchanged.
 * `integrity.ErrInvalidName` is now a plain `errors.New` sentinel (the
   `integrity.InvalidNameError` type is removed). Match it with
   `errors.Is(err, integrity.ErrInvalidName)` as before.
+
+### <a id="encoding-modes">hasher/crypto: encoding modes</a>
+
+`hasher.Hasher` and the `crypto` RSA-PSS signer/verifier gained variadic
+options and an explicit encoding mode, selected with `WithMode()`:
+
+* `ModeAuto` (default) — produces **raw** bytes and, on verification, accepts a
+  stored digest/signature in **either raw or lower-case hex** form.
+* `ModeHex` — produces and accepts **only** lower-case hex.
+* `ModeBin` — produces and accepts **only** raw bytes.
+
+The default (`ModeAuto`) keeps the previous raw output, so writes are
+unchanged; the only new behaviour is that verification now also tolerates a hex
+encoding, which lets you migrate stored data to hex incrementally.
+
+```Go
+// Default: raw output, reads both raw and hex.
+h := hasher.NewSHA256Hasher()
+digest, _ := h.Hash(data) // 32 raw bytes, as before
+
+// Force hex everywhere.
+hexHasher := hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeHex))
+hexDigest, _ := hexHasher.Hash(data) // 64-char hex string
+
+// Force raw everywhere.
+binHasher := hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeBin))
+
+sv := crypto.NewRSAPSS(priv, crypto.WithMode(crypto.ModeHex)) // hex signatures
+v := crypto.NewRSAPSSVerifier(pub)                            // auto: accepts both
+```
+
+`Name()` is unchanged for both, so the on-disk key layout is preserved — only
+the stored payload encoding can change (see below). The digest fed internally to
+RSA-PSS is always raw, regardless of the mode.
+
+### <a id="hasher-verify">hasher.Hasher gains a Verify method</a>
+
+The `Hasher` interface now requires:
+
+```Go
+Verify(data, stored []byte) error
+```
+
+It reports whether `stored` is an accepted encoding of the digest of `data`
+under the hasher's mode (`nil` on match). The built-in SHA-1/SHA-256 hashers
+implement it; **custom `Hasher` implementations must add it**. The integrity
+validator now calls `Verify` instead of byte-comparing `Hash` output, so hash
+verification respects the mode (and `ModeAuto` accepts both encodings).
+
+### <a id="rsapss-rename">crypto.NewRSAPSSSignerVerifier renamed</a>
+
+`crypto.NewRSAPSSSignerVerifier` is renamed to `crypto.NewRSAPSS`. Both it and
+`crypto.NewRSAPSSVerifier` now take variadic options.
+
+```Go
+// Before:                                  // After:
+sv := crypto.NewRSAPSSSignerVerifier(priv)  sv := crypto.NewRSAPSS(priv)
+```
+
+### <a id="on-disk-encoding">On-disk encoding of hashes and signatures</a>
+
+With the default `ModeAuto`, an `integrity.Codec` built with the default hasher
+and signer/verifier still stores **raw** hashes and signatures, exactly as
+before — so data round-trips with older versions. Because `ModeAuto` also reads
+hex, you can move a store to hex incrementally: switch writers to `ModeHex`
+while readers stay on `ModeAuto`, then tighten readers to `ModeHex` once all
+data is migrated.
+
+```Go
+// Write hex, while existing readers on ModeAuto keep accepting old raw data.
+codec, _ := integrity.NewCodecBuilder[MyConfig]().
+	WithHasher(hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeHex))).
+	WithSignerVerifier(crypto.NewRSAPSS(priv, crypto.WithMode(crypto.ModeHex))).
+	Build()
+```
 
 [go-modules-v2]: https://go.dev/ref/mod#major-version-suffixes

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ for multi-op transactions) drop the `name` parameter:
 ```go
 codec, err := integrity.NewCodecBuilder[AuthConfig]().
     WithObjectLocation("settings").
-    WithSignerVerifier(crypto.NewRSAPSSSignerVerifier(*privKey)).
+    WithSignerVerifier(crypto.NewRSAPSS(*privKey)).
     Build()
 if err != nil {
     log.Fatal(err)

--- a/crypto/encoding_test.go
+++ b/crypto/encoding_test.go
@@ -1,0 +1,146 @@
+package crypto_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/tarantool/go-storage/v2/crypto"
+)
+
+// TestRsaSign_DefaultsToRaw pins that, by default (ModeAuto), Sign emits raw
+// signature bytes and Verify accepts them.
+func TestRsaSign_DefaultsToRaw(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
+
+	data := []byte("payload")
+
+	sig, err := signerVerifier.Sign(data)
+	require.NoError(t, err)
+	require.Len(t, sig, 256, "default (auto) RSA-PSS signature over a 2048-bit key is 256 raw bytes")
+
+	require.NoError(t, signerVerifier.Verify(data, sig))
+}
+
+// TestRsaSign_Hex pins that ModeHex emits a hex-encoded signature and that a
+// hex signer/verifier round-trips.
+func TestRsaSign_Hex(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signerVerifier := crypto.NewRSAPSS(*privateKey, crypto.WithMode(crypto.ModeHex))
+
+	data := []byte("payload")
+
+	sig, err := signerVerifier.Sign(data)
+	require.NoError(t, err)
+
+	// Signature is a valid hex string of the raw 256-byte RSA-PSS signature.
+	raw, err := hex.DecodeString(string(sig))
+	require.NoError(t, err, "ModeHex signature must be hex-encoded")
+	require.Len(t, raw, 256)
+
+	require.NoError(t, signerVerifier.Verify(data, sig))
+}
+
+// TestRsaSign_Bin pins that ModeBin emits raw signature bytes and round-trips.
+func TestRsaSign_Bin(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	signer := crypto.NewRSAPSS(*privateKey, crypto.WithMode(crypto.ModeBin))
+	verifier := crypto.NewRSAPSSVerifier(privateKey.PublicKey, crypto.WithMode(crypto.ModeBin))
+
+	data := []byte("payload")
+
+	sig, err := signer.Sign(data)
+	require.NoError(t, err)
+	require.Len(t, sig, 256, "raw RSA-PSS signature over a 2048-bit key is 256 bytes")
+
+	require.NoError(t, verifier.Verify(data, sig))
+}
+
+// TestRsaVerify_AutoAcceptsBoth pins that a ModeAuto verifier accepts a
+// signature in either encoding — raw bytes or hex — regardless of how it was
+// produced. This is the migration-friendly read path.
+func TestRsaVerify_AutoAcceptsBoth(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	data := []byte("payload")
+
+	hexSig, err := crypto.NewRSAPSS(*privateKey, crypto.WithMode(crypto.ModeHex)).Sign(data)
+	require.NoError(t, err)
+
+	binSig, err := crypto.NewRSAPSS(*privateKey, crypto.WithMode(crypto.ModeBin)).Sign(data)
+	require.NoError(t, err)
+
+	autoVerifier := crypto.NewRSAPSSVerifier(privateKey.PublicKey) // ModeAuto.
+
+	require.NoError(t, autoVerifier.Verify(data, hexSig), "auto verifier must accept hex")
+	require.NoError(t, autoVerifier.Verify(data, binSig), "auto verifier must accept raw")
+}
+
+// TestRsaVerify_HexRejectsRaw pins that a ModeHex verifier rejects a raw
+// signature instead of silently accepting it.
+func TestRsaVerify_HexRejectsRaw(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	data := []byte("payload")
+
+	binSig, err := crypto.NewRSAPSS(*privateKey, crypto.WithMode(crypto.ModeBin)).Sign(data)
+	require.NoError(t, err)
+
+	hexVerifier := crypto.NewRSAPSSVerifier(privateKey.PublicKey, crypto.WithMode(crypto.ModeHex))
+
+	require.Error(t, hexVerifier.Verify(data, binSig))
+}
+
+// TestRsaVerify_BinRejectsHex pins that a ModeBin verifier rejects a hex
+// signature — the raw verifier treats the hex bytes as the signature itself.
+func TestRsaVerify_BinRejectsHex(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	data := []byte("payload")
+
+	hexSig, err := crypto.NewRSAPSS(*privateKey, crypto.WithMode(crypto.ModeHex)).Sign(data)
+	require.NoError(t, err)
+
+	binVerifier := crypto.NewRSAPSSVerifier(privateKey.PublicKey, crypto.WithMode(crypto.ModeBin))
+
+	require.Error(t, binVerifier.Verify(data, hexSig))
+}
+
+// TestRsaVerify_HexRejectsNonHex pins that a ModeHex verifier rejects a non-hex
+// signature with a clear error instead of treating it as raw.
+func TestRsaVerify_HexRejectsNonHex(t *testing.T) {
+	t.Parallel()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	verifier := crypto.NewRSAPSSVerifier(privateKey.PublicKey, crypto.WithMode(crypto.ModeHex))
+
+	err = verifier.Verify([]byte("payload"), []byte("zz-not-hex"))
+	require.ErrorContains(t, err, "failed to decode hex signature")
+}

--- a/crypto/options.go
+++ b/crypto/options.go
@@ -1,0 +1,40 @@
+package crypto
+
+// Mode selects how a signer encodes the signature it produces and which
+// encodings a verifier accepts.
+type Mode int
+
+const (
+	// ModeAuto emits raw signature bytes and, on verification, accepts a
+	// signature in either raw or lower-case hex form. It is the default.
+	ModeAuto Mode = iota
+	// ModeHex emits a lower-case hex signature and accepts only hex on
+	// verification.
+	ModeHex
+	// ModeBin emits raw signature bytes and accepts only raw bytes on
+	// verification.
+	ModeBin
+)
+
+// Option configures an RSA-PSS signer/verifier constructor.
+type Option func(*config)
+
+type config struct {
+	mode Mode
+}
+
+func newConfig(opts ...Option) config {
+	var cfg config // mode defaults to ModeAuto (the zero value).
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return cfg
+}
+
+// WithMode sets the encoding mode of the signer/verifier. See ModeAuto,
+// ModeHex and ModeBin. When omitted, ModeAuto is used.
+func WithMode(m Mode) Option {
+	return func(c *config) { c.mode = m }
+}

--- a/crypto/rsapss.go
+++ b/crypto/rsapss.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/hex"
 	"errors"
 	"fmt"
 
@@ -18,31 +19,39 @@ func zero[T any]() (out T) { return } //nolint:nonamedreturns
 
 // RSAPSS represents RSA PSS algo for signing/verification
 // (with SHA256 as digest calculation function).
+//
+// The encoding of produced signatures and the encodings accepted on
+// verification are controlled by the Mode (see ModeAuto, ModeHex, ModeBin). By
+// default (ModeAuto) signatures are emitted as raw bytes and Verify accepts a
+// signature in either raw or hex form.
 type RSAPSS struct {
 	publicKey  rsa.PublicKey
 	privateKey rsa.PrivateKey
 	hash       crypto.Hash
 	hasher     hasher.Hasher
+	mode       Mode
 }
 
-// NewRSAPSSSignerVerifier creates new RSAPSS object that can both sign and verify.
+// NewRSAPSS creates new RSAPSS object that can both sign and verify.
 // The public key is derived from the private key.
-func NewRSAPSSSignerVerifier(privKey rsa.PrivateKey) SignerVerifier {
+func NewRSAPSS(privKey rsa.PrivateKey, opts ...Option) SignerVerifier {
 	return RSAPSS{
 		publicKey:  privKey.PublicKey,
 		privateKey: privKey,
 		hash:       crypto.SHA256,
-		hasher:     hasher.NewSHA256Hasher(),
+		hasher:     hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeBin)),
+		mode:       newConfig(opts...).mode,
 	}
 }
 
 // NewRSAPSSVerifier creates new RSAPSS object that can only verify signatures.
-func NewRSAPSSVerifier(pubKey rsa.PublicKey) Verifier {
+func NewRSAPSSVerifier(pubKey rsa.PublicKey, opts ...Option) Verifier {
 	return RSAPSS{
 		publicKey:  pubKey,
 		privateKey: zero[rsa.PrivateKey](),
 		hash:       crypto.SHA256,
-		hasher:     hasher.NewSHA256Hasher(),
+		hasher:     hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeBin)),
+		mode:       newConfig(opts...).mode,
 	}
 }
 
@@ -51,7 +60,9 @@ func (r RSAPSS) Name() string {
 	return "rsapss"
 }
 
-// Sign generates SHA-256 digest and signs it using RSASSA-PSS.
+// Sign generates SHA-256 digest and signs it using RSASSA-PSS. The returned
+// signature is encoded according to the signer's Mode (raw bytes for ModeAuto
+// and ModeBin, hex for ModeHex).
 func (r RSAPSS) Sign(data []byte) ([]byte, error) {
 	if r.privateKey.N == nil {
 		return nil, ErrEmptyPrivateKey
@@ -70,17 +81,24 @@ func (r RSAPSS) Sign(data []byte) ([]byte, error) {
 		return nil, fmt.Errorf("failed to sign: %w", err)
 	}
 
-	return signature, nil
+	return r.encode(signature), nil
 }
 
-// Verify compares data with signature.
+// Verify compares data with signature. The accepted signature encoding depends
+// on the verifier's Mode: ModeHex expects hex, ModeBin expects raw bytes and
+// ModeAuto accepts either.
 func (r RSAPSS) Verify(data []byte, signature []byte) error {
+	sig, err := r.decode(signature)
+	if err != nil {
+		return err
+	}
+
 	digest, err := r.hasher.Hash(data)
 	if err != nil {
 		return fmt.Errorf("failed to get hash: %w", err)
 	}
 
-	err = rsa.VerifyPSS(&r.publicKey, r.hash, digest, signature, &rsa.PSSOptions{
+	err = rsa.VerifyPSS(&r.publicKey, r.hash, digest, sig, &rsa.PSSOptions{
 		SaltLength: rsa.PSSSaltLengthEqualsHash,
 		Hash:       r.hash,
 	})
@@ -89,4 +107,67 @@ func (r RSAPSS) Verify(data []byte, signature []byte) error {
 	}
 
 	return nil
+}
+
+// sigBytes is the raw RSA-PSS signature length in bytes for the configured key,
+// or 0 when no public modulus is set (verification will fail downstream).
+func (r RSAPSS) sigBytes() int {
+	if r.publicKey.N == nil {
+		return 0
+	}
+
+	return r.publicKey.Size()
+}
+
+// encode encodes the signature according to the receiver's Mode: hex for
+// ModeHex, raw bytes for ModeAuto and ModeBin.
+func (r RSAPSS) encode(sig []byte) []byte {
+	if r.mode != ModeHex {
+		return sig
+	}
+
+	dst := make([]byte, hex.EncodedLen(len(sig)))
+	hex.Encode(dst, sig)
+
+	return dst
+}
+
+// decode decodes the signature according to the receiver's Mode. ModeBin
+// returns the bytes unchanged, ModeHex hex-decodes them, and ModeAuto detects
+// the encoding from the length: a raw signature is exactly sigBytes long, its
+// hex form exactly twice that.
+func (r RSAPSS) decode(sig []byte) ([]byte, error) {
+	if r.mode == ModeBin {
+		return sig, nil
+	}
+
+	if r.mode == ModeHex {
+		return hexDecode(sig)
+	}
+
+	// ModeAuto: a raw signature is exactly sigBytes long.
+	if len(sig) == r.sigBytes() {
+		return sig, nil
+	}
+
+	// Otherwise try hex; accept it only if it decodes to the raw length.
+	raw, err := hexDecode(sig)
+	if err == nil && len(raw) == r.sigBytes() {
+		return raw, nil
+	}
+
+	// Fall back to treating the input as raw bytes; VerifyPSS will reject it if
+	// the length is wrong.
+	return sig, nil
+}
+
+func hexDecode(sig []byte) ([]byte, error) {
+	raw := make([]byte, hex.DecodedLen(len(sig)))
+
+	n, err := hex.Decode(raw, sig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode hex signature: %w", err)
+	}
+
+	return raw[:n], nil
 }

--- a/crypto/rsapss_test.go
+++ b/crypto/rsapss_test.go
@@ -13,7 +13,7 @@ import (
 func TestRsaWithoutKeys(t *testing.T) {
 	t.Parallel()
 
-	rsapss := crypto.NewRSAPSSSignerVerifier(rsa.PrivateKey{}) //nolint:exhaustruct
+	rsapss := crypto.NewRSAPSS(rsa.PrivateKey{}) //nolint:exhaustruct
 	require.NotNil(t, rsapss, "rsapss must be returned")
 
 	data := []byte("abc")
@@ -32,7 +32,7 @@ func TestRsaOnlyPrivateKey(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signer := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signer := crypto.NewRSAPSS(*privateKey)
 	require.NotNil(t, signer, "signer must be returned")
 
 	verifier := crypto.NewRSAPSSVerifier(rsa.PublicKey{}) //nolint:exhaustruct
@@ -68,7 +68,7 @@ func TestRsaOnlyPublicKey(t *testing.T) {
 	require.Nil(t, sig, "signature must be nil")
 
 	// Create signer+verifier with private key.
-	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
 	require.NotNil(t, signerVerifier, "signerVerifier must be returned")
 
 	sign, err := signerVerifier.Sign(data)
@@ -85,7 +85,7 @@ func TestRsaSignVerify(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
 	require.NotNil(t, signerVerifier, "signerVerifier must be returned")
 
 	data := []byte("abc")
@@ -107,7 +107,7 @@ func TestRsaSign_EmptyData_NoExplosion(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signer := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signer := crypto.NewRSAPSS(*privateKey)
 
 	for _, data := range [][]byte{nil, {}} {
 		sig, err := signer.Sign(data)
@@ -125,7 +125,7 @@ func TestRsaVerify_EmptyData_NoExplosion(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
 
 	sig, err := signerVerifier.Sign(nil)
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestRsaVerify_EmptySignature(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
 
 	for _, sig := range [][]byte{nil, {}} {
 		err := signerVerifier.Verify([]byte("payload"), sig)
@@ -163,7 +163,7 @@ func TestRsaSignVerify_EmptyData(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
 
 	for _, data := range [][]byte{nil, {}} {
 		sig, err := signerVerifier.Sign(data)
@@ -192,6 +192,6 @@ func TestRSAPSS_Name(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
 	require.Equal(t, "rsapss", signerVerifier.Name())
 }

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -2,14 +2,26 @@
 package hasher
 
 import (
+	"bytes"
 	"crypto/sha1" //nolint:gosec
 	"crypto/sha256"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"hash"
 )
 
+// ErrHashMismatch is returned by Verify when the stored digest does not match
+// any encoding of the computed digest accepted under the hasher's Mode.
+var ErrHashMismatch = errors.New("hash mismatch")
+
 // Hasher is the interface that storage hashers must implement.
 // It provides low-level operations for hash calculating.
+//
+// The encoding of the produced digest and the encodings accepted by Verify are
+// controlled by the hasher's Mode (see ModeAuto, ModeHex, ModeBin). By default
+// (ModeAuto) Hash returns the raw digest bytes and Verify accepts a stored
+// digest in either raw or hex form.
 //
 // Implementations must accept nil and zero-length input and return the
 // well-defined hash of the empty bit string for both. This matters because
@@ -17,17 +29,24 @@ import (
 // legitimately-empty value must hash without error.
 type Hasher interface {
 	Name() string
+	// Hash returns the digest of data, encoded according to the hasher's Mode.
 	Hash(data []byte) ([]byte, error)
+	// Verify reports whether stored is an accepted encoding of the digest of
+	// data under the hasher's Mode. It returns nil on a match.
+	Verify(data, stored []byte) error
 }
 
 type sha256Hasher struct {
 	hash hash.Hash
+	mode Mode
 }
 
-// NewSHA256Hasher creates a new sha256Hasher instance.
-func NewSHA256Hasher() Hasher {
+// NewSHA256Hasher creates a new SHA-256 hasher. Its encoding behaviour is
+// controlled by the given options; see WithMode (default ModeAuto).
+func NewSHA256Hasher(opts ...Option) Hasher {
 	return &sha256Hasher{
 		hash: sha256.New(),
+		mode: newConfig(opts...).mode,
 	}
 }
 
@@ -38,6 +57,25 @@ func (h *sha256Hasher) Name() string {
 
 // Hash implements Hasher interface.
 func (h *sha256Hasher) Hash(data []byte) ([]byte, error) {
+	sum, err := h.sum(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return encode(sum, h.mode), nil
+}
+
+// Verify implements Hasher interface.
+func (h *sha256Hasher) Verify(data, stored []byte) error {
+	sum, err := h.sum(data)
+	if err != nil {
+		return err
+	}
+
+	return verify(sum, stored, h.mode)
+}
+
+func (h *sha256Hasher) sum(data []byte) ([]byte, error) {
 	h.hash.Reset()
 
 	n, err := h.hash.Write(data)
@@ -50,12 +88,15 @@ func (h *sha256Hasher) Hash(data []byte) ([]byte, error) {
 
 type sha1Hasher struct {
 	hash hash.Hash
+	mode Mode
 }
 
-// NewSHA1Hasher creates a new NewSHA1Hasher instance.
-func NewSHA1Hasher() Hasher {
+// NewSHA1Hasher creates a new SHA-1 hasher. Its encoding behaviour is
+// controlled by the given options; see WithMode (default ModeAuto).
+func NewSHA1Hasher(opts ...Option) Hasher {
 	return &sha1Hasher{
 		hash: sha1.New(), //nolint:gosec
+		mode: newConfig(opts...).mode,
 	}
 }
 
@@ -66,6 +107,25 @@ func (h *sha1Hasher) Name() string {
 
 // Hash implements Hasher interface.
 func (h *sha1Hasher) Hash(data []byte) ([]byte, error) {
+	sum, err := h.sum(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return encode(sum, h.mode), nil
+}
+
+// Verify implements Hasher interface.
+func (h *sha1Hasher) Verify(data, stored []byte) error {
+	sum, err := h.sum(data)
+	if err != nil {
+		return err
+	}
+
+	return verify(sum, stored, h.mode)
+}
+
+func (h *sha1Hasher) sum(data []byte) ([]byte, error) {
 	h.hash.Reset()
 
 	n, err := h.hash.Write(data)
@@ -74,4 +134,35 @@ func (h *sha1Hasher) Hash(data []byte) ([]byte, error) {
 	}
 
 	return h.hash.Sum(nil), nil
+}
+
+// encode returns sum encoded according to mode: hex for ModeHex, raw bytes for
+// ModeAuto and ModeBin.
+func encode(sum []byte, mode Mode) []byte {
+	if mode != ModeHex {
+		return sum
+	}
+
+	return hexEncode(sum)
+}
+
+// verify reports whether stored is an accepted encoding of the raw digest sum
+// under mode. ModeBin accepts only the raw bytes, ModeHex only the hex form,
+// ModeAuto accepts either.
+func verify(sum, stored []byte, mode Mode) error {
+	rawOK := mode != ModeHex && bytes.Equal(stored, sum)
+	hexOK := mode != ModeBin && bytes.Equal(stored, hexEncode(sum))
+
+	if rawOK || hexOK {
+		return nil
+	}
+
+	return fmt.Errorf("%w: stored %x, computed digest %x", ErrHashMismatch, stored, sum)
+}
+
+func hexEncode(src []byte) []byte {
+	dst := make([]byte, hex.EncodedLen(len(src)))
+	hex.Encode(dst, src)
+
+	return dst
 }

--- a/hasher/hasher_test.go
+++ b/hasher/hasher_test.go
@@ -33,11 +33,22 @@ func TestSHA1Hasher(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Default (ModeAuto) output is the raw digest.
 			h := hasher.NewSHA1Hasher()
 
 			result, err := h.Hash(test.in)
 			require.NoError(t, err)
 			assert.Equal(t, test.out, hex.EncodeToString(result))
+
+			// ModeHex returns lower-case hex.
+			hexResult, err := hasher.NewSHA1Hasher(hasher.WithMode(hasher.ModeHex)).Hash(test.in)
+			require.NoError(t, err)
+			assert.Equal(t, test.out, string(hexResult))
+
+			// ModeBin returns the raw digest.
+			binResult, err := hasher.NewSHA1Hasher(hasher.WithMode(hasher.ModeBin)).Hash(test.in)
+			require.NoError(t, err)
+			assert.Equal(t, test.out, hex.EncodeToString(binResult))
 		})
 	}
 }
@@ -76,11 +87,65 @@ func TestSHA256Hasher(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
+			// Default (ModeAuto) output is the raw digest.
 			h := hasher.NewSHA256Hasher()
 
 			result, err := h.Hash(test.in)
 			require.NoError(t, err)
 			assert.Equal(t, test.expected, hex.EncodeToString(result))
+
+			// ModeHex returns lower-case hex.
+			hexResult, err := hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeHex)).Hash(test.in)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, string(hexResult))
+
+			// ModeBin returns the raw digest.
+			binResult, err := hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeBin)).Hash(test.in)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, hex.EncodeToString(binResult))
+		})
+	}
+}
+
+// TestHasherVerify_Modes pins the per-mode Verify contract: ModeAuto accepts a
+// stored digest in either raw or hex form, ModeHex only hex, ModeBin only raw.
+func TestHasherVerify_Modes(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("abc")
+	raw, err := hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeBin)).Hash(data)
+	require.NoError(t, err)
+
+	hexDigest, err := hasher.NewSHA256Hasher(hasher.WithMode(hasher.ModeHex)).Hash(data)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		mode      hasher.Mode
+		stored    []byte
+		wantError bool
+	}{
+		{"auto accepts raw", hasher.ModeAuto, raw, false},
+		{"auto accepts hex", hasher.ModeAuto, hexDigest, false},
+		{"auto rejects garbage", hasher.ModeAuto, []byte("nope"), true},
+		{"hex accepts hex", hasher.ModeHex, hexDigest, false},
+		{"hex rejects raw", hasher.ModeHex, raw, true},
+		{"bin accepts raw", hasher.ModeBin, raw, false},
+		{"bin rejects hex", hasher.ModeBin, hexDigest, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := hasher.NewSHA256Hasher(hasher.WithMode(test.mode))
+
+			err := h.Verify(data, test.stored)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/hasher/options.go
+++ b/hasher/options.go
@@ -1,0 +1,40 @@
+package hasher
+
+// Mode selects how a Hasher encodes the digest it produces and which encodings
+// it accepts when verifying a stored digest.
+type Mode int
+
+const (
+	// ModeAuto produces the raw digest bytes and, on verification, accepts a
+	// stored digest in either raw or lower-case hex form. It is the default.
+	ModeAuto Mode = iota
+	// ModeHex produces a lower-case hex digest and accepts only hex on
+	// verification.
+	ModeHex
+	// ModeBin produces the raw digest bytes and accepts only raw bytes on
+	// verification.
+	ModeBin
+)
+
+// Option configures a Hasher constructor.
+type Option func(*config)
+
+type config struct {
+	mode Mode
+}
+
+func newConfig(opts ...Option) config {
+	var cfg config // mode defaults to ModeAuto (the zero value).
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return cfg
+}
+
+// WithMode sets the encoding mode of the hasher. See ModeAuto, ModeHex and
+// ModeBin. When omitted, ModeAuto is used.
+func WithMode(m Mode) Option {
+	return func(c *config) { c.mode = m }
+}

--- a/integrity/codec_example_test.go
+++ b/integrity/codec_example_test.go
@@ -118,7 +118,7 @@ func ExampleCodecBuilder_WithSignerVerifier() {
 
 	codec, err := integrity.NewCodecBuilder[codecExampleConfig]().WithObjectLocation("objects").
 		WithHasher(hasher.NewSHA256Hasher()).
-		WithSignerVerifier(crypto.NewRSAPSSSignerVerifier(*priv)).
+		WithSignerVerifier(crypto.NewRSAPSS(*priv)).
 		Build()
 	if err != nil {
 		log.Fatalf("build codec: %v", err)

--- a/integrity/codec_test.go
+++ b/integrity/codec_test.go
@@ -28,7 +28,7 @@ func newTestRSAPSS(t *testing.T) crypto.SignerVerifier {
 	pk, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	return crypto.NewRSAPSSSignerVerifier(*pk)
+	return crypto.NewRSAPSS(*pk)
 }
 
 func TestCodecBuilder_Defaults(t *testing.T) {

--- a/integrity/generator_test.go
+++ b/integrity/generator_test.go
@@ -1,6 +1,7 @@
 package integrity_test
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
@@ -40,6 +41,19 @@ func (m *mockHasher) Hash(data []byte) ([]byte, error) {
 	}
 
 	return []byte("mock-hash-" + m.name), nil
+}
+
+func (m *mockHasher) Verify(data, stored []byte) error {
+	h, err := m.Hash(data)
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(stored, h) {
+		return errors.New("mock hash mismatch")
+	}
+
+	return nil
 }
 
 type mockSigner struct {

--- a/integrity/integration_codec_tx_test.go
+++ b/integrity/integration_codec_tx_test.go
@@ -240,7 +240,7 @@ func TestStoreIntegration_Range_EmptyWithSignerVerifier(t *testing.T) {
 
 		ctx := t.Context()
 		shaHash := hasher.NewSHA256Hasher()
-		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+		rsaSV := crypto.NewRSAPSS(*rsaPK2048)
 
 		_, store := newIntegrationCodecStore(t, driverInstance,
 			func(b integrity.CodecBuilder[IntegrationStruct]) integrity.CodecBuilder[IntegrationStruct] {
@@ -294,7 +294,7 @@ func TestStoreIntegration_WithSignerVerifier(t *testing.T) {
 
 		ctx := t.Context()
 		shaHash := hasher.NewSHA256Hasher()
-		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+		rsaSV := crypto.NewRSAPSS(*rsaPK2048)
 
 		_, store := newIntegrationCodecStore(t, driverInstance,
 			func(b integrity.CodecBuilder[IntegrationStruct]) integrity.CodecBuilder[IntegrationStruct] {
@@ -600,7 +600,7 @@ func TestTxIntegration_EmptyValue_RoundTrip(t *testing.T) {
 		base := scopedStorage(t, driverInstance)
 
 		shaHash := hasher.NewSHA256Hasher()
-		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+		rsaSV := crypto.NewRSAPSS(*rsaPK2048)
 
 		codec, err := integrity.NewCodecBuilder[[]byte]().
 			WithObjectLocation("objects").
@@ -645,7 +645,7 @@ func TestStoreIntegration_EmptyValue_GetPut(t *testing.T) {
 		base := scopedStorage(t, driverInstance)
 
 		shaHash := hasher.NewSHA256Hasher()
-		rsaSV := crypto.NewRSAPSSSignerVerifier(*rsaPK2048)
+		rsaSV := crypto.NewRSAPSS(*rsaPK2048)
 
 		codec, err := integrity.NewCodecBuilder[[]byte]().
 			WithObjectLocation("objects").

--- a/integrity/validator.go
+++ b/integrity/validator.go
@@ -1,8 +1,6 @@
 package integrity
 
 import (
-	"bytes"
-
 	"github.com/tarantool/go-option"
 
 	"github.com/tarantool/go-storage/v2/crypto"
@@ -140,12 +138,16 @@ func (v Validator[T]) validateSingle(name string, kvs []extendedKV) ValidatedRes
 
 			delete(expectedHashers, kvi.parsedKey.Property())
 
-			hash, err := hasher.Hash(body)
-			switch {
-			case err != nil:
-				aggregatedError.Append(errFailedToComputeHashWith(kvi.parsedKey.Property(), err))
-			case !bytes.Equal(hash, kvi.keyValue.Value):
-				aggregatedError.Append(errHashMismatch(kvi.parsedKey.Property(), kvi.keyValue.Value, hash))
+			err := hasher.Verify(body, kvi.keyValue.Value)
+			if err != nil {
+				// Recompute to produce a precise diagnostic and to tell a
+				// compute failure apart from a genuine mismatch.
+				computed, herr := hasher.Hash(body)
+				if herr != nil {
+					aggregatedError.Append(errFailedToComputeHashWith(kvi.parsedKey.Property(), herr))
+				} else {
+					aggregatedError.Append(errHashMismatch(kvi.parsedKey.Property(), kvi.keyValue.Value, computed))
+				}
 			}
 		case namer.KeyTypeSignature:
 			verifier, ok := expectedVerifiers[kvi.parsedKey.Property()]

--- a/integrity/validator_test.go
+++ b/integrity/validator_test.go
@@ -898,7 +898,7 @@ func TestValidatorValidate_EmptyValue_WithVerifier(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	signerVerifier := crypto.NewRSAPSSSignerVerifier(*privateKey)
+	signerVerifier := crypto.NewRSAPSS(*privateKey)
 
 	sig, err := signerVerifier.Sign(nil)
 	require.NoError(t, err)


### PR DESCRIPTION
v2 take on the hex encoding work (the v1 PR #114 added separate `NewHex…` decorators). Here the single constructors gain variadic options, hex becomes the default, and `WithRaw()` opts back into raw bytes.

- hasher: `NewSHA256Hasher` / `NewSHA1Hasher` take options; `Hash` returns lower-case hex unless `hasher.WithRaw()` is passed. `Name()` is unchanged, so the on-disk key layout is preserved.
- crypto: `NewRSAPSSSignerVerifier` is renamed to `NewRSAPSS`; both `NewRSAPSS` and `NewRSAPSSVerifier` take options; signatures are hex unless `crypto.WithRaw()` is passed. The internal digest fed to `rsa.SignPSS` stays raw.

Breaking changes (v2): the default on-disk encoding of integrity hashes and signatures is now hex, and `NewRSAPSSSignerVerifier` is gone. Validator test fixtures that embedded raw digests are updated to their hex form.

All hasher/crypto/integrity tests pass (`go test -short`); hasher and crypto lint clean.