### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [v1.6.1] - 2026-06-22
+
+This release adds hex-encoding decorators for hashers and signer/verifiers.
+New constructors wrap an existing `Hasher` or `SignerVerifier` so the stored
+payload is lower-case hex while `Name()` is passed through unchanged,
+preserving the on-disk key layout.
+
+### Added
+
 - hasher, crypto: hex-encoding decorators that wrap an existing `Hasher` or
   `SignerVerifier` so the stored payload is lower-case hex while `Name()` is
   passed through unchanged, preserving the on-disk key layout. New
@@ -16,10 +29,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `hasher.NewHexSHA1Hasher`, `crypto.NewHexSignerVerifier`,
   `crypto.NewHexVerifier`, `crypto.NewHexRSAPSSSignerVerifier`, and
   `crypto.NewHexRSAPSSVerifier`. The raw constructors are unchanged (#114).
-
-### Changed
-
-### Fixed
 
 ## [v1.6.0] - 2026-06-09
 


### PR DESCRIPTION
This release adds hex-encoding decorators for hashers and signer/verifiers. New constructors wrap an existing `Hasher` or `SignerVerifier` so the stored payload is lower-case hex while `Name()` is passed through unchanged, preserving the on-disk key layout.

### Added

- hasher, crypto: hex-encoding decorators that wrap an existing `Hasher` or `SignerVerifier` so the stored payload is lower-case hex while `Name()` is passed through unchanged, preserving the on-disk key layout. New constructors: `hasher.NewHexHasher`, `hasher.NewHexSHA256Hasher`, `hasher.NewHexSHA1Hasher`, `crypto.NewHexSignerVerifier`, `crypto.NewHexVerifier`, `crypto.NewHexRSAPSSSignerVerifier`, and `crypto.NewHexRSAPSSVerifier`. The raw constructors are unchanged (#114).