### PR TITLE
v2: API-polish cleanup sweep (export surface, cross-driver consistency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - hasher: `Hasher` interface gains `Verify(data, stored []byte) error`, which
   reports whether a stored digest matches under the hasher's mode. The integrity
   validator uses it so hash verification is encoding-aware.
+- integrity: exported the option aliases `GetOption`, `PutOption` and
+  `DeleteOption` for the `With…`/`Ignore…` option constructors. The option type
+  was previously `internal/options.OptionCallback[…]` over an unexported struct
+  in an internal package, so callers could not name it to forward options.
+- hasher, crypto: exported the algorithm-name constants returned by `Name()` —
+  `hasher.AlgoSHA256`, `hasher.AlgoSHA1` and `crypto.AlgoRSAPSS` — so codec
+  callers can pass a compile-checked constant to `WithHashLocation` /
+  `WithSignatureLocation` instead of retyping the bare string.
+- driver/etcd: `NewWithLocker(client *etcd.Client)` builds a locking-capable
+  driver (see Changed).
 
 ### Changed
 
@@ -52,6 +62,41 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   it. The built-in SHA-1/SHA-256 hashers implement it.
 - **BREAKING:** `crypto.NewRSAPSSSignerVerifier` is renamed to
   `crypto.NewRSAPSS`.
+- **BREAKING:** `driver/etcd` makes locking a construction-time choice. `New`
+  now builds a driver without locking — `NewLocker` returns
+  `locker.ErrUnsupported` — and the new `NewWithLocker(*etcd.Client)` builds a
+  locking-capable driver. This replaces the previous runtime
+  `client.(*etcd.Client)` type assertion, which silently disabled locking for
+  any wrapper that implemented the `Client` interface. `connect` uses
+  `NewWithLocker`, so locking via `connect` is unaffected.
+- **BREAKING:** renamed the `driver/tcs` connection interface `DoerWatcher` to
+  `Client`, matching `driver/etcd.Client` so every driver's connection
+  dependency shares one name. The generated mock is now `mocks.TCSClientMock`
+  (was `mocks.DoerWatcherMock`).
+- **BREAKING:** lock-name validation is now uniform across drivers. Every
+  driver's `NewLocker` requires `name` to start with `/` and not end with `/`;
+  previously only tcs enforced this and etcd/dummy accepted any string.
+  Violations return the new `locker.ErrNameNoLeadingSlash` /
+  `locker.ErrNameTrailingSlash`, checked by the shared `locker.ValidateName`.
+- **BREAKING:** `predicate.ValueEqual` / `ValueNotEqual` normalize a `string`
+  comparison value to `[]byte`, so `Predicate.Value()` returns `[]byte` for
+  both `[]byte` and `string` inputs. Previously a `string` value worked on the
+  dummy and tcs drivers but was rejected by etcd; every driver now receives
+  `[]byte`.
+- **BREAKING:** `namer.KeyType.String()` returns the wire form (`"value"`,
+  `"hash"`, `"signature"`) instead of the Go identifier (`"KeyTypeValue"`, …);
+  unknown values format as `KeyType(N)`. The method is display-only and does
+  not affect key construction.
+- **BREAKING:** `driver/etcd.Driver` and `driver/tcs.Driver` use pointer
+  receivers (matching `driver/dummy`). Both constructors already returned
+  `*Driver`, so typical callers are unaffected.
+- error sentinels in `connect`, `crypto`, `hasher`, `driver/tcs` and
+  `integrity` are now prefixed with their package name (e.g. `not found` →
+  `integrity: not found`, `hash mismatch` → `hasher: hash mismatch`). Sentinel
+  identity (`errors.Is`) is unchanged; only `Error()` strings differ.
+- `namer.Results` accessors (`SelectSingle`, `Items`, `Result`, `Select`,
+  `Len`) use value receivers instead of pointer receivers; existing call sites
+  keep compiling.
 
 ### Removed
 
@@ -77,6 +122,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `marshaller.Marshallable` interfaces (nothing referenced them).
 - **BREAKING:** removed the `integrity.InvalidNameError` type; `ErrInvalidName`
   is now a plain sentinel (see Fixed).
+- **BREAKING:** unexported `crypto.RSAPSS`. `NewRSAPSS` / `NewRSAPSSVerifier`
+  return the `SignerVerifier` / `Verifier` interfaces, so the concrete type is
+  no longer part of the public surface — matching the `hasher` package, whose
+  algorithm types are unexported.
+- **BREAKING:** unexported `integrity.ModRevisionEmpty`, an internal sentinel
+  (value `0`) used only by the generator and validator.
 
 ### Fixed
 
@@ -88,6 +139,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   reliable.
 - `marshaller` error strings are now lowercased per Go convention
   (`failed to marshal`/`failed to unmarshal`).
+- `driver/dummy` scopes its lock registry to the `Driver` instance instead of a
+  process-global `sync.Map`, so two independent dummy drivers no longer share a
+  lock namespace.
 
 ## [v2.0.0]
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -111,6 +111,13 @@ for the full list.
 * [hasher.Hasher gains a Verify method](#hasher-verify)
 * [crypto.NewRSAPSSSignerVerifier renamed](#rsapss-rename)
 * [On-disk encoding of hashes and signatures](#on-disk-encoding)
+* [driver/etcd: locking constructor](#etcd-locker)
+* [driver/tcs: DoerWatcher renamed to Client](#tcs-client)
+* [locker: lock-name validation](#locker-name)
+* [predicate: string values normalized to bytes](#predicate-normalize)
+* [namer.KeyType.String wire form](#keytype-string)
+* [crypto.RSAPSS unexported](#rsapss-unexport)
+* [Other source-level changes](#other-cleanup)
 
 ### <a id="integrity-typed">integrity: Typed storage removed</a>
 
@@ -296,5 +303,105 @@ codec, _ := integrity.NewCodecBuilder[MyConfig]().
 	WithSignerVerifier(crypto.NewRSAPSS(priv, crypto.WithMode(crypto.ModeHex))).
 	Build()
 ```
+
+### <a id="etcd-locker">driver/etcd: locking constructor</a>
+
+`driver/etcd.New` now builds a driver **without** locking support: its
+`NewLocker` returns `locker.ErrUnsupported`. To get a locking-capable driver,
+build it with the new `NewWithLocker(*etcd.Client)`.
+
+```Go
+// Before — locking worked implicitly when client was a concrete *etcd.Client:
+drv := etcd.New(client)
+
+// After — choose locking explicitly:
+drv := etcd.NewWithLocker(client) // KV/watch/tx + locking
+// or
+drv := etcd.New(client)           // KV/watch/tx only; NewLocker → ErrUnsupported
+```
+
+`connect.NewEtcdStorage` / `connect.Connect` use `NewWithLocker`, so storage
+obtained through `connect` keeps locking with no change on your side.
+
+### <a id="tcs-client">driver/tcs: DoerWatcher renamed to Client</a>
+
+The `driver/tcs` connection interface `DoerWatcher` is renamed to `Client`
+(matching `driver/etcd.Client`). The interface contents are unchanged. The
+generated mock is now `mocks.TCSClientMock` (was `mocks.DoerWatcherMock`).
+
+```Go
+// Before:                        // After:
+var c tcs.DoerWatcher             var c tcs.Client
+m := mocks.NewDoerWatcherMock(t)  m := mocks.NewTCSClientMock(t)
+```
+
+### <a id="locker-name">locker: lock-name validation</a>
+
+Every driver's `NewLocker` now requires `name` to **start with `/`** and **not
+end with `/`** (previously only tcs enforced this; etcd and dummy accepted any
+string). Prefix bare names with `/`:
+
+```Go
+// Before:                          // After:
+lk, err := stg.NewLocker(ctx, "leader")  lk, err := stg.NewLocker(ctx, "/leader")
+```
+
+Violations return `locker.ErrNameNoLeadingSlash` / `locker.ErrNameTrailingSlash`.
+The shared `locker.ValidateName(name)` helper is exported if you want to
+pre-check.
+
+### <a id="predicate-normalize">predicate: string values normalized to bytes</a>
+
+`predicate.ValueEqual` / `ValueNotEqual` now convert a `string` comparison
+value to `[]byte`, so `Predicate.Value()` returns `[]byte` for both `[]byte`
+and `string` inputs. This removes a driver-dependent difference (a `string`
+value used to work on dummy/tcs but was rejected by etcd). If you inspected
+`Value()` and type-switched on `string`, expect `[]byte` now.
+
+### <a id="keytype-string">namer.KeyType.String wire form</a>
+
+`namer.KeyType.String()` returns the wire form instead of the Go identifier:
+
+| KeyType | Before | After |
+|---|---|---|
+| `KeyTypeValue` | `"KeyTypeValue"` | `"value"` |
+| `KeyTypeHash` | `"KeyTypeHash"` | `"hash"` |
+| `KeyTypeSignature` | `"KeyTypeSignature"` | `"signature"` |
+| unknown | `"KeyType[N]"` | `"KeyType(N)"` |
+
+The method is display-only (key construction is unaffected). Update any logs or
+assertions that relied on the old strings.
+
+### <a id="rsapss-unexport">crypto.RSAPSS unexported</a>
+
+The concrete `crypto.RSAPSS` type is unexported. The constructors already
+return interfaces, so hold the interface type instead of the concrete struct:
+
+```Go
+// Before:                                // After:
+var sv crypto.RSAPSS = ...                var sv crypto.SignerVerifier = crypto.NewRSAPSS(priv)
+```
+
+`NewRSAPSS` / `NewRSAPSSVerifier` and the `crypto.AlgoRSAPSS` name constant are
+unchanged.
+
+### <a id="other-cleanup">Other source-level changes</a>
+
+These rarely require action:
+
+* **Error message prefixes.** Leaf error sentinels in `connect`, `crypto`,
+  `hasher`, `driver/tcs` and `integrity` now carry a package prefix (e.g.
+  `integrity: not found`, `hasher: hash mismatch`). Sentinel **identity** is
+  unchanged, so `errors.Is` keeps working; only match on `Error()` text needs
+  updating.
+* **Driver receivers.** `driver/etcd.Driver` and `driver/tcs.Driver` use
+  pointer receivers (the constructors already returned `*Driver`).
+* **`namer.Results` receivers.** Its accessors switched to value receivers;
+  existing call sites keep compiling.
+* **`integrity.ModRevisionEmpty` removed.** It was an internal `0` sentinel;
+  compare `ModRevision` against `0` directly.
+* **New exported names.** `integrity.GetOption`/`PutOption`/`DeleteOption`
+  option aliases and the `hasher.AlgoSHA256`/`AlgoSHA1`/`crypto.AlgoRSAPSS`
+  algorithm-name constants are additive.
 
 [go-modules-v2]: https://go.dev/ref/mod#major-version-suffixes

--- a/connect/connect.go
+++ b/connect/connect.go
@@ -20,7 +20,9 @@ func NewEtcdStorage(ctx context.Context, cfg Config) (storage.Storage, CleanupFu
 		return nil, nil, err
 	}
 
-	drv := etcddriver.New(client)
+	// NewWithLocker so storage built via connect supports locking; client is the
+	// concrete *etcd.Client the concurrency package requires.
+	drv := etcddriver.NewWithLocker(client)
 
 	return storage.NewStorage(drv), cleanup, nil
 }

--- a/connect/error.go
+++ b/connect/error.go
@@ -4,11 +4,11 @@ import "errors"
 
 var (
 	// ErrNoEndpoint is returned when no endpoint is provided.
-	ErrNoEndpoint = errors.New("at least one endpoint is required")
+	ErrNoEndpoint = errors.New("connect: at least one endpoint is required")
 	// ErrSSLDisabled is returned when SSL is requested but support is disabled.
-	ErrSSLDisabled = errors.New("SSL support is disabled")
+	ErrSSLDisabled = errors.New("connect: SSL support is disabled")
 	// ErrInvalidSSLConfig is returned when SSL configuration is invalid.
-	ErrInvalidSSLConfig = errors.New("invalid SSL configuration")
+	ErrInvalidSSLConfig = errors.New("connect: invalid SSL configuration")
 
 	errNoCACerts         = errors.New("failed to append CA certificates")
 	errFailedReadCAFile  = errors.New("failed to read CA file")

--- a/connect/tcs.go
+++ b/connect/tcs.go
@@ -12,7 +12,7 @@ import (
 	tcsdriver "github.com/tarantool/go-storage/v2/driver/tcs"
 )
 
-func createTCSConnection(ctx context.Context, cfg Config) (tcsdriver.DoerWatcher, CleanupFunc, error) {
+func createTCSConnection(ctx context.Context, cfg Config) (tcsdriver.Client, CleanupFunc, error) {
 	if len(cfg.Endpoints) == 0 {
 		return nil, nil, ErrNoEndpoint
 	}

--- a/crypto/rsapss.go
+++ b/crypto/rsapss.go
@@ -15,6 +15,11 @@ var (
 	ErrEmptyPrivateKey = errors.New("crypto: cannot sign without a private key")
 )
 
+// AlgoRSAPSS is the algorithm name returned by the RSA-PSS signer/verifier's
+// Name method. Use it with integrity codec location options (e.g.
+// WithSignatureLocation) instead of retyping the bare string.
+const AlgoRSAPSS = "rsapss"
+
 func zero[T any]() (out T) { return } //nolint:nonamedreturns
 
 // RSAPSS represents RSA PSS algo for signing/verification
@@ -57,7 +62,7 @@ func NewRSAPSSVerifier(pubKey rsa.PublicKey, opts ...Option) Verifier {
 
 // Name implements SignerVerifier interface.
 func (r RSAPSS) Name() string {
-	return "rsapss"
+	return AlgoRSAPSS
 }
 
 // Sign generates SHA-256 digest and signs it using RSASSA-PSS. The returned

--- a/crypto/rsapss.go
+++ b/crypto/rsapss.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	ErrEmptyPrivateKey = errors.New("trying to sign without private key")
+	ErrEmptyPrivateKey = errors.New("crypto: cannot sign without a private key")
 )
 
 func zero[T any]() (out T) { return } //nolint:nonamedreturns

--- a/crypto/rsapss.go
+++ b/crypto/rsapss.go
@@ -22,14 +22,14 @@ const AlgoRSAPSS = "rsapss"
 
 func zero[T any]() (out T) { return } //nolint:nonamedreturns
 
-// RSAPSS represents RSA PSS algo for signing/verification
+// rsaPSS represents RSA PSS algo for signing/verification
 // (with SHA256 as digest calculation function).
 //
 // The encoding of produced signatures and the encodings accepted on
 // verification are controlled by the Mode (see ModeAuto, ModeHex, ModeBin). By
 // default (ModeAuto) signatures are emitted as raw bytes and Verify accepts a
 // signature in either raw or hex form.
-type RSAPSS struct {
+type rsaPSS struct {
 	publicKey  rsa.PublicKey
 	privateKey rsa.PrivateKey
 	hash       crypto.Hash
@@ -37,10 +37,10 @@ type RSAPSS struct {
 	mode       Mode
 }
 
-// NewRSAPSS creates new RSAPSS object that can both sign and verify.
+// NewRSAPSS creates new rsaPSS object that can both sign and verify.
 // The public key is derived from the private key.
 func NewRSAPSS(privKey rsa.PrivateKey, opts ...Option) SignerVerifier {
-	return RSAPSS{
+	return rsaPSS{
 		publicKey:  privKey.PublicKey,
 		privateKey: privKey,
 		hash:       crypto.SHA256,
@@ -49,9 +49,9 @@ func NewRSAPSS(privKey rsa.PrivateKey, opts ...Option) SignerVerifier {
 	}
 }
 
-// NewRSAPSSVerifier creates new RSAPSS object that can only verify signatures.
+// NewRSAPSSVerifier creates new rsaPSS object that can only verify signatures.
 func NewRSAPSSVerifier(pubKey rsa.PublicKey, opts ...Option) Verifier {
-	return RSAPSS{
+	return rsaPSS{
 		publicKey:  pubKey,
 		privateKey: zero[rsa.PrivateKey](),
 		hash:       crypto.SHA256,
@@ -61,14 +61,14 @@ func NewRSAPSSVerifier(pubKey rsa.PublicKey, opts ...Option) Verifier {
 }
 
 // Name implements SignerVerifier interface.
-func (r RSAPSS) Name() string {
+func (r rsaPSS) Name() string {
 	return AlgoRSAPSS
 }
 
 // Sign generates SHA-256 digest and signs it using RSASSA-PSS. The returned
 // signature is encoded according to the signer's Mode (raw bytes for ModeAuto
 // and ModeBin, hex for ModeHex).
-func (r RSAPSS) Sign(data []byte) ([]byte, error) {
+func (r rsaPSS) Sign(data []byte) ([]byte, error) {
 	if r.privateKey.N == nil {
 		return nil, ErrEmptyPrivateKey
 	}
@@ -92,7 +92,7 @@ func (r RSAPSS) Sign(data []byte) ([]byte, error) {
 // Verify compares data with signature. The accepted signature encoding depends
 // on the verifier's Mode: ModeHex expects hex, ModeBin expects raw bytes and
 // ModeAuto accepts either.
-func (r RSAPSS) Verify(data []byte, signature []byte) error {
+func (r rsaPSS) Verify(data []byte, signature []byte) error {
 	sig, err := r.decode(signature)
 	if err != nil {
 		return err
@@ -116,7 +116,7 @@ func (r RSAPSS) Verify(data []byte, signature []byte) error {
 
 // sigBytes is the raw RSA-PSS signature length in bytes for the configured key,
 // or 0 when no public modulus is set (verification will fail downstream).
-func (r RSAPSS) sigBytes() int {
+func (r rsaPSS) sigBytes() int {
 	if r.publicKey.N == nil {
 		return 0
 	}
@@ -126,7 +126,7 @@ func (r RSAPSS) sigBytes() int {
 
 // encode encodes the signature according to the receiver's Mode: hex for
 // ModeHex, raw bytes for ModeAuto and ModeBin.
-func (r RSAPSS) encode(sig []byte) []byte {
+func (r rsaPSS) encode(sig []byte) []byte {
 	if r.mode != ModeHex {
 		return sig
 	}
@@ -141,7 +141,7 @@ func (r RSAPSS) encode(sig []byte) []byte {
 // returns the bytes unchanged, ModeHex hex-decodes them, and ModeAuto detects
 // the encoding from the length: a raw signature is exactly sigBytes long, its
 // hex form exactly twice that.
-func (r RSAPSS) decode(sig []byte) ([]byte, error) {
+func (r rsaPSS) decode(sig []byte) ([]byte, error) {
 	if r.mode == ModeBin {
 		return sig, nil
 	}

--- a/driver/dummy/dummy.go
+++ b/driver/dummy/dummy.go
@@ -39,6 +39,9 @@ type dummyStorage struct {
 // suitable for testing and demonstration purposes.
 type Driver struct {
 	data dummyStorage
+	// lockRegistry maps lock names to shared entries, scoped to this Driver
+	// instance so independent drivers do not share a lock namespace.
+	lockRegistry *sync.Map
 }
 
 // New creates a new in-memory dummy driver instance.
@@ -51,6 +54,7 @@ func New() *Driver {
 			modRevision:      1,
 			mu:               sync.RWMutex{},
 		},
+		lockRegistry: &sync.Map{},
 	}
 }
 

--- a/driver/dummy/locker.go
+++ b/driver/dummy/locker.go
@@ -42,6 +42,11 @@ var closedDone = func() chan struct{} {
 var _ locker.Locker = (*dummyLocker)(nil)
 
 func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
+	err := locker.ValidateName(name)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // ValidateName returns a complete, locker-prefixed error.
+	}
+
 	_ = locker.ApplyOptions(opts)
 
 	return &dummyLocker{ //nolint:exhaustruct // mu/held/key are zero-initialized by design.

--- a/driver/dummy/locker.go
+++ b/driver/dummy/locker.go
@@ -12,11 +12,8 @@ type dummyLockEntry struct {
 	mu sync.Mutex
 }
 
-//nolint:gochecknoglobals // package-wide registry maps lock names to shared entries.
-var dummyLockRegistry sync.Map // name -> *dummyLockEntry.
-
-func lockEntryFor(name string) *dummyLockEntry {
-	v, _ := dummyLockRegistry.LoadOrStore(name, &dummyLockEntry{}) //nolint:exhaustruct
+func (d *Driver) lockEntryFor(name string) *dummyLockEntry {
+	v, _ := d.lockRegistry.LoadOrStore(name, &dummyLockEntry{}) //nolint:exhaustruct
 	entry, _ := v.(*dummyLockEntry)
 
 	return entry
@@ -48,7 +45,7 @@ func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Opti
 	_ = locker.ApplyOptions(opts)
 
 	return &dummyLocker{ //nolint:exhaustruct // mu/held/key are zero-initialized by design.
-		entry:   lockEntryFor(name),
+		entry:   d.lockEntryFor(name),
 		lifeCtx: ctx,
 		name:    name,
 	}, nil

--- a/driver/dummy/locker_test.go
+++ b/driver/dummy/locker_test.go
@@ -174,6 +174,41 @@ func TestDummyLocker_TwoLockers_SameName_Contend(t *testing.T) {
 	require.NoError(t, lockB.Unlock(ctx))
 }
 
+func TestDummyLocker_TwoDrivers_SameName_DoNotContend(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+
+	// Two independent drivers must not share a lock namespace: a lock held on
+	// one instance must not block the same name acquired on another.
+	driverA := dummy.New()
+	driverB := dummy.New()
+
+	lockA, err := driverA.NewLocker(ctx, "shared-name")
+	require.NoError(t, err)
+
+	lockB, err := driverB.NewLocker(ctx, "shared-name")
+	require.NoError(t, err)
+
+	require.NoError(t, lockA.Lock(ctx))
+
+	lockDone := make(chan error, 1)
+
+	go func() {
+		lockDone <- lockB.Lock(ctx)
+	}()
+
+	select {
+	case err := <-lockDone:
+		require.NoError(t, err)
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("lockB.Lock timed out though it is on a separate driver instance")
+	}
+
+	require.NoError(t, lockA.Unlock(ctx))
+	require.NoError(t, lockB.Unlock(ctx))
+}
+
 func TestDummyLocker_TwoLockers_DifferentNames_DoNotContend(t *testing.T) {
 	t.Parallel()
 

--- a/driver/dummy/locker_test.go
+++ b/driver/dummy/locker_test.go
@@ -28,14 +28,14 @@ func newLocker(t *testing.T, name string) locker.Locker {
 func TestDummyLocker_LockUnlock_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "test-lock")
+	lock := newLocker(t, "/test-lock")
 
 	assert.Empty(t, lock.Key())
 
 	err := lock.Lock(context.Background())
 	require.NoError(t, err)
 
-	assert.Equal(t, "test-lock", lock.Key())
+	assert.Equal(t, "/test-lock", lock.Key())
 
 	err = lock.Unlock(context.Background())
 	require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestDummyLocker_LockUnlock_HappyPath(t *testing.T) {
 func TestDummyLocker_ReLock_IsNoOp(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "relock-test")
+	lock := newLocker(t, "/relock-test")
 
 	err := lock.Lock(context.Background())
 	require.NoError(t, err)
@@ -64,10 +64,10 @@ func TestDummyLocker_TryLock_Contended(t *testing.T) {
 	ctx := context.Background()
 	d := dummy.New()
 
-	lockA, err := d.NewLocker(ctx, "trylock-contend")
+	lockA, err := d.NewLocker(ctx, "/trylock-contend")
 	require.NoError(t, err)
 
-	lockB, err := d.NewLocker(ctx, "trylock-contend")
+	lockB, err := d.NewLocker(ctx, "/trylock-contend")
 	require.NoError(t, err)
 
 	require.NoError(t, lockA.Lock(ctx))
@@ -81,11 +81,11 @@ func TestDummyLocker_TryLock_Contended(t *testing.T) {
 func TestDummyLocker_TryLock_Free(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "trylock-free")
+	lock := newLocker(t, "/trylock-free")
 
 	err := lock.TryLock(context.Background())
 	require.NoError(t, err)
-	assert.Equal(t, "trylock-free", lock.Key())
+	assert.Equal(t, "/trylock-free", lock.Key())
 
 	require.NoError(t, lock.Unlock(context.Background()))
 }
@@ -93,7 +93,7 @@ func TestDummyLocker_TryLock_Free(t *testing.T) {
 func TestDummyLocker_TryLock_AlreadyHeld(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "trylock-held")
+	lock := newLocker(t, "/trylock-held")
 
 	require.NoError(t, lock.Lock(context.Background()))
 	require.NoError(t, lock.TryLock(context.Background()))
@@ -103,7 +103,7 @@ func TestDummyLocker_TryLock_AlreadyHeld(t *testing.T) {
 func TestDummyLocker_DoubleUnlock(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "double-unlock")
+	lock := newLocker(t, "/double-unlock")
 
 	require.NoError(t, lock.Lock(context.Background()))
 	require.NoError(t, lock.Unlock(context.Background()))
@@ -115,7 +115,7 @@ func TestDummyLocker_DoubleUnlock(t *testing.T) {
 func TestDummyLocker_Unlock_NeverLocked(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "never-locked")
+	lock := newLocker(t, "/never-locked")
 
 	err := lock.Unlock(context.Background())
 	require.ErrorIs(t, err, locker.ErrLockReleased)
@@ -127,11 +127,11 @@ func TestDummyLocker_Lock_CtxCancellation(t *testing.T) {
 	ctx := context.Background()
 	driver := dummy.New()
 
-	lockA, err := driver.NewLocker(ctx, "ctx-cancel")
+	lockA, err := driver.NewLocker(ctx, "/ctx-cancel")
 	require.NoError(t, err)
 	require.NoError(t, lockA.Lock(ctx))
 
-	lockB, err := driver.NewLocker(ctx, "ctx-cancel")
+	lockB, err := driver.NewLocker(ctx, "/ctx-cancel")
 	require.NoError(t, err)
 
 	callCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
@@ -157,10 +157,10 @@ func TestDummyLocker_TwoLockers_SameName_Contend(t *testing.T) {
 	ctx := context.Background()
 	driver := dummy.New()
 
-	lockA, err := driver.NewLocker(ctx, "shared-name")
+	lockA, err := driver.NewLocker(ctx, "/shared-name")
 	require.NoError(t, err)
 
-	lockB, err := driver.NewLocker(ctx, "shared-name")
+	lockB, err := driver.NewLocker(ctx, "/shared-name")
 	require.NoError(t, err)
 
 	require.NoError(t, lockA.Lock(ctx))
@@ -184,10 +184,10 @@ func TestDummyLocker_TwoDrivers_SameName_DoNotContend(t *testing.T) {
 	driverA := dummy.New()
 	driverB := dummy.New()
 
-	lockA, err := driverA.NewLocker(ctx, "shared-name")
+	lockA, err := driverA.NewLocker(ctx, "/shared-name")
 	require.NoError(t, err)
 
-	lockB, err := driverB.NewLocker(ctx, "shared-name")
+	lockB, err := driverB.NewLocker(ctx, "/shared-name")
 	require.NoError(t, err)
 
 	require.NoError(t, lockA.Lock(ctx))
@@ -215,10 +215,10 @@ func TestDummyLocker_TwoLockers_DifferentNames_DoNotContend(t *testing.T) {
 	ctx := context.Background()
 	driver := dummy.New()
 
-	lockA, err := driver.NewLocker(ctx, "name-a")
+	lockA, err := driver.NewLocker(ctx, "/name-a")
 	require.NoError(t, err)
 
-	lockB, err := driver.NewLocker(ctx, "name-b")
+	lockB, err := driver.NewLocker(ctx, "/name-b")
 	require.NoError(t, err)
 
 	require.NoError(t, lockA.Lock(ctx))
@@ -243,7 +243,7 @@ func TestDummyLocker_TwoLockers_DifferentNames_DoNotContend(t *testing.T) {
 func TestDummyLocker_Done_NeverLocked_IsClosed(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "done-never")
+	lock := newLocker(t, "/done-never")
 
 	select {
 	case <-lock.Done():
@@ -255,7 +255,7 @@ func TestDummyLocker_Done_NeverLocked_IsClosed(t *testing.T) {
 func TestDummyLocker_Done_WhileHeld_IsOpen(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "done-held")
+	lock := newLocker(t, "/done-held")
 	require.NoError(t, lock.Lock(context.Background()))
 
 	t.Cleanup(func() { _ = lock.Unlock(context.Background()) })
@@ -270,7 +270,7 @@ func TestDummyLocker_Done_WhileHeld_IsOpen(t *testing.T) {
 func TestDummyLocker_Done_ClosedAfterUnlock(t *testing.T) {
 	t.Parallel()
 
-	lock := newLocker(t, "done-unlock")
+	lock := newLocker(t, "/done-unlock")
 	require.NoError(t, lock.Lock(context.Background()))
 
 	done := lock.Done()
@@ -290,12 +290,12 @@ func TestDummyLocker_LifeCtxCancellation_AbortsBlockingLock(t *testing.T) {
 	driver := dummy.New()
 
 	holderCtx := context.Background()
-	lockA, err := driver.NewLocker(holderCtx, "life-ctx-test")
+	lockA, err := driver.NewLocker(holderCtx, "/life-ctx-test")
 	require.NoError(t, err)
 	require.NoError(t, lockA.Lock(holderCtx))
 
 	lifeCtx, cancelLife := context.WithCancel(ctx)
-	lockB, err := driver.NewLocker(lifeCtx, "life-ctx-test")
+	lockB, err := driver.NewLocker(lifeCtx, "/life-ctx-test")
 	require.NoError(t, err)
 
 	var (

--- a/driver/etcd/etcd.go
+++ b/driver/etcd/etcd.go
@@ -33,6 +33,11 @@ type Client interface {
 // It uses etcd as the underlying key-value storage backend.
 type Driver struct {
 	client Client
+	// lockClient is the concrete client used for locking. It is nil for drivers
+	// built with New (locking unsupported) and set by NewWithLocker. The
+	// concurrency package requires the concrete *etcd.Client type, which the
+	// Client interface cannot express.
+	lockClient *etcd.Client
 }
 
 var (
@@ -50,13 +55,23 @@ var (
 // New creates a new etcd driver instance using an existing etcd client.
 // The client should be properly configured and connected to an etcd cluster.
 //
-// NewLocker is only supported when client is a concrete *etcd.Client — the
-// concurrency package needs the concrete type which the Client interface does
-// not expose. Drivers built from a non-concrete Client return
-// locker.ErrUnsupported from NewLocker.
+// Drivers built with New do not support locking: NewLocker returns
+// locker.ErrUnsupported. Use NewWithLocker when locking is required.
 func New(client Client) *Driver {
 	return &Driver{
-		client: client,
+		client:     client,
+		lockClient: nil, // locking unsupported; see NewWithLocker.
+	}
+}
+
+// NewWithLocker creates a new etcd driver instance that supports locking.
+// It takes a concrete *etcd.Client because the underlying concurrency package
+// requires the concrete type. The same client backs key/value, watch and
+// transaction operations.
+func NewWithLocker(client *etcd.Client) *Driver {
+	return &Driver{
+		client:     client,
+		lockClient: client,
 	}
 }
 

--- a/driver/etcd/etcd.go
+++ b/driver/etcd/etcd.go
@@ -62,7 +62,7 @@ func New(client Client) *Driver {
 
 // Execute executes a transactional operation with conditional logic.
 // It processes predicates to determine whether to execute thenOps or elseOps.
-func (d Driver) Execute(
+func (d *Driver) Execute(
 	ctx context.Context,
 	predicates []predicate.Predicate,
 	thenOps []operation.Operation,
@@ -105,7 +105,7 @@ const (
 
 // Watch monitors changes to a specific key and returns a stream of events.
 // event.Key is the watched key with any trailing "/" stripped.
-func (d Driver) Watch(ctx context.Context, key []byte) (<-chan watch.Event, func(), error) {
+func (d *Driver) Watch(ctx context.Context, key []byte) (<-chan watch.Event, func(), error) {
 	eventCh := make(chan watch.Event, eventChannelSize)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/driver/etcd/examples_test.go
+++ b/driver/etcd/examples_test.go
@@ -63,7 +63,9 @@ func createEtcdDriver(tb testing.TB) (*etcd.Driver, func()) {
 
 	tb.Cleanup(func() { _ = client.Close() })
 
-	driver := etcd.New(client)
+	// NewWithLocker so the locker example can acquire locks; KV/watch/tx
+	// examples work the same on a locker-capable driver.
+	driver := etcd.NewWithLocker(client)
 
 	return driver, func() {}
 }

--- a/driver/etcd/locker.go
+++ b/driver/etcd/locker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	etcd "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 
 	"github.com/tarantool/go-storage/v2/locker"
@@ -32,19 +31,19 @@ var closedDone = func() chan struct{} {
 
 var _ locker.Locker = (*etcdLocker)(nil)
 
-// NewLocker returns locker.ErrUnsupported when the Driver was built with a
-// Client that is not a concrete *etcd.Client — the concurrency package needs
-// the concrete type which the Client interface does not expose.
+// NewLocker returns locker.ErrUnsupported unless the Driver was built with
+// NewWithLocker: the concurrency package needs the concrete *etcd.Client, which
+// the Client interface cannot express, so locking support is a construction-time
+// choice rather than a runtime type assertion.
 func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
-	concrete, ok := d.client.(*etcd.Client)
-	if !ok {
+	if d.lockClient == nil {
 		return nil, locker.ErrUnsupported
 	}
 
 	options := locker.ApplyOptions(opts)
 
 	session, err := concurrency.NewSession(
-		concrete,
+		d.lockClient,
 		concurrency.WithTTL(int(options.TTL.Seconds())),
 		concurrency.WithContext(ctx),
 	)

--- a/driver/etcd/locker.go
+++ b/driver/etcd/locker.go
@@ -35,7 +35,7 @@ var _ locker.Locker = (*etcdLocker)(nil)
 // NewLocker returns locker.ErrUnsupported when the Driver was built with a
 // Client that is not a concrete *etcd.Client — the concurrency package needs
 // the concrete type which the Client interface does not expose.
-func (d Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
+func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
 	concrete, ok := d.client.(*etcd.Client)
 	if !ok {
 		return nil, locker.ErrUnsupported

--- a/driver/etcd/locker.go
+++ b/driver/etcd/locker.go
@@ -36,6 +36,11 @@ var _ locker.Locker = (*etcdLocker)(nil)
 // the Client interface cannot express, so locking support is a construction-time
 // choice rather than a runtime type assertion.
 func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
+	err := locker.ValidateName(name)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // ValidateName returns a complete, locker-prefixed error.
+	}
+
 	if d.lockClient == nil {
 		return nil, locker.ErrUnsupported
 	}

--- a/driver/etcd/locker_test.go
+++ b/driver/etcd/locker_test.go
@@ -68,7 +68,7 @@ func createTestDriverConcrete(t *testing.T) (*etcddriver.Driver, *etcdclient.Cli
 	require.NoError(t, err, "failed to create etcd client")
 	t.Cleanup(func() { _ = client.Close() })
 
-	return etcddriver.New(client), client
+	return etcddriver.NewWithLocker(client), client
 }
 
 func createSecondClient(t *testing.T, endpoints []string) *etcdclient.Client {
@@ -150,7 +150,7 @@ func TestLocker_Contention(t *testing.T) {
 	driverA, clientA := createTestDriverConcrete(t)
 	endpoints := clientA.Endpoints()
 	clientB := createSecondClient(t, endpoints)
-	driverB := etcddriver.New(clientB)
+	driverB := etcddriver.NewWithLocker(clientB)
 
 	// Outer timeout is generous (3x per-op timeout) because the test does
 	// several Lock/Unlock round-trips and an internal time.After wait of
@@ -196,7 +196,7 @@ func TestLocker_TryLock_Contended(t *testing.T) {
 	driverA, clientA := createTestDriverConcrete(t)
 	endpoints := clientA.Endpoints()
 	clientB := createSecondClient(t, endpoints)
-	driverB := etcddriver.New(clientB)
+	driverB := etcddriver.NewWithLocker(clientB)
 
 	ctx, cancel := context.WithTimeout(t.Context(), lockerTestTimeout)
 	t.Cleanup(cancel)
@@ -221,7 +221,7 @@ func TestLocker_CtxCancellation_AbortsLock(t *testing.T) {
 	driverA, clientA := createTestDriverConcrete(t)
 	endpoints := clientA.Endpoints()
 	clientB := createSecondClient(t, endpoints)
-	driverB := etcddriver.New(clientB)
+	driverB := etcddriver.NewWithLocker(clientB)
 
 	// 3x per-op timeout to cover several Lock/Unlock round-trips plus an
 	// internal time.After(lockerTestTimeout) wait for the C locker.
@@ -252,7 +252,7 @@ func TestLocker_CtxCancellation_AbortsLock(t *testing.T) {
 	require.NoError(t, lockA.Unlock(ctx))
 
 	clientC := createSecondClient(t, endpoints)
-	driverC := etcddriver.New(clientC)
+	driverC := etcddriver.NewWithLocker(clientC)
 
 	lockC, err := driverC.NewLocker(ctx, lockName)
 	require.NoError(t, err)
@@ -323,9 +323,11 @@ func TestLocker_Done_ClosedAfterUnlock(t *testing.T) {
 	}
 }
 
-func TestLocker_NewLockerOnNonConcreteClient_ReturnsErrUnsupported(t *testing.T) {
+func TestLocker_NewLockerWithoutLockSupport_ReturnsErrUnsupported(t *testing.T) {
 	mc := minimock.NewController(t)
 
+	// A driver built with New (rather than NewWithLocker) does not support
+	// locking regardless of the client type.
 	client := mocks.NewEtcdClientMock(mc)
 	driver := etcddriver.New(client)
 

--- a/driver/tcs/integration_test.go
+++ b/driver/tcs/integration_test.go
@@ -74,7 +74,7 @@ func createTestDriver(ctx context.Context, t *testing.T) (*tcs.Driver, func()) {
 	conn, err := pool.New(ctx, instances)
 	require.NoError(t, err, "Failed to connect to Tarantool pool")
 
-	// Wrap the pool connection to implement DoerWatcher.
+	// Wrap the pool connection to implement Client.
 	wrapper := pool.NewConnectorAdapter(conn, pool.ModeRW)
 
 	return tcs.New(wrapper), func() { _ = wrapper.Close() }

--- a/driver/tcs/locker.go
+++ b/driver/tcs/locker.go
@@ -58,7 +58,7 @@ var _ locker.Locker = (*tcsLocker)(nil)
 //
 // Returns ErrUnsupportedFeatures if the TCS server does not advertise
 // features.ttl and features.keepalive.
-func (d Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
+func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
 	if !strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") {
 		return nil, errInvalidLockerName
 	}

--- a/driver/tcs/locker.go
+++ b/driver/tcs/locker.go
@@ -28,7 +28,7 @@ var (
 // at ttl/3 cadence, which assumes replication_synchro_timeout + RTT < ttl/3
 // on a healthy cluster.
 type tcsLocker struct {
-	conn   DoerWatcher
+	conn   Client
 	name   string
 	ttlSec int
 	//nolint:containedctx // lifeCtx scopes the locker; cancellation aborts a blocking Lock.

--- a/driver/tcs/locker.go
+++ b/driver/tcs/locker.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -15,13 +14,9 @@ import (
 	"github.com/tarantool/go-storage/v2/locker"
 )
 
-var (
-	errInvalidLockerName = errors.New("tcs locker: name must start with '/' and must not end with '/'")
-
-	// ErrUnsupportedFeatures is returned by NewLocker when the TCS instance does
-	// not advertise both the ttl and keepalive features required by the locker.
-	ErrUnsupportedFeatures = errors.New("tcs locker: server does not support ttl+keepalive — schema upgrade required")
-)
+// ErrUnsupportedFeatures is returned by NewLocker when the TCS instance does
+// not advertise both the ttl and keepalive features required by the locker.
+var ErrUnsupportedFeatures = errors.New("tcs locker: server does not support ttl+keepalive — schema upgrade required")
 
 // tcsLocker implements "smallest mod_revision wins" locking over the prefix
 // `name + "/"`. Each attempt writes a unique ephemeral key with a TTL renewed
@@ -59,8 +54,9 @@ var _ locker.Locker = (*tcsLocker)(nil)
 // Returns ErrUnsupportedFeatures if the TCS server does not advertise
 // features.ttl and features.keepalive.
 func (d *Driver) NewLocker(ctx context.Context, name string, opts ...locker.Option) (locker.Locker, error) {
-	if !strings.HasPrefix(name, "/") || strings.HasSuffix(name, "/") {
-		return nil, errInvalidLockerName
+	err := locker.ValidateName(name)
+	if err != nil {
+		return nil, err //nolint:wrapcheck // ValidateName returns a complete, locker-prefixed error.
 	}
 
 	hasTTL, hasKeepalive, err := infoFeatures(ctx, d.conn)

--- a/driver/tcs/locker_calls.go
+++ b/driver/tcs/locker_calls.go
@@ -17,7 +17,7 @@ type lockEntry struct {
 // assigned to the write — the same value reappears as mod_revision in
 // config.storage.get results, providing the ordering for "smallest revision
 // wins".
-func putWithTTL(ctx context.Context, conn DoerWatcher, path, value string, ttlSec int) (int64, error) {
+func putWithTTL(ctx context.Context, conn Client, path, value string, ttlSec int) (int64, error) {
 	req := tarantool.NewCallRequest("config.storage.put").
 		Args([]any{path, value, map[string]any{"ttl": ttlSec}}).
 		Context(ctx)
@@ -40,7 +40,7 @@ func putWithTTL(ctx context.Context, conn DoerWatcher, path, value string, ttlSe
 	return result[0].Revision, nil
 }
 
-func keepalivePath(ctx context.Context, conn DoerWatcher, path string, ttlSec int) error {
+func keepalivePath(ctx context.Context, conn Client, path string, ttlSec int) error {
 	req := tarantool.NewCallRequest("config.storage.keepalive").
 		Args([]any{path, ttlSec}).
 		Context(ctx)
@@ -58,7 +58,7 @@ func keepalivePath(ctx context.Context, conn DoerWatcher, path string, ttlSec in
 // getPrefix returns entries under prefix. Response shape:
 //
 //	[ { data: [ {path, value, mod_revision}, ... ], revision: N } ]
-func getPrefix(ctx context.Context, conn DoerWatcher, prefix string) ([]lockEntry, error) {
+func getPrefix(ctx context.Context, conn Client, prefix string) ([]lockEntry, error) {
 	req := tarantool.NewCallRequest("config.storage.get").
 		Args([]any{prefix}).
 		Context(ctx)
@@ -93,7 +93,7 @@ func getPrefix(ctx context.Context, conn DoerWatcher, prefix string) ([]lockEntr
 	return entries, nil
 }
 
-func deletePath(ctx context.Context, conn DoerWatcher, path string) error {
+func deletePath(ctx context.Context, conn Client, path string) error {
 	req := tarantool.NewCallRequest("config.storage.delete").
 		Args([]any{path}).
 		Context(ctx)
@@ -110,7 +110,7 @@ func deletePath(ctx context.Context, conn DoerWatcher, path string) error {
 
 // infoFeatures reports whether the server exposes the ttl and keepalive
 // features required by the locker.
-func infoFeatures(ctx context.Context, conn DoerWatcher) (bool, bool, error) {
+func infoFeatures(ctx context.Context, conn Client) (bool, bool, error) {
 	req := tarantool.NewCallRequest("config.storage.info").
 		Args([]any{}).
 		Context(ctx)

--- a/driver/tcs/operations.go
+++ b/driver/tcs/operations.go
@@ -11,7 +11,7 @@ import (
 // Error definitions for err113 compliance.
 var (
 	// ErrUnknownOperation is returned when the operation is unknown.
-	ErrUnknownOperation = errors.New("unknown operation")
+	ErrUnknownOperation = errors.New("tcs: unknown operation")
 )
 
 const (

--- a/driver/tcs/predicate.go
+++ b/driver/tcs/predicate.go
@@ -10,9 +10,9 @@ import (
 
 var (
 	// ErrUnknownOperator is returned when the operator is unknown.
-	ErrUnknownOperator = errors.New("unknown operator")
+	ErrUnknownOperator = errors.New("tcs: unknown operator")
 	// ErrUnknownTarget is returned when the target is unknown.
-	ErrUnknownTarget = errors.New("unknown target")
+	ErrUnknownTarget = errors.New("tcs: unknown target")
 
 	_ msgpack.CustomEncoder = predicate{Predicate: nil}
 

--- a/driver/tcs/tcs.go
+++ b/driver/tcs/tcs.go
@@ -20,9 +20,10 @@ import (
 
 const watchEventChannelSize = 16
 
-// DoerWatcher is an interface that combines tarantool.Doer and NewWatcher method.
+// Client is the minimal connection capability the tcs driver needs: a Doer to
+// issue requests and a NewWatcher to subscribe to changes.
 // tarantool.Connection and pool.ConnectionAdapter implement this interface.
-type DoerWatcher interface {
+type Client interface {
 	Do(req tarantool.Request) (fut tarantool.Future)
 	NewWatcher(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error)
 }
@@ -30,7 +31,7 @@ type DoerWatcher interface {
 // Driver is a Tarantool implementation of the storage driver interface.
 // It uses TCS as the underlying key-value storage backend.
 type Driver struct {
-	conn DoerWatcher // Tarantool connection pool.
+	conn Client // Tarantool connection pool.
 }
 
 var (
@@ -42,8 +43,8 @@ var (
 
 // New creates a new Tarantool driver instance.
 // It establishes connections to Tarantool instances using the provided addresses.
-func New(doer DoerWatcher) *Driver {
-	return &Driver{conn: doer}
+func New(client Client) *Driver {
+	return &Driver{conn: client}
 }
 
 // Execute executes a transactional operation with conditional logic.

--- a/driver/tcs/tcs.go
+++ b/driver/tcs/tcs.go
@@ -48,7 +48,7 @@ func New(doer DoerWatcher) *Driver {
 
 // Execute executes a transactional operation with conditional logic.
 // It processes predicates to determine whether to execute thenOps or elseOps.
-func (d Driver) Execute(
+func (d *Driver) Execute(
 	ctx context.Context,
 	predicates []goPredicate.Predicate,
 	thenOps []goOperation.Operation,
@@ -73,7 +73,7 @@ func (d Driver) Execute(
 
 // Watch monitors changes to a specific key and returns a stream of events.
 // event.Key is the watched key with any trailing "/" stripped.
-func (d Driver) Watch(ctx context.Context, key []byte) (<-chan watch.Event, func(), error) {
+func (d *Driver) Watch(ctx context.Context, key []byte) (<-chan watch.Event, func(), error) {
 	rvChan := make(chan watch.Event, watchEventChannelSize)
 
 	emitted := bytes.TrimSuffix(key, []byte("/"))

--- a/driver/tcs/tcs.go
+++ b/driver/tcs/tcs.go
@@ -37,7 +37,7 @@ var (
 	_ driver.Driver = &Driver{} //nolint:exhaustruct
 
 	// ErrUnexpectedResponse is returned when the response from tarantool has unexpected format.
-	ErrUnexpectedResponse = errors.New("unexpected response from tarantool")
+	ErrUnexpectedResponse = errors.New("tcs: unexpected response from tarantool")
 )
 
 // New creates a new Tarantool driver instance.

--- a/driver/tcs/tcs_test.go
+++ b/driver/tcs/tcs_test.go
@@ -28,7 +28,7 @@ const (
 func TestNew(t *testing.T) {
 	t.Parallel()
 
-	mockDoer := mocks.NewDoerWatcherMock(t)
+	mockDoer := mocks.NewTCSClientMock(t)
 	driver := tcs.New(mockDoer)
 
 	assert.NotNil(t, driver)
@@ -39,7 +39,7 @@ func TestDriver_Watch_WatcherSuccess(t *testing.T) {
 
 	mc := minimock.NewController(t)
 
-	mockDoer := mocks.NewDoerWatcherMock(mc)
+	mockDoer := mocks.NewTCSClientMock(mc)
 	watcher := mocks.NewWatcherMock(mc).UnregisterMock.Expect().Times(1).Return()
 
 	mockDoer.NewWatcherMock.Set(func(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error) {
@@ -72,7 +72,7 @@ func TestDriver_Watch_WatcherError(t *testing.T) {
 
 	var (
 		mc         = minimock.NewController(t)
-		mockDoer   = mocks.NewDoerWatcherMock(mc)
+		mockDoer   = mocks.NewTCSClientMock(mc)
 		watcherErr = errors.New("watcher creation failed")
 	)
 
@@ -102,7 +102,7 @@ func TestDriver_Watch_ContextCanceled_Before(t *testing.T) {
 
 	mc := minimock.NewController(t)
 
-	mockDoer := mocks.NewDoerWatcherMock(mc)
+	mockDoer := mocks.NewTCSClientMock(mc)
 	watcher := mocks.NewWatcherMock(mc).UnregisterMock.Expect().Times(1).Return()
 
 	mockDoer.NewWatcherMock.Set(func(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error) {
@@ -135,7 +135,7 @@ func TestDriver_Watch_ContextCanceled_After(t *testing.T) {
 
 	mc := minimock.NewController(t)
 
-	mockDoer := mocks.NewDoerWatcherMock(mc)
+	mockDoer := mocks.NewTCSClientMock(mc)
 	watcher := mocks.NewWatcherMock(mc).UnregisterMock.Expect().Times(1).Return()
 
 	mockDoer.NewWatcherMock.Set(func(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error) {
@@ -169,7 +169,7 @@ func TestDriver_Watch_CallbackOnceCalled(t *testing.T) {
 
 	mc := minimock.NewController(t)
 
-	mockDoer := mocks.NewDoerWatcherMock(mc)
+	mockDoer := mocks.NewTCSClientMock(mc)
 	watcher := mocks.NewWatcherMock(mc).UnregisterMock.Expect().Times(1).Return()
 
 	mockDoer.NewWatcherMock.Set(func(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error) {
@@ -213,7 +213,7 @@ func TestDriver_Watch_CallbackTwiceCalled(t *testing.T) {
 
 	mc := minimock.NewController(t)
 
-	mockDoer := mocks.NewDoerWatcherMock(mc)
+	mockDoer := mocks.NewTCSClientMock(mc)
 	watcher := mocks.NewWatcherMock(mc).UnregisterMock.Expect().Times(1).Return()
 
 	mockDoer.NewWatcherMock.Set(func(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error) {
@@ -271,7 +271,7 @@ func TestDriver_Watch_PrefixKeyStripsTrailingSlash(t *testing.T) {
 
 	mc := minimock.NewController(t)
 
-	mockDoer := mocks.NewDoerWatcherMock(mc)
+	mockDoer := mocks.NewTCSClientMock(mc)
 	watcher := mocks.NewWatcherMock(mc).UnregisterMock.Expect().Times(1).Return()
 
 	mockDoer.NewWatcherMock.Set(func(key string, callback tarantool.WatchCallback) (tarantool.Watcher, error) {

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -13,7 +13,7 @@ import (
 
 // ErrHashMismatch is returned by Verify when the stored digest does not match
 // any encoding of the computed digest accepted under the hasher's Mode.
-var ErrHashMismatch = errors.New("hash mismatch")
+var ErrHashMismatch = errors.New("hasher: hash mismatch")
 
 // Hasher is the interface that storage hashers must implement.
 // It provides low-level operations for hash calculating.

--- a/hasher/hasher.go
+++ b/hasher/hasher.go
@@ -15,6 +15,14 @@ import (
 // any encoding of the computed digest accepted under the hasher's Mode.
 var ErrHashMismatch = errors.New("hasher: hash mismatch")
 
+// Algorithm names returned by the built-in hashers' Name method. Use these with
+// integrity codec location options (e.g. WithHashLocation) instead of retyping
+// the bare string.
+const (
+	AlgoSHA256 = "sha256"
+	AlgoSHA1   = "sha1"
+)
+
 // Hasher is the interface that storage hashers must implement.
 // It provides low-level operations for hash calculating.
 //
@@ -52,7 +60,7 @@ func NewSHA256Hasher(opts ...Option) Hasher {
 
 // Name implements Hasher interface.
 func (h *sha256Hasher) Name() string {
-	return "sha256"
+	return AlgoSHA256
 }
 
 // Hash implements Hasher interface.
@@ -102,7 +110,7 @@ func NewSHA1Hasher(opts ...Option) Hasher {
 
 // Name implements Hasher interface.
 func (h *sha1Hasher) Name() string {
-	return "sha1"
+	return AlgoSHA1
 }
 
 // Hash implements Hasher interface.

--- a/integrity/error.go
+++ b/integrity/error.go
@@ -253,4 +253,4 @@ func (e *FailedToValidateAggregatedError) Finalize() error {
 
 // ErrInvalidName is returned for empty, leading-slash, or trailing-slash names.
 // Match it with errors.Is.
-var ErrInvalidName = errors.New("invalid name")
+var ErrInvalidName = errors.New("integrity: invalid name")

--- a/integrity/generator.go
+++ b/integrity/generator.go
@@ -92,7 +92,7 @@ func (g Generator[T]) Generate(name string, value T) ([]kv.KeyValue, error) {
 		results = append(results, kv.KeyValue{
 			Key:         []byte(key.Build()),
 			Value:       valueData,
-			ModRevision: ModRevisionEmpty,
+			ModRevision: modRevisionEmpty,
 		})
 	}
 

--- a/integrity/integration_test.go
+++ b/integrity/integration_test.go
@@ -174,7 +174,7 @@ func createTcsTestDriver(ctx context.Context, t *testing.T) (driver.Driver, func
 	conn, err := pool.New(ctx, instances)
 	require.NoError(t, err, "Failed to connect to Tarantool pool")
 
-	// Wrap the pool connection to implement DoerWatcher.
+	// Wrap the pool connection to implement Client.
 	wrapper := pool.NewConnectorAdapter(conn, pool.ModeRW)
 
 	return tcsdriver.New(wrapper), func() { _ = wrapper.Close() }

--- a/integrity/integrity.go
+++ b/integrity/integrity.go
@@ -115,12 +115,12 @@ func IgnoreMoreThanOneResult() GetOption {
 }
 
 var (
-	ErrNotFound                  = errors.New("not found")
-	ErrMoreThanOneResult         = errors.New("more than one result was returned")
-	ErrInvalidPredicateValueType = errors.New("invalid predicate value type")
-	ErrNoValueKey                = errors.New("no value key found in generated keys")
+	ErrNotFound                  = errors.New("integrity: not found")
+	ErrMoreThanOneResult         = errors.New("integrity: more than one result was returned")
+	ErrInvalidPredicateValueType = errors.New("integrity: invalid predicate value type")
+	ErrNoValueKey                = errors.New("integrity: no value key found in generated keys")
 	// ErrPredicateFailed is returned by Put or Delete when predicates are specified
 	// but the transaction predicate check fails (i.e., the conditions are not met).
 	// Use [WithPutPredicates] or [WithDeletePredicates] to specify predicates.
-	ErrPredicateFailed = errors.New("predicate check failed")
+	ErrPredicateFailed = errors.New("integrity: predicate check failed")
 )

--- a/integrity/integrity.go
+++ b/integrity/integrity.go
@@ -60,10 +60,21 @@ type deleteOptions struct {
 	Predicates []Predicate
 }
 
+// GetOption configures Get and Range operations (see [IgnoreVerificationError],
+// [IgnoreMoreThanOneResult]).
+type GetOption = options.OptionCallback[getOptions]
+
+// PutOption configures Put operations (see [WithPutPredicates]).
+type PutOption = options.OptionCallback[putOptions]
+
+// DeleteOption configures Delete operations (see [WithDeletePredicates],
+// [WithPrefix]).
+type DeleteOption = options.OptionCallback[deleteOptions]
+
 // WithPutPredicates configures predicates for conditional Put operations.
 // The Put operation will only succeed if all predicates evaluate to true.
 // If predicates are specified but fail, [ErrPredicateFailed] is returned.
-func WithPutPredicates(predicates ...Predicate) options.OptionCallback[putOptions] {
+func WithPutPredicates(predicates ...Predicate) PutOption {
 	return func(opts *putOptions) {
 		opts.Predicates = append(opts.Predicates, predicates...)
 	}
@@ -72,14 +83,14 @@ func WithPutPredicates(predicates ...Predicate) options.OptionCallback[putOption
 // WithDeletePredicates configures predicates for conditional Delete operations.
 // The Delete operation will only succeed if all predicates evaluate to true.
 // If predicates are specified but fail, [ErrPredicateFailed] is returned.
-func WithDeletePredicates(predicates ...Predicate) options.OptionCallback[deleteOptions] {
+func WithDeletePredicates(predicates ...Predicate) DeleteOption {
 	return func(opts *deleteOptions) {
 		opts.Predicates = append(opts.Predicates, predicates...)
 	}
 }
 
 // WithPrefix configures the ability to delete keys by a prefix.
-func WithPrefix() options.OptionCallback[deleteOptions] {
+func WithPrefix() DeleteOption {
 	return func(opts *deleteOptions) {
 		opts.withPrefix = true
 	}
@@ -88,7 +99,7 @@ func WithPrefix() options.OptionCallback[deleteOptions] {
 // IgnoreVerificationError returns an option that allows Get and Range operations
 // to return results even if hash or signature verification fails.
 // The returned result will still contain the Error field with verification details.
-func IgnoreVerificationError() options.OptionCallback[getOptions] {
+func IgnoreVerificationError() GetOption {
 	return func(opts *getOptions) {
 		opts.ignoreVerificationError = true
 	}
@@ -97,7 +108,7 @@ func IgnoreVerificationError() options.OptionCallback[getOptions] {
 // IgnoreMoreThanOneResult returns an option that allows Get operation
 // to succeed when multiple results are returned for a single name.
 // By default, Get returns ErrMoreThanOneResult in such cases.
-func IgnoreMoreThanOneResult() options.OptionCallback[getOptions] {
+func IgnoreMoreThanOneResult() GetOption {
 	return func(opts *getOptions) {
 		opts.ignoreMoreThanOneResult = true
 	}

--- a/integrity/store.go
+++ b/integrity/store.go
@@ -25,7 +25,7 @@ type Store[T any] struct {
 func (s *Store[T]) Get(
 	ctx context.Context,
 	name string,
-	opts ...options.OptionCallback[getOptions],
+	opts ...GetOption,
 ) (ValidatedResult[T], error) {
 	tx := NewTx(s.storage)
 	fut := s.codec.TxGet(tx, name, opts...)
@@ -45,7 +45,7 @@ func (s *Store[T]) Put(
 	ctx context.Context,
 	name string,
 	value T,
-	vOpts ...options.OptionCallback[putOptions],
+	vOpts ...PutOption,
 ) error {
 	opts := options.ApplyOptions[putOptions](nil, vOpts)
 
@@ -83,7 +83,7 @@ func (s *Store[T]) Put(
 func (s *Store[T]) Delete(
 	ctx context.Context,
 	name string,
-	vOpts ...options.OptionCallback[deleteOptions],
+	vOpts ...DeleteOption,
 ) error {
 	opts := options.ApplyOptions[deleteOptions](nil, vOpts)
 
@@ -119,7 +119,7 @@ func (s *Store[T]) Delete(
 func (s *Store[T]) Range(
 	ctx context.Context,
 	name string,
-	opts ...options.OptionCallback[getOptions],
+	opts ...GetOption,
 ) ([]ValidatedResult[T], error) {
 	tx := NewTx(s.storage)
 	fut := s.codec.TxRange(tx, name, opts...)

--- a/integrity/store_singleton.go
+++ b/integrity/store_singleton.go
@@ -3,7 +3,6 @@ package integrity
 import (
 	"context"
 
-	"github.com/tarantool/go-storage/v2/internal/options"
 	"github.com/tarantool/go-storage/v2/predicate"
 	"github.com/tarantool/go-storage/v2/watch"
 )
@@ -25,7 +24,7 @@ type SingletonStore[T any] struct {
 // Get reads the singleton's value and verifies its hashes/signatures.
 func (s *SingletonStore[T]) Get(
 	ctx context.Context,
-	opts ...options.OptionCallback[getOptions],
+	opts ...GetOption,
 ) (ValidatedResult[T], error) {
 	return s.store.Get(ctx, s.name, opts...)
 }
@@ -36,7 +35,7 @@ func (s *SingletonStore[T]) Get(
 func (s *SingletonStore[T]) Put(
 	ctx context.Context,
 	value T,
-	opts ...options.OptionCallback[putOptions],
+	opts ...PutOption,
 ) error {
 	return s.store.Put(ctx, s.name, value, opts...)
 }
@@ -46,7 +45,7 @@ func (s *SingletonStore[T]) Put(
 // is returned if any predicate fails.
 func (s *SingletonStore[T]) Delete(
 	ctx context.Context,
-	opts ...options.OptionCallback[deleteOptions],
+	opts ...DeleteOption,
 ) error {
 	return s.store.Delete(ctx, s.name, opts...)
 }
@@ -63,7 +62,7 @@ func (s *SingletonStore[T]) Watch(ctx context.Context) (<-chan watch.Event, erro
 // the name parameter — the bound name is used.
 func (s *SingletonStore[T]) TxGet(
 	b Branchable,
-	opts ...options.OptionCallback[getOptions],
+	opts ...GetOption,
 ) *GetFuture[T] {
 	return s.store.codec.TxGet(b, s.name, opts...)
 }
@@ -78,7 +77,7 @@ func (s *SingletonStore[T]) TxPut(b Branchable, value T) error {
 // Codec[T].TxDelete without the name parameter.
 func (s *SingletonStore[T]) TxDelete(
 	b Branchable,
-	opts ...options.OptionCallback[deleteOptions],
+	opts ...DeleteOption,
 ) error {
 	return s.store.codec.TxDelete(b, s.name, opts...)
 }

--- a/integrity/store_test.go
+++ b/integrity/store_test.go
@@ -300,7 +300,7 @@ func TestStore_Get_Success(t *testing.T) {
 	namedValue, err := store.Get(ctx, "my-object")
 	require.NoError(t, err)
 	assert.Equal(t, "my-object", namedValue.Name)
-	assert.Equal(t, int64(integrity.ModRevisionEmpty), namedValue.ModRevision)
+	assert.Equal(t, int64(0), namedValue.ModRevision)
 	assert.True(t, namedValue.Value.IsSome())
 
 	val, ok := namedValue.Value.Get()
@@ -1438,7 +1438,7 @@ func TestStore_Range_Success(t *testing.T) {
 
 	for _, result := range results {
 		require.NoError(t, result.Error)
-		require.Equal(t, int64(integrity.ModRevisionEmpty), result.ModRevision)
+		require.Equal(t, int64(0), result.ModRevision)
 		require.True(t, result.Value.IsSome())
 
 		val, ok := result.Value.Get()

--- a/integrity/tx.go
+++ b/integrity/tx.go
@@ -227,7 +227,7 @@ func (f *RangeFuture[T]) Result() ([]ValidatedResult[T], error) {
 func (c *Codec[T]) TxGet(
 	b Branchable,
 	name string,
-	opts ...options.OptionCallback[getOptions],
+	opts ...GetOption,
 ) *GetFuture[T] {
 	branch := b.branch()
 	txn := branch.parent
@@ -342,7 +342,7 @@ func (c *Codec[T]) TxPut(b Branchable, name string, value T) error {
 func (c *Codec[T]) TxDelete(
 	b Branchable,
 	name string,
-	opts ...options.OptionCallback[deleteOptions],
+	opts ...DeleteOption,
 ) error {
 	branch := b.branch()
 	txn := branch.parent
@@ -394,7 +394,7 @@ func (c *Codec[T]) TxDelete(
 func (c *Codec[T]) TxRange(
 	b Branchable,
 	name string,
-	opts ...options.OptionCallback[getOptions],
+	opts ...GetOption,
 ) *RangeFuture[T] {
 	branch := b.branch()
 	txn := branch.parent

--- a/integrity/validator.go
+++ b/integrity/validator.go
@@ -10,8 +10,8 @@ import (
 	"github.com/tarantool/go-storage/v2/namer"
 )
 
-// ModRevisionEmpty is used to initialize the ModRevision field by default.
-const ModRevisionEmpty = 0
+// modRevisionEmpty is used to initialize the ModRevision field by default.
+const modRevisionEmpty = 0
 
 // Validator verifies integrity-protected key-value pairs.
 type Validator[T any] struct {
@@ -100,7 +100,7 @@ func (v Validator[T]) validateSingle(name string, kvs []extendedKV) ValidatedRes
 	output := ValidatedResult[T]{
 		Name:        name,
 		Value:       option.None[T](),
-		ModRevision: ModRevisionEmpty,
+		ModRevision: modRevisionEmpty,
 		Error:       nil,
 	}
 

--- a/internal/mocks/doer_watcher.go
+++ b/internal/mocks/doer_watcher.go
@@ -1,3 +1,0 @@
-package mocks
-
-//go:generate go tool minimock -g -i github.com/tarantool/go-storage/v2/driver/tcs.DoerWatcher -s _mock.go

--- a/internal/mocks/tcs_client.go
+++ b/internal/mocks/tcs_client.go
@@ -1,0 +1,3 @@
+package mocks
+
+//go:generate go tool minimock -g -i github.com/tarantool/go-storage/v2/driver/tcs.Client -pr tcs_ -s _mock.go -n TCSClientMock

--- a/internal/mocks/tcs_client_mock.go
+++ b/internal/mocks/tcs_client_mock.go
@@ -11,8 +11,8 @@ import (
 	"github.com/tarantool/go-tarantool/v3"
 )
 
-// DoerWatcherMock implements mm_tcs.DoerWatcher
-type DoerWatcherMock struct {
+// TCSClientMock implements mm_tcs.Client
+type TCSClientMock struct {
 	t          minimock.Tester
 	finishOnce sync.Once
 
@@ -21,76 +21,76 @@ type DoerWatcherMock struct {
 	inspectFuncDo   func(req tarantool.Request)
 	afterDoCounter  uint64
 	beforeDoCounter uint64
-	DoMock          mDoerWatcherMockDo
+	DoMock          mTCSClientMockDo
 
 	funcNewWatcher          func(key string, callback tarantool.WatchCallback) (w1 tarantool.Watcher, err error)
 	funcNewWatcherOrigin    string
 	inspectFuncNewWatcher   func(key string, callback tarantool.WatchCallback)
 	afterNewWatcherCounter  uint64
 	beforeNewWatcherCounter uint64
-	NewWatcherMock          mDoerWatcherMockNewWatcher
+	NewWatcherMock          mTCSClientMockNewWatcher
 }
 
-// NewDoerWatcherMock returns a mock for mm_tcs.DoerWatcher
-func NewDoerWatcherMock(t minimock.Tester) *DoerWatcherMock {
-	m := &DoerWatcherMock{t: t}
+// NewTCSClientMock returns a mock for mm_tcs.Client
+func NewTCSClientMock(t minimock.Tester) *TCSClientMock {
+	m := &TCSClientMock{t: t}
 
 	if controller, ok := t.(minimock.MockController); ok {
 		controller.RegisterMocker(m)
 	}
 
-	m.DoMock = mDoerWatcherMockDo{mock: m}
-	m.DoMock.callArgs = []*DoerWatcherMockDoParams{}
+	m.DoMock = mTCSClientMockDo{mock: m}
+	m.DoMock.callArgs = []*TCSClientMockDoParams{}
 
-	m.NewWatcherMock = mDoerWatcherMockNewWatcher{mock: m}
-	m.NewWatcherMock.callArgs = []*DoerWatcherMockNewWatcherParams{}
+	m.NewWatcherMock = mTCSClientMockNewWatcher{mock: m}
+	m.NewWatcherMock.callArgs = []*TCSClientMockNewWatcherParams{}
 
 	t.Cleanup(m.MinimockFinish)
 
 	return m
 }
 
-type mDoerWatcherMockDo struct {
+type mTCSClientMockDo struct {
 	optional           bool
-	mock               *DoerWatcherMock
-	defaultExpectation *DoerWatcherMockDoExpectation
-	expectations       []*DoerWatcherMockDoExpectation
+	mock               *TCSClientMock
+	defaultExpectation *TCSClientMockDoExpectation
+	expectations       []*TCSClientMockDoExpectation
 
-	callArgs []*DoerWatcherMockDoParams
+	callArgs []*TCSClientMockDoParams
 	mutex    sync.RWMutex
 
 	expectedInvocations       uint64
 	expectedInvocationsOrigin string
 }
 
-// DoerWatcherMockDoExpectation specifies expectation struct of the DoerWatcher.Do
-type DoerWatcherMockDoExpectation struct {
-	mock               *DoerWatcherMock
-	params             *DoerWatcherMockDoParams
-	paramPtrs          *DoerWatcherMockDoParamPtrs
-	expectationOrigins DoerWatcherMockDoExpectationOrigins
-	results            *DoerWatcherMockDoResults
+// TCSClientMockDoExpectation specifies expectation struct of the Client.Do
+type TCSClientMockDoExpectation struct {
+	mock               *TCSClientMock
+	params             *TCSClientMockDoParams
+	paramPtrs          *TCSClientMockDoParamPtrs
+	expectationOrigins TCSClientMockDoExpectationOrigins
+	results            *TCSClientMockDoResults
 	returnOrigin       string
 	Counter            uint64
 }
 
-// DoerWatcherMockDoParams contains parameters of the DoerWatcher.Do
-type DoerWatcherMockDoParams struct {
+// TCSClientMockDoParams contains parameters of the Client.Do
+type TCSClientMockDoParams struct {
 	req tarantool.Request
 }
 
-// DoerWatcherMockDoParamPtrs contains pointers to parameters of the DoerWatcher.Do
-type DoerWatcherMockDoParamPtrs struct {
+// TCSClientMockDoParamPtrs contains pointers to parameters of the Client.Do
+type TCSClientMockDoParamPtrs struct {
 	req *tarantool.Request
 }
 
-// DoerWatcherMockDoResults contains results of the DoerWatcher.Do
-type DoerWatcherMockDoResults struct {
+// TCSClientMockDoResults contains results of the Client.Do
+type TCSClientMockDoResults struct {
 	fut tarantool.Future
 }
 
-// DoerWatcherMockDoOrigins contains origins of expectations of the DoerWatcher.Do
-type DoerWatcherMockDoExpectationOrigins struct {
+// TCSClientMockDoOrigins contains origins of expectations of the Client.Do
+type TCSClientMockDoExpectationOrigins struct {
 	origin    string
 	originReq string
 }
@@ -100,26 +100,26 @@ type DoerWatcherMockDoExpectationOrigins struct {
 // Optional() makes method check to work in '0 or more' mode.
 // It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
 // catch the problems when the expected method call is totally skipped during test run.
-func (mmDo *mDoerWatcherMockDo) Optional() *mDoerWatcherMockDo {
+func (mmDo *mTCSClientMockDo) Optional() *mTCSClientMockDo {
 	mmDo.optional = true
 	return mmDo
 }
 
-// Expect sets up expected params for DoerWatcher.Do
-func (mmDo *mDoerWatcherMockDo) Expect(req tarantool.Request) *mDoerWatcherMockDo {
+// Expect sets up expected params for Client.Do
+func (mmDo *mTCSClientMockDo) Expect(req tarantool.Request) *mTCSClientMockDo {
 	if mmDo.mock.funcDo != nil {
-		mmDo.mock.t.Fatalf("DoerWatcherMock.Do mock is already set by Set")
+		mmDo.mock.t.Fatalf("TCSClientMock.Do mock is already set by Set")
 	}
 
 	if mmDo.defaultExpectation == nil {
-		mmDo.defaultExpectation = &DoerWatcherMockDoExpectation{}
+		mmDo.defaultExpectation = &TCSClientMockDoExpectation{}
 	}
 
 	if mmDo.defaultExpectation.paramPtrs != nil {
-		mmDo.mock.t.Fatalf("DoerWatcherMock.Do mock is already set by ExpectParams functions")
+		mmDo.mock.t.Fatalf("TCSClientMock.Do mock is already set by ExpectParams functions")
 	}
 
-	mmDo.defaultExpectation.params = &DoerWatcherMockDoParams{req}
+	mmDo.defaultExpectation.params = &TCSClientMockDoParams{req}
 	mmDo.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
 	for _, e := range mmDo.expectations {
 		if minimock.Equal(e.params, mmDo.defaultExpectation.params) {
@@ -130,22 +130,22 @@ func (mmDo *mDoerWatcherMockDo) Expect(req tarantool.Request) *mDoerWatcherMockD
 	return mmDo
 }
 
-// ExpectReqParam1 sets up expected param req for DoerWatcher.Do
-func (mmDo *mDoerWatcherMockDo) ExpectReqParam1(req tarantool.Request) *mDoerWatcherMockDo {
+// ExpectReqParam1 sets up expected param req for Client.Do
+func (mmDo *mTCSClientMockDo) ExpectReqParam1(req tarantool.Request) *mTCSClientMockDo {
 	if mmDo.mock.funcDo != nil {
-		mmDo.mock.t.Fatalf("DoerWatcherMock.Do mock is already set by Set")
+		mmDo.mock.t.Fatalf("TCSClientMock.Do mock is already set by Set")
 	}
 
 	if mmDo.defaultExpectation == nil {
-		mmDo.defaultExpectation = &DoerWatcherMockDoExpectation{}
+		mmDo.defaultExpectation = &TCSClientMockDoExpectation{}
 	}
 
 	if mmDo.defaultExpectation.params != nil {
-		mmDo.mock.t.Fatalf("DoerWatcherMock.Do mock is already set by Expect")
+		mmDo.mock.t.Fatalf("TCSClientMock.Do mock is already set by Expect")
 	}
 
 	if mmDo.defaultExpectation.paramPtrs == nil {
-		mmDo.defaultExpectation.paramPtrs = &DoerWatcherMockDoParamPtrs{}
+		mmDo.defaultExpectation.paramPtrs = &TCSClientMockDoParamPtrs{}
 	}
 	mmDo.defaultExpectation.paramPtrs.req = &req
 	mmDo.defaultExpectation.expectationOrigins.originReq = minimock.CallerInfo(1)
@@ -153,10 +153,10 @@ func (mmDo *mDoerWatcherMockDo) ExpectReqParam1(req tarantool.Request) *mDoerWat
 	return mmDo
 }
 
-// Inspect accepts an inspector function that has same arguments as the DoerWatcher.Do
-func (mmDo *mDoerWatcherMockDo) Inspect(f func(req tarantool.Request)) *mDoerWatcherMockDo {
+// Inspect accepts an inspector function that has same arguments as the Client.Do
+func (mmDo *mTCSClientMockDo) Inspect(f func(req tarantool.Request)) *mTCSClientMockDo {
 	if mmDo.mock.inspectFuncDo != nil {
-		mmDo.mock.t.Fatalf("Inspect function is already set for DoerWatcherMock.Do")
+		mmDo.mock.t.Fatalf("Inspect function is already set for TCSClientMock.Do")
 	}
 
 	mmDo.mock.inspectFuncDo = f
@@ -164,28 +164,28 @@ func (mmDo *mDoerWatcherMockDo) Inspect(f func(req tarantool.Request)) *mDoerWat
 	return mmDo
 }
 
-// Return sets up results that will be returned by DoerWatcher.Do
-func (mmDo *mDoerWatcherMockDo) Return(fut tarantool.Future) *DoerWatcherMock {
+// Return sets up results that will be returned by Client.Do
+func (mmDo *mTCSClientMockDo) Return(fut tarantool.Future) *TCSClientMock {
 	if mmDo.mock.funcDo != nil {
-		mmDo.mock.t.Fatalf("DoerWatcherMock.Do mock is already set by Set")
+		mmDo.mock.t.Fatalf("TCSClientMock.Do mock is already set by Set")
 	}
 
 	if mmDo.defaultExpectation == nil {
-		mmDo.defaultExpectation = &DoerWatcherMockDoExpectation{mock: mmDo.mock}
+		mmDo.defaultExpectation = &TCSClientMockDoExpectation{mock: mmDo.mock}
 	}
-	mmDo.defaultExpectation.results = &DoerWatcherMockDoResults{fut}
+	mmDo.defaultExpectation.results = &TCSClientMockDoResults{fut}
 	mmDo.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
 	return mmDo.mock
 }
 
-// Set uses given function f to mock the DoerWatcher.Do method
-func (mmDo *mDoerWatcherMockDo) Set(f func(req tarantool.Request) (fut tarantool.Future)) *DoerWatcherMock {
+// Set uses given function f to mock the Client.Do method
+func (mmDo *mTCSClientMockDo) Set(f func(req tarantool.Request) (fut tarantool.Future)) *TCSClientMock {
 	if mmDo.defaultExpectation != nil {
-		mmDo.mock.t.Fatalf("Default expectation is already set for the DoerWatcher.Do method")
+		mmDo.mock.t.Fatalf("Default expectation is already set for the Client.Do method")
 	}
 
 	if len(mmDo.expectations) > 0 {
-		mmDo.mock.t.Fatalf("Some expectations are already set for the DoerWatcher.Do method")
+		mmDo.mock.t.Fatalf("Some expectations are already set for the Client.Do method")
 	}
 
 	mmDo.mock.funcDo = f
@@ -193,39 +193,39 @@ func (mmDo *mDoerWatcherMockDo) Set(f func(req tarantool.Request) (fut tarantool
 	return mmDo.mock
 }
 
-// When sets expectation for the DoerWatcher.Do which will trigger the result defined by the following
+// When sets expectation for the Client.Do which will trigger the result defined by the following
 // Then helper
-func (mmDo *mDoerWatcherMockDo) When(req tarantool.Request) *DoerWatcherMockDoExpectation {
+func (mmDo *mTCSClientMockDo) When(req tarantool.Request) *TCSClientMockDoExpectation {
 	if mmDo.mock.funcDo != nil {
-		mmDo.mock.t.Fatalf("DoerWatcherMock.Do mock is already set by Set")
+		mmDo.mock.t.Fatalf("TCSClientMock.Do mock is already set by Set")
 	}
 
-	expectation := &DoerWatcherMockDoExpectation{
+	expectation := &TCSClientMockDoExpectation{
 		mock:               mmDo.mock,
-		params:             &DoerWatcherMockDoParams{req},
-		expectationOrigins: DoerWatcherMockDoExpectationOrigins{origin: minimock.CallerInfo(1)},
+		params:             &TCSClientMockDoParams{req},
+		expectationOrigins: TCSClientMockDoExpectationOrigins{origin: minimock.CallerInfo(1)},
 	}
 	mmDo.expectations = append(mmDo.expectations, expectation)
 	return expectation
 }
 
-// Then sets up DoerWatcher.Do return parameters for the expectation previously defined by the When method
-func (e *DoerWatcherMockDoExpectation) Then(fut tarantool.Future) *DoerWatcherMock {
-	e.results = &DoerWatcherMockDoResults{fut}
+// Then sets up Client.Do return parameters for the expectation previously defined by the When method
+func (e *TCSClientMockDoExpectation) Then(fut tarantool.Future) *TCSClientMock {
+	e.results = &TCSClientMockDoResults{fut}
 	return e.mock
 }
 
-// Times sets number of times DoerWatcher.Do should be invoked
-func (mmDo *mDoerWatcherMockDo) Times(n uint64) *mDoerWatcherMockDo {
+// Times sets number of times Client.Do should be invoked
+func (mmDo *mTCSClientMockDo) Times(n uint64) *mTCSClientMockDo {
 	if n == 0 {
-		mmDo.mock.t.Fatalf("Times of DoerWatcherMock.Do mock can not be zero")
+		mmDo.mock.t.Fatalf("Times of TCSClientMock.Do mock can not be zero")
 	}
 	mm_atomic.StoreUint64(&mmDo.expectedInvocations, n)
 	mmDo.expectedInvocationsOrigin = minimock.CallerInfo(1)
 	return mmDo
 }
 
-func (mmDo *mDoerWatcherMockDo) invocationsDone() bool {
+func (mmDo *mTCSClientMockDo) invocationsDone() bool {
 	if len(mmDo.expectations) == 0 && mmDo.defaultExpectation == nil && mmDo.mock.funcDo == nil {
 		return true
 	}
@@ -236,8 +236,8 @@ func (mmDo *mDoerWatcherMockDo) invocationsDone() bool {
 	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
 }
 
-// Do implements mm_tcs.DoerWatcher
-func (mmDo *DoerWatcherMock) Do(req tarantool.Request) (fut tarantool.Future) {
+// Do implements mm_tcs.Client
+func (mmDo *TCSClientMock) Do(req tarantool.Request) (fut tarantool.Future) {
 	mm_atomic.AddUint64(&mmDo.beforeDoCounter, 1)
 	defer mm_atomic.AddUint64(&mmDo.afterDoCounter, 1)
 
@@ -247,7 +247,7 @@ func (mmDo *DoerWatcherMock) Do(req tarantool.Request) (fut tarantool.Future) {
 		mmDo.inspectFuncDo(req)
 	}
 
-	mm_params := DoerWatcherMockDoParams{req}
+	mm_params := TCSClientMockDoParams{req}
 
 	// Record call args
 	mmDo.DoMock.mutex.Lock()
@@ -266,49 +266,49 @@ func (mmDo *DoerWatcherMock) Do(req tarantool.Request) (fut tarantool.Future) {
 		mm_want := mmDo.DoMock.defaultExpectation.params
 		mm_want_ptrs := mmDo.DoMock.defaultExpectation.paramPtrs
 
-		mm_got := DoerWatcherMockDoParams{req}
+		mm_got := TCSClientMockDoParams{req}
 
 		if mm_want_ptrs != nil {
 
 			if mm_want_ptrs.req != nil && !minimock.Equal(*mm_want_ptrs.req, mm_got.req) {
-				mmDo.t.Errorf("DoerWatcherMock.Do got unexpected parameter req, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmDo.t.Errorf("TCSClientMock.Do got unexpected parameter req, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
 					mmDo.DoMock.defaultExpectation.expectationOrigins.originReq, *mm_want_ptrs.req, mm_got.req, minimock.Diff(*mm_want_ptrs.req, mm_got.req))
 			}
 
 		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
-			mmDo.t.Errorf("DoerWatcherMock.Do got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+			mmDo.t.Errorf("TCSClientMock.Do got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
 				mmDo.DoMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
 		}
 
 		mm_results := mmDo.DoMock.defaultExpectation.results
 		if mm_results == nil {
-			mmDo.t.Fatal("No results are set for the DoerWatcherMock.Do")
+			mmDo.t.Fatal("No results are set for the TCSClientMock.Do")
 		}
 		return (*mm_results).fut
 	}
 	if mmDo.funcDo != nil {
 		return mmDo.funcDo(req)
 	}
-	mmDo.t.Fatalf("Unexpected call to DoerWatcherMock.Do. %v", req)
+	mmDo.t.Fatalf("Unexpected call to TCSClientMock.Do. %v", req)
 	return
 }
 
-// DoAfterCounter returns a count of finished DoerWatcherMock.Do invocations
-func (mmDo *DoerWatcherMock) DoAfterCounter() uint64 {
+// DoAfterCounter returns a count of finished TCSClientMock.Do invocations
+func (mmDo *TCSClientMock) DoAfterCounter() uint64 {
 	return mm_atomic.LoadUint64(&mmDo.afterDoCounter)
 }
 
-// DoBeforeCounter returns a count of DoerWatcherMock.Do invocations
-func (mmDo *DoerWatcherMock) DoBeforeCounter() uint64 {
+// DoBeforeCounter returns a count of TCSClientMock.Do invocations
+func (mmDo *TCSClientMock) DoBeforeCounter() uint64 {
 	return mm_atomic.LoadUint64(&mmDo.beforeDoCounter)
 }
 
-// Calls returns a list of arguments used in each call to DoerWatcherMock.Do.
+// Calls returns a list of arguments used in each call to TCSClientMock.Do.
 // The list is in the same order as the calls were made (i.e. recent calls have a higher index)
-func (mmDo *mDoerWatcherMockDo) Calls() []*DoerWatcherMockDoParams {
+func (mmDo *mTCSClientMockDo) Calls() []*TCSClientMockDoParams {
 	mmDo.mutex.RLock()
 
-	argCopy := make([]*DoerWatcherMockDoParams, len(mmDo.callArgs))
+	argCopy := make([]*TCSClientMockDoParams, len(mmDo.callArgs))
 	copy(argCopy, mmDo.callArgs)
 
 	mmDo.mutex.RUnlock()
@@ -318,7 +318,7 @@ func (mmDo *mDoerWatcherMockDo) Calls() []*DoerWatcherMockDoParams {
 
 // MinimockDoDone returns true if the count of the Do invocations corresponds
 // the number of defined expectations
-func (m *DoerWatcherMock) MinimockDoDone() bool {
+func (m *TCSClientMock) MinimockDoDone() bool {
 	if m.DoMock.optional {
 		// Optional methods provide '0 or more' call count restriction.
 		return true
@@ -334,10 +334,10 @@ func (m *DoerWatcherMock) MinimockDoDone() bool {
 }
 
 // MinimockDoInspect logs each unmet expectation
-func (m *DoerWatcherMock) MinimockDoInspect() {
+func (m *TCSClientMock) MinimockDoInspect() {
 	for _, e := range m.DoMock.expectations {
 		if mm_atomic.LoadUint64(&e.Counter) < 1 {
-			m.t.Errorf("Expected call to DoerWatcherMock.Do at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+			m.t.Errorf("Expected call to TCSClientMock.Do at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
 		}
 	}
 
@@ -345,66 +345,66 @@ func (m *DoerWatcherMock) MinimockDoInspect() {
 	// if default expectation was set then invocations count should be greater than zero
 	if m.DoMock.defaultExpectation != nil && afterDoCounter < 1 {
 		if m.DoMock.defaultExpectation.params == nil {
-			m.t.Errorf("Expected call to DoerWatcherMock.Do at\n%s", m.DoMock.defaultExpectation.returnOrigin)
+			m.t.Errorf("Expected call to TCSClientMock.Do at\n%s", m.DoMock.defaultExpectation.returnOrigin)
 		} else {
-			m.t.Errorf("Expected call to DoerWatcherMock.Do at\n%s with params: %#v", m.DoMock.defaultExpectation.expectationOrigins.origin, *m.DoMock.defaultExpectation.params)
+			m.t.Errorf("Expected call to TCSClientMock.Do at\n%s with params: %#v", m.DoMock.defaultExpectation.expectationOrigins.origin, *m.DoMock.defaultExpectation.params)
 		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcDo != nil && afterDoCounter < 1 {
-		m.t.Errorf("Expected call to DoerWatcherMock.Do at\n%s", m.funcDoOrigin)
+		m.t.Errorf("Expected call to TCSClientMock.Do at\n%s", m.funcDoOrigin)
 	}
 
 	if !m.DoMock.invocationsDone() && afterDoCounter > 0 {
-		m.t.Errorf("Expected %d calls to DoerWatcherMock.Do at\n%s but found %d calls",
+		m.t.Errorf("Expected %d calls to TCSClientMock.Do at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.DoMock.expectedInvocations), m.DoMock.expectedInvocationsOrigin, afterDoCounter)
 	}
 }
 
-type mDoerWatcherMockNewWatcher struct {
+type mTCSClientMockNewWatcher struct {
 	optional           bool
-	mock               *DoerWatcherMock
-	defaultExpectation *DoerWatcherMockNewWatcherExpectation
-	expectations       []*DoerWatcherMockNewWatcherExpectation
+	mock               *TCSClientMock
+	defaultExpectation *TCSClientMockNewWatcherExpectation
+	expectations       []*TCSClientMockNewWatcherExpectation
 
-	callArgs []*DoerWatcherMockNewWatcherParams
+	callArgs []*TCSClientMockNewWatcherParams
 	mutex    sync.RWMutex
 
 	expectedInvocations       uint64
 	expectedInvocationsOrigin string
 }
 
-// DoerWatcherMockNewWatcherExpectation specifies expectation struct of the DoerWatcher.NewWatcher
-type DoerWatcherMockNewWatcherExpectation struct {
-	mock               *DoerWatcherMock
-	params             *DoerWatcherMockNewWatcherParams
-	paramPtrs          *DoerWatcherMockNewWatcherParamPtrs
-	expectationOrigins DoerWatcherMockNewWatcherExpectationOrigins
-	results            *DoerWatcherMockNewWatcherResults
+// TCSClientMockNewWatcherExpectation specifies expectation struct of the Client.NewWatcher
+type TCSClientMockNewWatcherExpectation struct {
+	mock               *TCSClientMock
+	params             *TCSClientMockNewWatcherParams
+	paramPtrs          *TCSClientMockNewWatcherParamPtrs
+	expectationOrigins TCSClientMockNewWatcherExpectationOrigins
+	results            *TCSClientMockNewWatcherResults
 	returnOrigin       string
 	Counter            uint64
 }
 
-// DoerWatcherMockNewWatcherParams contains parameters of the DoerWatcher.NewWatcher
-type DoerWatcherMockNewWatcherParams struct {
+// TCSClientMockNewWatcherParams contains parameters of the Client.NewWatcher
+type TCSClientMockNewWatcherParams struct {
 	key      string
 	callback tarantool.WatchCallback
 }
 
-// DoerWatcherMockNewWatcherParamPtrs contains pointers to parameters of the DoerWatcher.NewWatcher
-type DoerWatcherMockNewWatcherParamPtrs struct {
+// TCSClientMockNewWatcherParamPtrs contains pointers to parameters of the Client.NewWatcher
+type TCSClientMockNewWatcherParamPtrs struct {
 	key      *string
 	callback *tarantool.WatchCallback
 }
 
-// DoerWatcherMockNewWatcherResults contains results of the DoerWatcher.NewWatcher
-type DoerWatcherMockNewWatcherResults struct {
+// TCSClientMockNewWatcherResults contains results of the Client.NewWatcher
+type TCSClientMockNewWatcherResults struct {
 	w1  tarantool.Watcher
 	err error
 }
 
-// DoerWatcherMockNewWatcherOrigins contains origins of expectations of the DoerWatcher.NewWatcher
-type DoerWatcherMockNewWatcherExpectationOrigins struct {
+// TCSClientMockNewWatcherOrigins contains origins of expectations of the Client.NewWatcher
+type TCSClientMockNewWatcherExpectationOrigins struct {
 	origin         string
 	originKey      string
 	originCallback string
@@ -415,26 +415,26 @@ type DoerWatcherMockNewWatcherExpectationOrigins struct {
 // Optional() makes method check to work in '0 or more' mode.
 // It is NOT RECOMMENDED to use this option unless you really need it, as default behaviour helps to
 // catch the problems when the expected method call is totally skipped during test run.
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) Optional() *mDoerWatcherMockNewWatcher {
+func (mmNewWatcher *mTCSClientMockNewWatcher) Optional() *mTCSClientMockNewWatcher {
 	mmNewWatcher.optional = true
 	return mmNewWatcher
 }
 
-// Expect sets up expected params for DoerWatcher.NewWatcher
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) Expect(key string, callback tarantool.WatchCallback) *mDoerWatcherMockNewWatcher {
+// Expect sets up expected params for Client.NewWatcher
+func (mmNewWatcher *mTCSClientMockNewWatcher) Expect(key string, callback tarantool.WatchCallback) *mTCSClientMockNewWatcher {
 	if mmNewWatcher.mock.funcNewWatcher != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by Set")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by Set")
 	}
 
 	if mmNewWatcher.defaultExpectation == nil {
-		mmNewWatcher.defaultExpectation = &DoerWatcherMockNewWatcherExpectation{}
+		mmNewWatcher.defaultExpectation = &TCSClientMockNewWatcherExpectation{}
 	}
 
 	if mmNewWatcher.defaultExpectation.paramPtrs != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by ExpectParams functions")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by ExpectParams functions")
 	}
 
-	mmNewWatcher.defaultExpectation.params = &DoerWatcherMockNewWatcherParams{key, callback}
+	mmNewWatcher.defaultExpectation.params = &TCSClientMockNewWatcherParams{key, callback}
 	mmNewWatcher.defaultExpectation.expectationOrigins.origin = minimock.CallerInfo(1)
 	for _, e := range mmNewWatcher.expectations {
 		if minimock.Equal(e.params, mmNewWatcher.defaultExpectation.params) {
@@ -445,22 +445,22 @@ func (mmNewWatcher *mDoerWatcherMockNewWatcher) Expect(key string, callback tara
 	return mmNewWatcher
 }
 
-// ExpectKeyParam1 sets up expected param key for DoerWatcher.NewWatcher
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) ExpectKeyParam1(key string) *mDoerWatcherMockNewWatcher {
+// ExpectKeyParam1 sets up expected param key for Client.NewWatcher
+func (mmNewWatcher *mTCSClientMockNewWatcher) ExpectKeyParam1(key string) *mTCSClientMockNewWatcher {
 	if mmNewWatcher.mock.funcNewWatcher != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by Set")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by Set")
 	}
 
 	if mmNewWatcher.defaultExpectation == nil {
-		mmNewWatcher.defaultExpectation = &DoerWatcherMockNewWatcherExpectation{}
+		mmNewWatcher.defaultExpectation = &TCSClientMockNewWatcherExpectation{}
 	}
 
 	if mmNewWatcher.defaultExpectation.params != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by Expect")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by Expect")
 	}
 
 	if mmNewWatcher.defaultExpectation.paramPtrs == nil {
-		mmNewWatcher.defaultExpectation.paramPtrs = &DoerWatcherMockNewWatcherParamPtrs{}
+		mmNewWatcher.defaultExpectation.paramPtrs = &TCSClientMockNewWatcherParamPtrs{}
 	}
 	mmNewWatcher.defaultExpectation.paramPtrs.key = &key
 	mmNewWatcher.defaultExpectation.expectationOrigins.originKey = minimock.CallerInfo(1)
@@ -468,22 +468,22 @@ func (mmNewWatcher *mDoerWatcherMockNewWatcher) ExpectKeyParam1(key string) *mDo
 	return mmNewWatcher
 }
 
-// ExpectCallbackParam2 sets up expected param callback for DoerWatcher.NewWatcher
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) ExpectCallbackParam2(callback tarantool.WatchCallback) *mDoerWatcherMockNewWatcher {
+// ExpectCallbackParam2 sets up expected param callback for Client.NewWatcher
+func (mmNewWatcher *mTCSClientMockNewWatcher) ExpectCallbackParam2(callback tarantool.WatchCallback) *mTCSClientMockNewWatcher {
 	if mmNewWatcher.mock.funcNewWatcher != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by Set")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by Set")
 	}
 
 	if mmNewWatcher.defaultExpectation == nil {
-		mmNewWatcher.defaultExpectation = &DoerWatcherMockNewWatcherExpectation{}
+		mmNewWatcher.defaultExpectation = &TCSClientMockNewWatcherExpectation{}
 	}
 
 	if mmNewWatcher.defaultExpectation.params != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by Expect")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by Expect")
 	}
 
 	if mmNewWatcher.defaultExpectation.paramPtrs == nil {
-		mmNewWatcher.defaultExpectation.paramPtrs = &DoerWatcherMockNewWatcherParamPtrs{}
+		mmNewWatcher.defaultExpectation.paramPtrs = &TCSClientMockNewWatcherParamPtrs{}
 	}
 	mmNewWatcher.defaultExpectation.paramPtrs.callback = &callback
 	mmNewWatcher.defaultExpectation.expectationOrigins.originCallback = minimock.CallerInfo(1)
@@ -491,10 +491,10 @@ func (mmNewWatcher *mDoerWatcherMockNewWatcher) ExpectCallbackParam2(callback ta
 	return mmNewWatcher
 }
 
-// Inspect accepts an inspector function that has same arguments as the DoerWatcher.NewWatcher
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) Inspect(f func(key string, callback tarantool.WatchCallback)) *mDoerWatcherMockNewWatcher {
+// Inspect accepts an inspector function that has same arguments as the Client.NewWatcher
+func (mmNewWatcher *mTCSClientMockNewWatcher) Inspect(f func(key string, callback tarantool.WatchCallback)) *mTCSClientMockNewWatcher {
 	if mmNewWatcher.mock.inspectFuncNewWatcher != nil {
-		mmNewWatcher.mock.t.Fatalf("Inspect function is already set for DoerWatcherMock.NewWatcher")
+		mmNewWatcher.mock.t.Fatalf("Inspect function is already set for TCSClientMock.NewWatcher")
 	}
 
 	mmNewWatcher.mock.inspectFuncNewWatcher = f
@@ -502,28 +502,28 @@ func (mmNewWatcher *mDoerWatcherMockNewWatcher) Inspect(f func(key string, callb
 	return mmNewWatcher
 }
 
-// Return sets up results that will be returned by DoerWatcher.NewWatcher
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) Return(w1 tarantool.Watcher, err error) *DoerWatcherMock {
+// Return sets up results that will be returned by Client.NewWatcher
+func (mmNewWatcher *mTCSClientMockNewWatcher) Return(w1 tarantool.Watcher, err error) *TCSClientMock {
 	if mmNewWatcher.mock.funcNewWatcher != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by Set")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by Set")
 	}
 
 	if mmNewWatcher.defaultExpectation == nil {
-		mmNewWatcher.defaultExpectation = &DoerWatcherMockNewWatcherExpectation{mock: mmNewWatcher.mock}
+		mmNewWatcher.defaultExpectation = &TCSClientMockNewWatcherExpectation{mock: mmNewWatcher.mock}
 	}
-	mmNewWatcher.defaultExpectation.results = &DoerWatcherMockNewWatcherResults{w1, err}
+	mmNewWatcher.defaultExpectation.results = &TCSClientMockNewWatcherResults{w1, err}
 	mmNewWatcher.defaultExpectation.returnOrigin = minimock.CallerInfo(1)
 	return mmNewWatcher.mock
 }
 
-// Set uses given function f to mock the DoerWatcher.NewWatcher method
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) Set(f func(key string, callback tarantool.WatchCallback) (w1 tarantool.Watcher, err error)) *DoerWatcherMock {
+// Set uses given function f to mock the Client.NewWatcher method
+func (mmNewWatcher *mTCSClientMockNewWatcher) Set(f func(key string, callback tarantool.WatchCallback) (w1 tarantool.Watcher, err error)) *TCSClientMock {
 	if mmNewWatcher.defaultExpectation != nil {
-		mmNewWatcher.mock.t.Fatalf("Default expectation is already set for the DoerWatcher.NewWatcher method")
+		mmNewWatcher.mock.t.Fatalf("Default expectation is already set for the Client.NewWatcher method")
 	}
 
 	if len(mmNewWatcher.expectations) > 0 {
-		mmNewWatcher.mock.t.Fatalf("Some expectations are already set for the DoerWatcher.NewWatcher method")
+		mmNewWatcher.mock.t.Fatalf("Some expectations are already set for the Client.NewWatcher method")
 	}
 
 	mmNewWatcher.mock.funcNewWatcher = f
@@ -531,39 +531,39 @@ func (mmNewWatcher *mDoerWatcherMockNewWatcher) Set(f func(key string, callback 
 	return mmNewWatcher.mock
 }
 
-// When sets expectation for the DoerWatcher.NewWatcher which will trigger the result defined by the following
+// When sets expectation for the Client.NewWatcher which will trigger the result defined by the following
 // Then helper
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) When(key string, callback tarantool.WatchCallback) *DoerWatcherMockNewWatcherExpectation {
+func (mmNewWatcher *mTCSClientMockNewWatcher) When(key string, callback tarantool.WatchCallback) *TCSClientMockNewWatcherExpectation {
 	if mmNewWatcher.mock.funcNewWatcher != nil {
-		mmNewWatcher.mock.t.Fatalf("DoerWatcherMock.NewWatcher mock is already set by Set")
+		mmNewWatcher.mock.t.Fatalf("TCSClientMock.NewWatcher mock is already set by Set")
 	}
 
-	expectation := &DoerWatcherMockNewWatcherExpectation{
+	expectation := &TCSClientMockNewWatcherExpectation{
 		mock:               mmNewWatcher.mock,
-		params:             &DoerWatcherMockNewWatcherParams{key, callback},
-		expectationOrigins: DoerWatcherMockNewWatcherExpectationOrigins{origin: minimock.CallerInfo(1)},
+		params:             &TCSClientMockNewWatcherParams{key, callback},
+		expectationOrigins: TCSClientMockNewWatcherExpectationOrigins{origin: minimock.CallerInfo(1)},
 	}
 	mmNewWatcher.expectations = append(mmNewWatcher.expectations, expectation)
 	return expectation
 }
 
-// Then sets up DoerWatcher.NewWatcher return parameters for the expectation previously defined by the When method
-func (e *DoerWatcherMockNewWatcherExpectation) Then(w1 tarantool.Watcher, err error) *DoerWatcherMock {
-	e.results = &DoerWatcherMockNewWatcherResults{w1, err}
+// Then sets up Client.NewWatcher return parameters for the expectation previously defined by the When method
+func (e *TCSClientMockNewWatcherExpectation) Then(w1 tarantool.Watcher, err error) *TCSClientMock {
+	e.results = &TCSClientMockNewWatcherResults{w1, err}
 	return e.mock
 }
 
-// Times sets number of times DoerWatcher.NewWatcher should be invoked
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) Times(n uint64) *mDoerWatcherMockNewWatcher {
+// Times sets number of times Client.NewWatcher should be invoked
+func (mmNewWatcher *mTCSClientMockNewWatcher) Times(n uint64) *mTCSClientMockNewWatcher {
 	if n == 0 {
-		mmNewWatcher.mock.t.Fatalf("Times of DoerWatcherMock.NewWatcher mock can not be zero")
+		mmNewWatcher.mock.t.Fatalf("Times of TCSClientMock.NewWatcher mock can not be zero")
 	}
 	mm_atomic.StoreUint64(&mmNewWatcher.expectedInvocations, n)
 	mmNewWatcher.expectedInvocationsOrigin = minimock.CallerInfo(1)
 	return mmNewWatcher
 }
 
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) invocationsDone() bool {
+func (mmNewWatcher *mTCSClientMockNewWatcher) invocationsDone() bool {
 	if len(mmNewWatcher.expectations) == 0 && mmNewWatcher.defaultExpectation == nil && mmNewWatcher.mock.funcNewWatcher == nil {
 		return true
 	}
@@ -574,8 +574,8 @@ func (mmNewWatcher *mDoerWatcherMockNewWatcher) invocationsDone() bool {
 	return totalInvocations > 0 && (expectedInvocations == 0 || expectedInvocations == totalInvocations)
 }
 
-// NewWatcher implements mm_tcs.DoerWatcher
-func (mmNewWatcher *DoerWatcherMock) NewWatcher(key string, callback tarantool.WatchCallback) (w1 tarantool.Watcher, err error) {
+// NewWatcher implements mm_tcs.Client
+func (mmNewWatcher *TCSClientMock) NewWatcher(key string, callback tarantool.WatchCallback) (w1 tarantool.Watcher, err error) {
 	mm_atomic.AddUint64(&mmNewWatcher.beforeNewWatcherCounter, 1)
 	defer mm_atomic.AddUint64(&mmNewWatcher.afterNewWatcherCounter, 1)
 
@@ -585,7 +585,7 @@ func (mmNewWatcher *DoerWatcherMock) NewWatcher(key string, callback tarantool.W
 		mmNewWatcher.inspectFuncNewWatcher(key, callback)
 	}
 
-	mm_params := DoerWatcherMockNewWatcherParams{key, callback}
+	mm_params := TCSClientMockNewWatcherParams{key, callback}
 
 	// Record call args
 	mmNewWatcher.NewWatcherMock.mutex.Lock()
@@ -604,54 +604,54 @@ func (mmNewWatcher *DoerWatcherMock) NewWatcher(key string, callback tarantool.W
 		mm_want := mmNewWatcher.NewWatcherMock.defaultExpectation.params
 		mm_want_ptrs := mmNewWatcher.NewWatcherMock.defaultExpectation.paramPtrs
 
-		mm_got := DoerWatcherMockNewWatcherParams{key, callback}
+		mm_got := TCSClientMockNewWatcherParams{key, callback}
 
 		if mm_want_ptrs != nil {
 
 			if mm_want_ptrs.key != nil && !minimock.Equal(*mm_want_ptrs.key, mm_got.key) {
-				mmNewWatcher.t.Errorf("DoerWatcherMock.NewWatcher got unexpected parameter key, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmNewWatcher.t.Errorf("TCSClientMock.NewWatcher got unexpected parameter key, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
 					mmNewWatcher.NewWatcherMock.defaultExpectation.expectationOrigins.originKey, *mm_want_ptrs.key, mm_got.key, minimock.Diff(*mm_want_ptrs.key, mm_got.key))
 			}
 
 			if mm_want_ptrs.callback != nil && !minimock.Equal(*mm_want_ptrs.callback, mm_got.callback) {
-				mmNewWatcher.t.Errorf("DoerWatcherMock.NewWatcher got unexpected parameter callback, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+				mmNewWatcher.t.Errorf("TCSClientMock.NewWatcher got unexpected parameter callback, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
 					mmNewWatcher.NewWatcherMock.defaultExpectation.expectationOrigins.originCallback, *mm_want_ptrs.callback, mm_got.callback, minimock.Diff(*mm_want_ptrs.callback, mm_got.callback))
 			}
 
 		} else if mm_want != nil && !minimock.Equal(*mm_want, mm_got) {
-			mmNewWatcher.t.Errorf("DoerWatcherMock.NewWatcher got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
+			mmNewWatcher.t.Errorf("TCSClientMock.NewWatcher got unexpected parameters, expected at\n%s:\nwant: %#v\n got: %#v%s\n",
 				mmNewWatcher.NewWatcherMock.defaultExpectation.expectationOrigins.origin, *mm_want, mm_got, minimock.Diff(*mm_want, mm_got))
 		}
 
 		mm_results := mmNewWatcher.NewWatcherMock.defaultExpectation.results
 		if mm_results == nil {
-			mmNewWatcher.t.Fatal("No results are set for the DoerWatcherMock.NewWatcher")
+			mmNewWatcher.t.Fatal("No results are set for the TCSClientMock.NewWatcher")
 		}
 		return (*mm_results).w1, (*mm_results).err
 	}
 	if mmNewWatcher.funcNewWatcher != nil {
 		return mmNewWatcher.funcNewWatcher(key, callback)
 	}
-	mmNewWatcher.t.Fatalf("Unexpected call to DoerWatcherMock.NewWatcher. %v %v", key, callback)
+	mmNewWatcher.t.Fatalf("Unexpected call to TCSClientMock.NewWatcher. %v %v", key, callback)
 	return
 }
 
-// NewWatcherAfterCounter returns a count of finished DoerWatcherMock.NewWatcher invocations
-func (mmNewWatcher *DoerWatcherMock) NewWatcherAfterCounter() uint64 {
+// NewWatcherAfterCounter returns a count of finished TCSClientMock.NewWatcher invocations
+func (mmNewWatcher *TCSClientMock) NewWatcherAfterCounter() uint64 {
 	return mm_atomic.LoadUint64(&mmNewWatcher.afterNewWatcherCounter)
 }
 
-// NewWatcherBeforeCounter returns a count of DoerWatcherMock.NewWatcher invocations
-func (mmNewWatcher *DoerWatcherMock) NewWatcherBeforeCounter() uint64 {
+// NewWatcherBeforeCounter returns a count of TCSClientMock.NewWatcher invocations
+func (mmNewWatcher *TCSClientMock) NewWatcherBeforeCounter() uint64 {
 	return mm_atomic.LoadUint64(&mmNewWatcher.beforeNewWatcherCounter)
 }
 
-// Calls returns a list of arguments used in each call to DoerWatcherMock.NewWatcher.
+// Calls returns a list of arguments used in each call to TCSClientMock.NewWatcher.
 // The list is in the same order as the calls were made (i.e. recent calls have a higher index)
-func (mmNewWatcher *mDoerWatcherMockNewWatcher) Calls() []*DoerWatcherMockNewWatcherParams {
+func (mmNewWatcher *mTCSClientMockNewWatcher) Calls() []*TCSClientMockNewWatcherParams {
 	mmNewWatcher.mutex.RLock()
 
-	argCopy := make([]*DoerWatcherMockNewWatcherParams, len(mmNewWatcher.callArgs))
+	argCopy := make([]*TCSClientMockNewWatcherParams, len(mmNewWatcher.callArgs))
 	copy(argCopy, mmNewWatcher.callArgs)
 
 	mmNewWatcher.mutex.RUnlock()
@@ -661,7 +661,7 @@ func (mmNewWatcher *mDoerWatcherMockNewWatcher) Calls() []*DoerWatcherMockNewWat
 
 // MinimockNewWatcherDone returns true if the count of the NewWatcher invocations corresponds
 // the number of defined expectations
-func (m *DoerWatcherMock) MinimockNewWatcherDone() bool {
+func (m *TCSClientMock) MinimockNewWatcherDone() bool {
 	if m.NewWatcherMock.optional {
 		// Optional methods provide '0 or more' call count restriction.
 		return true
@@ -677,10 +677,10 @@ func (m *DoerWatcherMock) MinimockNewWatcherDone() bool {
 }
 
 // MinimockNewWatcherInspect logs each unmet expectation
-func (m *DoerWatcherMock) MinimockNewWatcherInspect() {
+func (m *TCSClientMock) MinimockNewWatcherInspect() {
 	for _, e := range m.NewWatcherMock.expectations {
 		if mm_atomic.LoadUint64(&e.Counter) < 1 {
-			m.t.Errorf("Expected call to DoerWatcherMock.NewWatcher at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
+			m.t.Errorf("Expected call to TCSClientMock.NewWatcher at\n%s with params: %#v", e.expectationOrigins.origin, *e.params)
 		}
 	}
 
@@ -688,24 +688,24 @@ func (m *DoerWatcherMock) MinimockNewWatcherInspect() {
 	// if default expectation was set then invocations count should be greater than zero
 	if m.NewWatcherMock.defaultExpectation != nil && afterNewWatcherCounter < 1 {
 		if m.NewWatcherMock.defaultExpectation.params == nil {
-			m.t.Errorf("Expected call to DoerWatcherMock.NewWatcher at\n%s", m.NewWatcherMock.defaultExpectation.returnOrigin)
+			m.t.Errorf("Expected call to TCSClientMock.NewWatcher at\n%s", m.NewWatcherMock.defaultExpectation.returnOrigin)
 		} else {
-			m.t.Errorf("Expected call to DoerWatcherMock.NewWatcher at\n%s with params: %#v", m.NewWatcherMock.defaultExpectation.expectationOrigins.origin, *m.NewWatcherMock.defaultExpectation.params)
+			m.t.Errorf("Expected call to TCSClientMock.NewWatcher at\n%s with params: %#v", m.NewWatcherMock.defaultExpectation.expectationOrigins.origin, *m.NewWatcherMock.defaultExpectation.params)
 		}
 	}
 	// if func was set then invocations count should be greater than zero
 	if m.funcNewWatcher != nil && afterNewWatcherCounter < 1 {
-		m.t.Errorf("Expected call to DoerWatcherMock.NewWatcher at\n%s", m.funcNewWatcherOrigin)
+		m.t.Errorf("Expected call to TCSClientMock.NewWatcher at\n%s", m.funcNewWatcherOrigin)
 	}
 
 	if !m.NewWatcherMock.invocationsDone() && afterNewWatcherCounter > 0 {
-		m.t.Errorf("Expected %d calls to DoerWatcherMock.NewWatcher at\n%s but found %d calls",
+		m.t.Errorf("Expected %d calls to TCSClientMock.NewWatcher at\n%s but found %d calls",
 			mm_atomic.LoadUint64(&m.NewWatcherMock.expectedInvocations), m.NewWatcherMock.expectedInvocationsOrigin, afterNewWatcherCounter)
 	}
 }
 
 // MinimockFinish checks that all mocked methods have been called the expected number of times
-func (m *DoerWatcherMock) MinimockFinish() {
+func (m *TCSClientMock) MinimockFinish() {
 	m.finishOnce.Do(func() {
 		if !m.minimockDone() {
 			m.MinimockDoInspect()
@@ -716,7 +716,7 @@ func (m *DoerWatcherMock) MinimockFinish() {
 }
 
 // MinimockWait waits for all mocked methods to be called the expected number of times
-func (m *DoerWatcherMock) MinimockWait(timeout mm_time.Duration) {
+func (m *TCSClientMock) MinimockWait(timeout mm_time.Duration) {
 	timeoutCh := mm_time.After(timeout)
 	for {
 		if m.minimockDone() {
@@ -731,7 +731,7 @@ func (m *DoerWatcherMock) MinimockWait(timeout mm_time.Duration) {
 	}
 }
 
-func (m *DoerWatcherMock) minimockDone() bool {
+func (m *TCSClientMock) minimockDone() bool {
 	done := true
 	return done &&
 		m.MinimockDoDone() &&

--- a/locker/locker.go
+++ b/locker/locker.go
@@ -4,6 +4,8 @@ package locker
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -21,7 +23,30 @@ var (
 	// ErrPrefixNoLeadingSlash is returned by Prefixed when a non-empty prefix
 	// does not start with "/".
 	ErrPrefixNoLeadingSlash = errors.New("locker: prefix must start with '/'")
+
+	// ErrNameNoLeadingSlash is returned by a driver's NewLocker when name does
+	// not start with "/".
+	ErrNameNoLeadingSlash = errors.New("locker: name must start with '/'")
+
+	// ErrNameTrailingSlash is returned by a driver's NewLocker when name ends
+	// with "/".
+	ErrNameTrailingSlash = errors.New("locker: name must not end with '/'")
 )
+
+// ValidateName checks that a lock name follows the shared contract: it must
+// start with "/" and must not end with "/". Every driver calls it at the top of
+// NewLocker so the lock-name contract is uniform across backends.
+func ValidateName(name string) error {
+	if !strings.HasPrefix(name, "/") {
+		return fmt.Errorf("%w: %q", ErrNameNoLeadingSlash, name)
+	}
+
+	if strings.HasSuffix(name, "/") {
+		return fmt.Errorf("%w: %q", ErrNameTrailingSlash, name)
+	}
+
+	return nil
+}
 
 // Locker acquires and releases a named distributed lock. A single Locker
 // instance holds the lock at most once at a time: re-Lock on an already-held

--- a/locker/locker_test.go
+++ b/locker/locker_test.go
@@ -18,6 +18,17 @@ func TestApplyOptions_DefaultTTL(t *testing.T) {
 	assert.Equal(t, locker.DefaultTTL, opts.TTL)
 }
 
+func TestValidateName(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, locker.ValidateName("/lock"))
+	require.NoError(t, locker.ValidateName("/foo/bar"))
+
+	require.ErrorIs(t, locker.ValidateName("lock"), locker.ErrNameNoLeadingSlash)
+	require.ErrorIs(t, locker.ValidateName(""), locker.ErrNameNoLeadingSlash)
+	require.ErrorIs(t, locker.ValidateName("/lock/"), locker.ErrNameTrailingSlash)
+}
+
 func TestApplyOptions_Override(t *testing.T) {
 	t.Parallel()
 

--- a/namer/key.go
+++ b/namer/key.go
@@ -19,13 +19,13 @@ const (
 func (t KeyType) String() string {
 	switch t {
 	case KeyTypeValue:
-		return "KeyTypeValue"
+		return "value"
 	case KeyTypeHash:
-		return "KeyTypeHash"
+		return "hash"
 	case KeyTypeSignature:
-		return "KeyTypeSignature"
+		return "signature"
 	default:
-		return fmt.Sprintf("KeyType[%d]", t)
+		return fmt.Sprintf("KeyType(%d)", t)
 	}
 }
 

--- a/namer/key_test.go
+++ b/namer/key_test.go
@@ -62,32 +62,32 @@ func TestKeyType_String(t *testing.T) {
 		{
 			name:     "KeyTypeValue",
 			keyType:  namer.KeyTypeValue,
-			expected: "KeyTypeValue",
+			expected: "value",
 		},
 		{
 			name:     "KeyTypeHash",
 			keyType:  namer.KeyTypeHash,
-			expected: "KeyTypeHash",
+			expected: "hash",
 		},
 		{
 			name:     "KeyTypeSignature",
 			keyType:  namer.KeyTypeSignature,
-			expected: "KeyTypeSignature",
+			expected: "signature",
 		},
 		{
 			name:     "Unknown key type zero",
 			keyType:  0,
-			expected: "KeyType[0]",
+			expected: "KeyType(0)",
 		},
 		{
 			name:     "Unknown key type negative",
 			keyType:  -1,
-			expected: "KeyType[-1]",
+			expected: "KeyType(-1)",
 		},
 		{
 			name:     "Unknown key type positive",
 			keyType:  100,
-			expected: "KeyType[100]",
+			expected: "KeyType(100)",
 		},
 	}
 

--- a/namer/layered_example_test.go
+++ b/namer/layered_example_test.go
@@ -32,9 +32,9 @@ func ExampleNew() {
 	}
 
 	// Output:
-	// KeyTypeValue -> /objects/alice
-	// KeyTypeHash -> /hashes/sha256/objects/alice
-	// KeyTypeSignature -> /sig/rsa/objects/alice
+	// value -> /objects/alice
+	// hash -> /hashes/sha256/objects/alice
+	// signature -> /sig/rsa/objects/alice
 }
 
 // ExampleCompactSingleHash shows the compact hash layout, which drops the
@@ -60,8 +60,8 @@ func ExampleCompactSingleHash() {
 	}
 
 	// Output:
-	// KeyTypeValue -> /objects/alice
-	// KeyTypeHash -> /hashes/objects/alice
+	// value -> /objects/alice
+	// hash -> /hashes/objects/alice
 }
 
 // ExampleCompactSingleSig shows the compact sig layout, which drops the
@@ -87,8 +87,8 @@ func ExampleCompactSingleSig() {
 	}
 
 	// Output:
-	// KeyTypeValue -> /objects/alice
-	// KeyTypeSignature -> /sig/objects/alice
+	// value -> /objects/alice
+	// signature -> /sig/objects/alice
 }
 
 // ExampleLegacyHashSigLayout shows the legacy product layout: hash and sig
@@ -114,9 +114,9 @@ func ExampleLegacyHashSigLayout() {
 	}
 
 	// Output:
-	// KeyTypeValue -> /config/all
-	// KeyTypeHash -> /hashes/sha256/all
-	// KeyTypeSignature -> /sig/ed25519/all
+	// value -> /config/all
+	// hash -> /hashes/sha256/all
+	// signature -> /sig/ed25519/all
 }
 
 // ExampleNew_parse shows how ParseKey resolves a raw key path
@@ -144,8 +144,8 @@ func ExampleNew_parse() {
 	}
 
 	// Output:
-	// KeyTypeValue name=alice property=""
-	// KeyTypeHash name=alice property="sha256"
+	// value name=alice property=""
+	// hash name=alice property="sha256"
 }
 
 // ExampleNew_prefix shows the prefix used to walk all values

--- a/namer/results.go
+++ b/namer/results.go
@@ -29,7 +29,7 @@ func NewResults(initial map[string][]Key) Results {
 }
 
 // SelectSingle gets keys for single-name case (if applicable).
-func (r *Results) SelectSingle() ([]Key, bool) {
+func (r Results) SelectSingle() ([]Key, bool) {
 	if r.isSingle {
 		return r.result[r.isSingleName], true
 	}
@@ -38,7 +38,7 @@ func (r *Results) SelectSingle() ([]Key, bool) {
 }
 
 // Items return iterator over all name->keys groups.
-func (r *Results) Items() iter.Seq2[string, []Key] {
+func (r Results) Items() iter.Seq2[string, []Key] {
 	return func(yield func(str string, res []Key) bool) {
 		for i, v := range r.result {
 			if !yield(i, v) {
@@ -49,12 +49,12 @@ func (r *Results) Items() iter.Seq2[string, []Key] {
 }
 
 // Result returns the underlying results map.
-func (r *Results) Result() map[string][]Key {
+func (r Results) Result() map[string][]Key {
 	return r.result
 }
 
 // Select gets keys for a specific object name.
-func (r *Results) Select(name string) ([]Key, bool) {
+func (r Results) Select(name string) ([]Key, bool) {
 	if i, ok := r.result[name]; ok {
 		return i, true
 	}
@@ -63,6 +63,6 @@ func (r *Results) Select(name string) ([]Key, bool) {
 }
 
 // Len returns the number of unique object names.
-func (r *Results) Len() int {
+func (r Results) Len() int {
 	return len(r.result)
 }

--- a/predicate/predicate.go
+++ b/predicate/predicate.go
@@ -44,13 +44,25 @@ func (p predicate) Value() any {
 	return p.value
 }
 
+// normalizeValue canonicalizes a value-predicate comparison value so every
+// driver receives the same representation: a string is converted to []byte.
+// Other types pass through unchanged. This closes a substitutability gap where
+// a string value worked on some drivers but was rejected by others.
+func normalizeValue(value any) any {
+	if s, ok := value.(string); ok {
+		return []byte(s)
+	}
+
+	return value
+}
+
 // ValueNotEqual creates a predicate that checks if a key's value is not equal to the specified value.
 func ValueNotEqual(key []byte, value any) Predicate {
 	return &predicate{
 		key:    key,
 		op:     OpNotEqual,
 		target: TargetValue,
-		value:  value,
+		value:  normalizeValue(value),
 	}
 }
 
@@ -60,7 +72,7 @@ func ValueEqual(key []byte, value any) Predicate {
 		key:    key,
 		op:     OpEqual,
 		target: TargetValue,
-		value:  value,
+		value:  normalizeValue(value),
 	}
 }
 

--- a/predicate/predicate_test.go
+++ b/predicate/predicate_test.go
@@ -18,7 +18,23 @@ func TestValueNotEqual(t *testing.T) {
 	assert.Equal(t, key, p.Key())
 	assert.Equal(t, predicate.OpNotEqual, p.Operation())
 	assert.Equal(t, predicate.TargetValue, p.Target())
-	assert.Equal(t, value, p.Value())
+	assert.Equal(t, []byte(value), p.Value())
+}
+
+func TestValuePredicates_StringNormalizedToBytes(t *testing.T) {
+	t.Parallel()
+
+	key := []byte("test-key")
+
+	eq := predicate.ValueEqual(key, "hello")
+	assert.Equal(t, []byte("hello"), eq.Value())
+
+	ne := predicate.ValueNotEqual(key, "hello")
+	assert.Equal(t, []byte("hello"), ne.Value())
+
+	// Non-string values pass through unchanged.
+	raw := predicate.ValueEqual(key, []byte("world"))
+	assert.Equal(t, []byte("world"), raw.Value())
 }
 
 func TestValueEqual(t *testing.T) {


### PR DESCRIPTION
First API-polish sweep on the v2 line: a series of small, independent breaking changes that tighten the public surface (nameable option types, package-prefixed errors, unexported internals) and make the three drivers behave consistently (uniform receivers, lock scoping, lock-name validation, predicate value handling, explicit etcd locker construction). Each change is its own commit with tests and lint; the full module is green — build, vet, test, and golangci-lint (pinned v2.11.4). The final commit documents the set in CHANGELOG and MIGRATION.

- integrity: export GetOption/PutOption/DeleteOption aliases
- integrity: unexport ModRevisionEmpty
- connect,crypto,hasher,tcs,integrity: prefix leaf error sentinels with package name
- driver/etcd,driver/tcs: use pointer receivers
- driver/dummy: scope lock registry to the Driver instance
- namer: KeyType.String returns the wire form
- hasher,crypto: export algorithm-name constants
- crypto: unexport RSAPSS concrete type
- predicate: normalize string comparison values to []byte
- driver/etcd: make locking a construction-time choice via NewWithLocker
- driver/tcs: rename DoerWatcher connection interface to Client
- locker: unify lock-name validation across drivers
- namer: give Results value receivers
- docs: changelog and migration notes for the v2 API cleanup sweep